### PR TITLE
Fix None chunk handling and update OpenAI image generation

### DIFF
--- a/servers/fastapi/api/routers/presentation/handlers/generate_stream.py
+++ b/servers/fastapi/api/routers/presentation/handlers/generate_stream.py
@@ -149,6 +149,9 @@ class PresentationGenerateStreamHandler(FetchAssetsOnPresentationGenerationMixin
             )
         ):
             chunk = event.choices[0].delta.content
+            if chunk is None:
+                continue
+            
             presentation_text += chunk
             yield SSEResponse(
                 event="response",

--- a/servers/fastapi/image_processor/images_finder.py
+++ b/servers/fastapi/image_processor/images_finder.py
@@ -52,8 +52,7 @@ async def generate_image(
 
 async def generate_image_openai(prompt: str, output_directory: str) -> str:
     client = get_llm_client()
-    result = await asyncio.to_thread(
-        client.images.generate,
+    result = await client.images.generate(
         model="dall-e-3",
         prompt=prompt,
         n=1,

--- a/servers/fastapi/image_processor/images_finder.py
+++ b/servers/fastapi/image_processor/images_finder.py
@@ -1,4 +1,4 @@
-import asyncio
+import base64
 import os
 import uuid
 import aiohttp
@@ -49,24 +49,23 @@ async def generate_image(
         print(f"Error generating image: {e}")
         return get_resource("assets/images/placeholder.jpg")
 
-
 async def generate_image_openai(prompt: str, output_directory: str) -> str:
     client = get_llm_client()
     result = await client.images.generate(
-        model="dall-e-3",
+        model="gpt-image-1",
+        background="auto",
+        moderation="auto",
         prompt=prompt,
-        n=1,
-        quality="standard",
+        quality="high",
         size="1024x1024",
     )
-    image_url = result.data[0].url
-    async with aiohttp.ClientSession() as session:
-        async with session.get(image_url) as response:
-            image_bytes = await response.read()
-            image_path = os.path.join(output_directory, f"{str(uuid.uuid4())}.jpg")
-            with open(image_path, "wb") as f:
-                f.write(image_bytes)
-            return image_path
+    
+    b64_data = result.data[0].b64_json
+    image_bytes = base64.b64decode(b64_data)
+    image_path = os.path.join(output_directory, f"{str(uuid.uuid4())}.png")
+    with open(image_path, "wb") as f:
+        f.write(image_bytes)
+    return image_path
 
 
 async def generate_image_google(prompt: str, output_directory: str) -> str:

--- a/servers/nextjs/app/(presentation-generator)/components/slide_layouts/AllChart.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/slide_layouts/AllChart.tsx
@@ -31,7 +31,7 @@ const AllChart = ({
       state.presentationGeneration?.presentationData?.slides[slideIndex];
 
 
-    const style = slide?.content.graph.style || {};
+    const style = slide?.content.graph?.style || {};
     return Object.keys(
       style === null || style === undefined ? {} : (style as ChartSettings)
     ).length > 0
@@ -43,7 +43,7 @@ const AllChart = ({
         showDataLabel: true,
         dataLabel: {
           dataLabelPosition:
-            slide?.content.graph.type === "pie"
+            slide?.content.graph?.type === "pie"
               ? ("Outside" as const)
               : ("Inside" as const),
           dataLabelAlignment: "Center" as const,


### PR DESCRIPTION
Skip None chunks in the presentation stream handler to prevent errors. Refactor OpenAI image generation to call the async method directly instead of using asyncio.to_thread.