### PR TITLE
Feat/separate text and image models 53

### DIFF
--- a/servers/fastapi/api/lifespan.py
+++ b/servers/fastapi/api/lifespan.py
@@ -5,12 +5,17 @@ from fastapi import FastAPI
 from sqlmodel import SQLModel
 
 from services import SQL_ENGINE
-from utils.model_availability import check_llm_model_availability
+from utils.model_availability import check_llm_and_image_provider_api_or_model_availability
 
 
 @asynccontextmanager
 async def app_lifespan(_: FastAPI):
+    """
+    Lifespan context manager for FastAPI application.
+    Initializes the application data directory and checks LLM model availability.
+    
+    """
     os.makedirs(os.getenv("APP_DATA_DIRECTORY"), exist_ok=True)
     SQLModel.metadata.create_all(SQL_ENGINE)
-    await check_llm_model_availability()
+    await check_llm_and_image_provider_api_or_model_availability()
     yield

--- a/servers/fastapi/enums/image_provider.py
+++ b/servers/fastapi/enums/image_provider.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+class ImageProvider(Enum):
+    PEXELS = "pexels"
+    PIXABAY = "pixabay"
+    IMAGEN = "imagen"
+    DALLE3 = "dall-e-3"

--- a/servers/fastapi/enums/image_provider.py
+++ b/servers/fastapi/enums/image_provider.py
@@ -3,5 +3,5 @@ from enum import Enum
 class ImageProvider(Enum):
     PEXELS = "pexels"
     PIXABAY = "pixabay"
-    IMAGEN = "imagen"
+    GEMINI_FLASH = "gemini_flash"
     DALLE3 = "dall-e-3"

--- a/servers/fastapi/models/user_config.py
+++ b/servers/fastapi/models/user_config.py
@@ -12,3 +12,5 @@ class UserConfig(BaseModel):
     CUSTOM_LLM_API_KEY: Optional[str] = None
     CUSTOM_MODEL: Optional[str] = None
     PEXELS_API_KEY: Optional[str] = None
+    IMAGE_PROVIDER: Optional[str] = None
+    PIXABAY_API_KEY: Optional[str] = None

--- a/servers/fastapi/services/image_generation_service.py
+++ b/servers/fastapi/services/image_generation_service.py
@@ -17,7 +17,7 @@ from utils.llm_provider import (
 from utils.image_provider import (
     is_pixels_selected,
     is_pixabay_selected,
-    is_imagen_selected,
+    is_gemini_flash_selected,
     is_dalle3_selected
 )
 
@@ -32,7 +32,7 @@ class ImageGenerationService:
             return self.get_image_from_pixabay
         elif is_pixels_selected():
             return self.get_image_from_pexels
-        elif is_imagen_selected():
+        elif is_gemini_flash_selected():
             return self.generate_image_google
         elif is_dalle3_selected():
             return self.generate_image_openai

--- a/servers/fastapi/tests/test_image_generation.py
+++ b/servers/fastapi/tests/test_image_generation.py
@@ -1,0 +1,400 @@
+import pytest
+import asyncio
+import os
+from unittest.mock import Mock, patch, AsyncMock
+import httpx
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from api.v1.ppt.endpoints.images import IMAGES_ROUTER
+from models.image_prompt import ImagePrompt
+from services.image_generation_service import ImageGenerationService
+from models.sql.image_asset import ImageAsset
+
+
+class TestImageGenerationService:
+    """
+    Testing the image Generation Service
+    """
+    
+    @pytest.fixture
+    def mock_images_directory(self, tmp_path):
+        """
+        Creates new images directory for every test case we run
+        """
+        images_dir = tmp_path / "images"
+        images_dir.mkdir()
+        return str(images_dir)
+    
+    @pytest.fixture
+    def sample_image_prompt(self):
+        """
+        Creates a sample ImagePrompt for testing
+        """
+        return ImagePrompt(prompt="A beautiful sunset over mountains")
+    
+    def test_image_generation_service_initialization(self, mock_images_directory):
+        """
+        Test initialization of ImageGenerationService with output directory
+        - Checks if the output directory is set correctly
+        - Checks if the image generation function is set based on environment variable
+        """
+        with patch.dict(os.environ, {"IMAGE_PROVIDER": "pexels"}):
+            service = ImageGenerationService(mock_images_directory)
+            assert service.output_directory == mock_images_directory
+            assert service.image_gen_func is not None or service.image_gen_func is None
+    
+    def test_get_image_gen_func_pixabay_selected(self, mock_images_directory):
+        """
+            Testing the function selection when Pixabay is selected
+            - Checks if the correct function is selected based on environment variable
+            - Ensures that the function is set to get_image_from_pixabay when Pixabay is selected
+        """
+        with patch('services.image_generation_service.is_pixabay_selected', return_value=True):
+            with patch('services.image_generation_service.is_pixels_selected', return_value=False):
+                with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                    with patch('services.image_generation_service.is_dalle3_selected', return_value=False):
+                        with patch.dict(os.environ, {"IMAGE_PROVIDER": "pixabay"}):
+                            service = ImageGenerationService(mock_images_directory)
+                            assert service.image_gen_func == service.get_image_from_pixabay
+    
+    def test_get_image_gen_func_pexels_selected(self, mock_images_directory):
+        """
+        Test function selection when Pexels is selected
+        - Checks if the correct function is selected based on environment variable
+        - Ensures that the function is set to get_image_from_pexels when Pexels is selected
+        """
+        with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
+            with patch('services.image_generation_service.is_pixels_selected', return_value=True):
+                with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                    with patch('services.image_generation_service.is_dalle3_selected', return_value=False):
+                        with patch.dict(os.environ, {"IMAGE_PROVIDER": "pexels"}):
+                            service = ImageGenerationService(mock_images_directory)
+                            assert service.image_gen_func == service.get_image_from_pexels
+    
+    def test_get_image_gen_func_dalle3_selected(self, mock_images_directory):
+        """
+        Test function selection when DALL-E 3 is selected
+        - Checks if the correct function is selected based on environment variable
+        - Ensures that the function is set to generate_image_openai when DALL-E 3 is selected
+        """
+        with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
+            with patch('services.image_generation_service.is_pixels_selected', return_value=False):
+                with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                    with patch('services.image_generation_service.is_dalle3_selected', return_value=True):
+                        with patch.dict(os.environ, {"IMAGE_PROVIDER": "dall-e-3"}):
+                            service = ImageGenerationService(mock_images_directory)
+                            assert service.image_gen_func == service.generate_image_openai
+    
+    def test_is_stock_provider_selected(self, mock_images_directory):
+        """
+        Test if stock provider is selected based on environment variable
+        - Checks if the stock provider is selected correctly based on environment variable
+        - Ensures that is_stock_provider_selected returns True for Pexels or Pixabay
+        """
+        with patch('services.image_generation_service.is_pixels_selected', return_value=True):
+            with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
+                with patch.dict(os.environ, {"IMAGE_PROVIDER": "pexels"}):
+                    service = ImageGenerationService(mock_images_directory)
+                    assert service.is_stock_provider_selected() is True
+        
+        with patch('services.image_generation_service.is_pixels_selected', return_value=False):
+            with patch('services.image_generation_service.is_pixabay_selected', return_value=True):
+                with patch.dict(os.environ, {"IMAGE_PROVIDER": "pixabay"}):
+                    service = ImageGenerationService(mock_images_directory)
+                    assert service.is_stock_provider_selected() is True
+        
+        with patch('services.image_generation_service.is_pixels_selected', return_value=False):
+            with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
+                with patch.dict(os.environ, {"IMAGE_PROVIDER": "dall-e-3"}):
+                    service = ImageGenerationService(mock_images_directory)
+                    assert service.is_stock_provider_selected() is False
+    
+    def test_generate_image_with_pexels_success(self, mock_images_directory, sample_image_prompt):
+        """
+        Test successful image generation with Pexels provider
+        - Mocks the Pexels API to return a valid image URL
+        - Ensures that the image generation function returns the expected URL
+        - Checks if the image generation function is called with the correct prompt
+        """
+        async def run_test():
+            with patch.dict(os.environ, {"IMAGE_PROVIDER": "pexels", "PEXELS_API_KEY": "test_key"}):
+                with patch('services.image_generation_service.is_pixels_selected', return_value=True):
+                    with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
+                        with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                            with patch('services.image_generation_service.is_dalle3_selected', return_value=False):
+                                service = ImageGenerationService(mock_images_directory)
+                                
+                                mock_response = AsyncMock()
+                                mock_response.json = AsyncMock(return_value={
+                                    "photos": [{
+                                        "src": {
+                                            "large": "https://example.com/image.jpg"
+                                        }
+                                    }]
+                                })
+                                
+                                mock_session = AsyncMock()
+                                mock_session.get = AsyncMock(return_value=mock_response)
+                                mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+                                mock_session.__aexit__ = AsyncMock(return_value=None)
+                                
+                                with patch('aiohttp.ClientSession', return_value=mock_session):
+                                    result = await service.generate_image(sample_image_prompt)
+                                    assert result == "https://example.com/image.jpg"
+        
+        asyncio.run(run_test())
+    
+    def test_generate_image_with_dalle3_success(self, mock_images_directory, sample_image_prompt):
+        """
+        Test successful image generation with DALL-E 3 provider
+        - Mocks the OpenAI client to return a valid image URL
+        - Ensures that the image generation function returns the expected URL
+        - Checks if the image generation function is called with the correct prompt
+        """
+        async def run_test():
+            with patch.dict(os.environ, {"IMAGE_PROVIDER": "dall-e-3"}):
+                with patch('services.image_generation_service.is_pixels_selected', return_value=False):
+                    with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
+                        with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                            with patch('services.image_generation_service.is_dalle3_selected', return_value=True):
+                                service = ImageGenerationService(mock_images_directory)
+                                
+                                # Create a real test file
+                                test_image_path = f"{mock_images_directory}/test_image.jpg"
+                                with open(test_image_path, 'w') as f:
+                                    f.write("fake image content")
+                                
+                                # Mock generate_image_openai to return the test file path
+                                async def mock_openai_generate(prompt, output_dir):
+                                    return test_image_path
+                                
+                                service.generate_image_openai = mock_openai_generate
+                                
+                                result = await service.generate_image(sample_image_prompt)
+                                
+                                # Should return ImageAsset for AI providers
+                                assert isinstance(result, ImageAsset)
+                                assert result.path == test_image_path
+                                assert result.extras["prompt"] == sample_image_prompt.prompt
+    
+    def test_generate_image_no_provider_selected(self, mock_images_directory, sample_image_prompt):
+        """
+        Test generate_image when no provider is selected
+        - Mocks the environment variable to simulate no provider selected
+        - Ensures that the function returns a placeholder image path
+        - Checks if the image generation function is called with the correct prompt
+        """
+        async def run_test():
+            with patch('services.image_generation_service.is_pixels_selected', return_value=False):
+                with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
+                    with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                        with patch('services.image_generation_service.is_dalle3_selected', return_value=False):
+                            with patch.dict(os.environ, {"IMAGE_PROVIDER": "pexels"}):
+                                service = ImageGenerationService(mock_images_directory)
+                                
+                                result = await service.generate_image(sample_image_prompt)
+                                
+                                # Should return placeholder
+                                assert result == "/static/images/placeholder.jpg"
+        
+        asyncio.run(run_test())
+    
+    def test_generate_image_provider_error(self, mock_images_directory, sample_image_prompt):
+        """
+        Test generate_image when provider function raises an error
+        - Mocks the Pexels API to raise an exception
+        - Ensures that the function returns a placeholder image path
+        - Checks if the image generation function is called with the correct prompt
+        """
+        async def run_test():
+            with patch('services.image_generation_service.is_pixels_selected', return_value=True):
+                with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
+                    with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                        with patch('services.image_generation_service.is_dalle3_selected', return_value=False):
+                            with patch.dict(os.environ, {"IMAGE_PROVIDER": "pexels"}):
+                                service = ImageGenerationService(mock_images_directory)
+                                
+                                async def mock_pexels_error(*args, **kwargs):
+                                    raise Exception("API Error")
+                                
+                                service.get_image_from_pexels = mock_pexels_error
+                                
+                                result = await service.generate_image(sample_image_prompt)
+                                
+                                assert result == "/static/images/placeholder.jpg"
+        
+        asyncio.run(run_test())
+    
+    def test_get_image_from_pexels_real_function(self, mock_images_directory):
+        """T
+        Test REAL Pexels function with mocked HTTP call
+        - Mocks the Pexels API to return a valid image URL
+        - Ensures that the function returns the expected URL
+        - Checks if the HTTP call is made with the correct parameters
+        """
+        async def run_test():
+            with patch.dict(os.environ, {"IMAGE_PROVIDER": "pexels", "PEXELS_API_KEY": "test_pexels_key"}):
+                service = ImageGenerationService(mock_images_directory)
+                
+                mock_response = AsyncMock()
+                mock_response.json = AsyncMock(return_value={
+                    "photos": [{
+                        "src": {
+                            "large": "https://example.com/pexels_image.jpg"
+                        }
+                    }]
+                })
+                
+                mock_session = AsyncMock()
+                mock_session.get = AsyncMock(return_value=mock_response)
+                mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+                mock_session.__aexit__ = AsyncMock(return_value=None)
+                
+                with patch('aiohttp.ClientSession', return_value=mock_session):
+                    result = await service.get_image_from_pexels("sunset")
+                    
+                    assert result == "https://example.com/pexels_image.jpg"
+                    mock_session.get.assert_called_once()
+        
+        asyncio.run(run_test())
+    
+    def test_get_image_from_pixabay_real_function(self, mock_images_directory):
+        """
+        Test REAL Pixabay function with mocked HTTP call
+        - Mocks the Pixabay API to return a valid image URL
+        - Ensures that the function returns the expected URL
+        - Checks if the HTTP call is made with the correct parameters
+        """
+        async def run_test():
+            with patch.dict(os.environ, {"IMAGE_PROVIDER": "pixabay", "PIXABAY_API_KEY": "test_pixabay_key"}):
+                service = ImageGenerationService(mock_images_directory)
+                
+                mock_response = AsyncMock()
+                mock_response.json = AsyncMock(return_value={
+                    "hits": [{
+                        "largeImageURL": "https://example.com/pixabay_image.jpg"
+                    }]
+                })
+                
+                mock_session = AsyncMock()
+                mock_session.get = AsyncMock(return_value=mock_response)
+                mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+                mock_session.__aexit__ = AsyncMock(return_value=None)
+                
+                with patch('aiohttp.ClientSession', return_value=mock_session):
+                    result = await service.get_image_from_pixabay("sunset")
+                    
+                    assert result == "https://example.com/pixabay_image.jpg"
+                    mock_session.get.assert_called_once()
+        
+        asyncio.run(run_test())
+
+
+class TestImageGenerationEndpoint:
+    """
+    Testing the Image Generation API Endpoint
+    """
+    
+    @pytest.fixture
+    def app(self):
+        """Create FastAPI app with the images router"""
+        app = FastAPI()
+        app.include_router(IMAGES_ROUTER)
+        return app
+    
+    @pytest.fixture
+    def client(self, app):
+        """Create test client"""
+        return TestClient(app)
+    
+    @pytest.fixture
+    def mock_images_directory(self, tmp_path):
+        """Mock images directory"""
+        images_dir = tmp_path / "images"
+        images_dir.mkdir()
+        return str(images_dir)
+    
+    def test_generate_image_endpoint_success_stock_provider(self, client, mock_images_directory):
+        """
+        Test successful image generation via API endpoint with stock provider
+        - Mocks the ImageGenerationService to return a stock image URL
+        - Ensures that the endpoint returns the expected URL
+        - Checks if the image generation function is called with the correct prompt
+        """
+        test_prompt = "A beautiful sunset over mountains"
+        
+        with patch('api.v1.ppt.endpoints.images.get_images_directory', return_value=mock_images_directory):
+            with patch('api.v1.ppt.endpoints.images.ImageGenerationService') as mock_service_class:
+                mock_service_instance = Mock()
+                mock_service_instance.generate_image = AsyncMock(return_value="https://example.com/stock_image.jpg")
+                mock_service_class.return_value = mock_service_instance
+                response = client.get(f"/images/generate?prompt={test_prompt}")
+                assert response.status_code == 200
+    
+    def test_generate_image_endpoint_success_ai_provider(self, client, mock_images_directory):
+        """
+        Test successful image generation via API endpoint with AI provider
+        - Mocks the ImageGenerationService to return an ImageAsset object
+        - Ensures that the endpoint returns the expected ImageAsset object
+        - Checks if the image generation function is called with the correct prompt
+        """
+        test_prompt = "A beautiful sunset over mountains"
+        
+        test_image_asset = ImageAsset(
+            path=f"{mock_images_directory}/test_image.jpg",
+            extras={"prompt": test_prompt, "theme_prompt": "professional"}
+        )
+        
+        with patch('api.v1.ppt.endpoints.images.get_images_directory', return_value=mock_images_directory):
+            with patch('api.v1.ppt.endpoints.images.ImageGenerationService') as mock_service_class:
+                mock_service_instance = Mock()
+                mock_service_instance.generate_image = AsyncMock(return_value=test_image_asset)
+                mock_service_class.return_value = mock_service_instance
+                
+                response = client.get(f"/images/generate?prompt={test_prompt}")
+                
+                assert response.status_code == 200
+    
+    def test_generate_image_endpoint_placeholder_response(self, client, mock_images_directory):
+        """
+        Test endpoint returns placeholder image when no provider is selected
+        - Mocks the ImageGenerationService to return a placeholder image path
+        - Ensures that the endpoint returns the placeholder image path
+        - Checks if the image generation function is called with the correct prompt
+        """
+        test_prompt = "Test prompt"
+        
+        with patch('api.v1.ppt.endpoints.images.get_images_directory', return_value=mock_images_directory):
+            with patch('api.v1.ppt.endpoints.images.ImageGenerationService') as mock_service_class:
+                mock_service_instance = Mock()
+                mock_service_instance.generate_image = AsyncMock(return_value="/static/images/placeholder.jpg")
+                mock_service_class.return_value = mock_service_instance
+                
+                response = client.get(f"/images/generate?prompt={test_prompt}")
+                
+                assert response.status_code == 200
+
+    def test_generate_image_endpoint_with_async_client(self, mock_images_directory):
+        """
+        Test the image generation endpoint using an async client
+        - Mocks the ImageGenerationService to return a valid image URL
+        - Ensures that the endpoint returns the expected URL
+        - Checks if the image generation function is called with the correct prompt
+        """
+        async def run_test():
+            app = FastAPI()
+            app.include_router(IMAGES_ROUTER)
+            
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+                with patch('api.v1.ppt.endpoints.images.get_images_directory', return_value=mock_images_directory):
+                    with patch('api.v1.ppt.endpoints.images.ImageGenerationService') as mock_service_class:
+                        mock_service_instance = Mock()
+                        mock_service_instance.generate_image = AsyncMock(return_value="https://example.com/image.jpg")
+                        mock_service_class.return_value = mock_service_instance
+                        
+                        response = await ac.get("/images/generate?prompt=test")
+                        assert response.status_code == 200
+        
+        asyncio.run(run_test())
+

--- a/servers/fastapi/tests/test_image_generation.py
+++ b/servers/fastapi/tests/test_image_generation.py
@@ -51,7 +51,7 @@ class TestImageGenerationService:
         """
         with patch('services.image_generation_service.is_pixabay_selected', return_value=True):
             with patch('services.image_generation_service.is_pixels_selected', return_value=False):
-                with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                with patch('services.image_generation_service.is_gemini_flash_selected', return_value=False):
                     with patch('services.image_generation_service.is_dalle3_selected', return_value=False):
                         with patch.dict(os.environ, {"IMAGE_PROVIDER": "pixabay"}):
                             service = ImageGenerationService(mock_images_directory)
@@ -65,7 +65,7 @@ class TestImageGenerationService:
         """
         with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
             with patch('services.image_generation_service.is_pixels_selected', return_value=True):
-                with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                with patch('services.image_generation_service.is_gemini_flash_selected', return_value=False):
                     with patch('services.image_generation_service.is_dalle3_selected', return_value=False):
                         with patch.dict(os.environ, {"IMAGE_PROVIDER": "pexels"}):
                             service = ImageGenerationService(mock_images_directory)
@@ -79,7 +79,7 @@ class TestImageGenerationService:
         """
         with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
             with patch('services.image_generation_service.is_pixels_selected', return_value=False):
-                with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                with patch('services.image_generation_service.is_gemini_flash_selected', return_value=False):
                     with patch('services.image_generation_service.is_dalle3_selected', return_value=True):
                         with patch.dict(os.environ, {"IMAGE_PROVIDER": "dall-e-3"}):
                             service = ImageGenerationService(mock_images_directory)
@@ -120,7 +120,7 @@ class TestImageGenerationService:
             with patch.dict(os.environ, {"IMAGE_PROVIDER": "pexels", "PEXELS_API_KEY": "test_key"}):
                 with patch('services.image_generation_service.is_pixels_selected', return_value=True):
                     with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
-                        with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                        with patch('services.image_generation_service.is_gemini_flash_selected', return_value=False):
                             with patch('services.image_generation_service.is_dalle3_selected', return_value=False):
                                 service = ImageGenerationService(mock_images_directory)
                                 
@@ -155,7 +155,7 @@ class TestImageGenerationService:
             with patch.dict(os.environ, {"IMAGE_PROVIDER": "dall-e-3"}):
                 with patch('services.image_generation_service.is_pixels_selected', return_value=False):
                     with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
-                        with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                        with patch('services.image_generation_service.is_gemini_flash_selected', return_value=False):
                             with patch('services.image_generation_service.is_dalle3_selected', return_value=True):
                                 service = ImageGenerationService(mock_images_directory)
                                 
@@ -187,7 +187,7 @@ class TestImageGenerationService:
         async def run_test():
             with patch('services.image_generation_service.is_pixels_selected', return_value=False):
                 with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
-                    with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                    with patch('services.image_generation_service.is_gemini_flash_selected', return_value=False):
                         with patch('services.image_generation_service.is_dalle3_selected', return_value=False):
                             with patch.dict(os.environ, {"IMAGE_PROVIDER": "pexels"}):
                                 service = ImageGenerationService(mock_images_directory)
@@ -209,7 +209,7 @@ class TestImageGenerationService:
         async def run_test():
             with patch('services.image_generation_service.is_pixels_selected', return_value=True):
                 with patch('services.image_generation_service.is_pixabay_selected', return_value=False):
-                    with patch('services.image_generation_service.is_imagen_selected', return_value=False):
+                    with patch('services.image_generation_service.is_gemini_flash_selected', return_value=False):
                         with patch('services.image_generation_service.is_dalle3_selected', return_value=False):
                             with patch.dict(os.environ, {"IMAGE_PROVIDER": "pexels"}):
                                 service = ImageGenerationService(mock_images_directory)

--- a/servers/fastapi/utils/get_env.py
+++ b/servers/fastapi/utils/get_env.py
@@ -55,3 +55,9 @@ def get_custom_model_env():
 
 def get_pexels_api_key_env():
     return os.getenv("PEXELS_API_KEY")
+
+def get_image_provider_env():
+    return os.getenv("IMAGE_PROVIDER")
+
+def get_pixabay_api_key_env():
+    return os.getenv("PIXABAY_API_KEY")

--- a/servers/fastapi/utils/image_provider.py
+++ b/servers/fastapi/utils/image_provider.py
@@ -1,0 +1,41 @@
+import os
+from enums.image_provider import ImageProvider
+
+
+def is_pixels_selected() -> bool:
+    return ImageProvider.PEXELS == get_selected_image_provider()
+
+
+def is_pixabay_selected() -> bool:
+    return ImageProvider.PIXABAY == get_selected_image_provider()
+
+
+def is_imagen_selected() -> bool:
+    return ImageProvider.IMAGEN == get_selected_image_provider()
+
+
+def is_dalle3_selected() -> bool:
+    return ImageProvider.DALLE3 == get_selected_image_provider()
+
+
+def get_selected_image_provider() -> ImageProvider:
+    """
+    Get the selected image provider from environment variables.
+    Returns:
+        ImageProvider: The selected image provider.
+    """
+    return ImageProvider(os.getenv("IMAGE_PROVIDER"))
+
+
+def get_image_provider_api_key() -> str:
+    selected_image_provider = get_selected_image_provider()
+    if selected_image_provider == ImageProvider.PEXELS:
+        return os.getenv("PEXELS_API_KEY")
+    elif selected_image_provider == ImageProvider.PIXABAY:
+        return os.getenv("PIXABAY_API_KEY")
+    elif selected_image_provider == ImageProvider.IMAGEN:
+        return os.getenv("GOOGLE_API_KEY")
+    elif selected_image_provider == ImageProvider.DALLE3:
+        return os.getenv("OPENAI_API_KEY")
+    else:
+        raise ValueError(f"Invalid image provider: {selected_image_provider}")

--- a/servers/fastapi/utils/image_provider.py
+++ b/servers/fastapi/utils/image_provider.py
@@ -10,8 +10,8 @@ def is_pixabay_selected() -> bool:
     return ImageProvider.PIXABAY == get_selected_image_provider()
 
 
-def is_imagen_selected() -> bool:
-    return ImageProvider.IMAGEN == get_selected_image_provider()
+def is_gemini_flash_selected() -> bool:
+    return ImageProvider.GEMINI_FLASH == get_selected_image_provider()
 
 
 def is_dalle3_selected() -> bool:
@@ -33,7 +33,7 @@ def get_image_provider_api_key() -> str:
         return os.getenv("PEXELS_API_KEY")
     elif selected_image_provider == ImageProvider.PIXABAY:
         return os.getenv("PIXABAY_API_KEY")
-    elif selected_image_provider == ImageProvider.IMAGEN:
+    elif selected_image_provider == ImageProvider.GEMINI_FLASH:
         return os.getenv("GOOGLE_API_KEY")
     elif selected_image_provider == ImageProvider.DALLE3:
         return os.getenv("OPENAI_API_KEY")

--- a/servers/fastapi/utils/model_availability.py
+++ b/servers/fastapi/utils/model_availability.py
@@ -9,9 +9,14 @@ from utils.llm_provider import (
     is_ollama_selected,
 )
 from utils.ollama import pull_ollama_model
+from utils.image_provider import (
+    is_pixels_selected,
+    is_pixabay_selected,
+    is_imagen_selected,
+    is_dalle3_selected,
+)
 
-
-async def check_llm_model_availability():
+async def check_llm_and_image_provider_api_or_model_availability():
     can_change_keys = get_can_change_keys_env() != "false"
     if not can_change_keys:
         if get_llm_provider() == LLMProvider.OPENAI:
@@ -58,3 +63,22 @@ async def check_llm_model_availability():
             print("-" * 50)
             if custom_model not in models:
                 raise Exception(f"Model {custom_model} is not available")
+        elif is_pixels_selected():
+            pexels_api_key = os.getenv("PEXELS_API_KEY")
+            if not pexels_api_key:
+                raise Exception("PEXELS_API_KEY must be provided")
+
+        elif is_pixabay_selected():
+            pixabay_api_key = os.getenv("PIXABAY_API_KEY")
+            if not pixabay_api_key:
+                raise Exception("PIXABAY_API_KEY must be provided")
+
+        elif is_imagen_selected():
+            google_api_key = os.getenv("GOOGLE_API_KEY")
+            if not google_api_key:
+                raise Exception("GOOGLE_API_KEY must be provided")
+
+        elif is_dalle3_selected():
+            openai_api_key = os.getenv("OPENAI_API_KEY")
+            if not openai_api_key:
+                raise Exception("OPENAI_API_KEY must be provided")

--- a/servers/fastapi/utils/model_availability.py
+++ b/servers/fastapi/utils/model_availability.py
@@ -12,7 +12,7 @@ from utils.ollama import pull_ollama_model
 from utils.image_provider import (
     is_pixels_selected,
     is_pixabay_selected,
-    is_imagen_selected,
+    is_gemini_flash_selected,
     is_dalle3_selected,
 )
 
@@ -73,7 +73,7 @@ async def check_llm_and_image_provider_api_or_model_availability():
             if not pixabay_api_key:
                 raise Exception("PIXABAY_API_KEY must be provided")
 
-        elif is_imagen_selected():
+        elif is_gemini_flash_selected():
             google_api_key = os.getenv("GOOGLE_API_KEY")
             if not google_api_key:
                 raise Exception("GOOGLE_API_KEY must be provided")

--- a/servers/fastapi/utils/set_env.py
+++ b/servers/fastapi/utils/set_env.py
@@ -43,3 +43,10 @@ def set_custom_model_env(value):
 
 def set_pexels_api_key_env(value):
     os.environ["PEXELS_API_KEY"] = value
+
+def set_image_provider_env(value):
+    os.environ["IMAGE_PROVIDER"] = value
+
+
+def set_pixabay_api_key_env(value):
+    os.environ["PIXABAY_API_KEY"] = value

--- a/servers/fastapi/utils/user_config.py
+++ b/servers/fastapi/utils/user_config.py
@@ -13,6 +13,8 @@ from utils.get_env import (
     get_openai_api_key_env,
     get_pexels_api_key_env,
     get_user_config_path_env,
+    get_image_provider_env,
+    get_pixabay_api_key_env
 )
 from utils.set_env import (
     set_custom_llm_api_key_env,
@@ -24,6 +26,8 @@ from utils.set_env import (
     set_ollama_url_env,
     set_openai_api_key_env,
     set_pexels_api_key_env,
+    set_image_provider_env,
+    set_pixabay_api_key_env
 )
 
 
@@ -49,6 +53,8 @@ def get_user_config():
         CUSTOM_LLM_API_KEY=existing_config.CUSTOM_LLM_API_KEY
         or get_custom_llm_api_key_env(),
         CUSTOM_MODEL=existing_config.CUSTOM_MODEL or get_custom_model_env(),
+        IMAGE_PROVIDER=existing_config.IMAGE_PROVIDER or get_image_provider_env(),
+        PIXABAY_API_KEY=existing_config.PIXABAY_API_KEY or get_pixabay_api_key_env(),
         PEXELS_API_KEY=existing_config.PEXELS_API_KEY or get_pexels_api_key_env(),
     )
 
@@ -71,5 +77,9 @@ def update_env_with_user_config():
         set_custom_llm_api_key_env(user_config.CUSTOM_LLM_API_KEY)
     if user_config.CUSTOM_MODEL:
         set_custom_model_env(user_config.CUSTOM_MODEL)
+    if user_config.IMAGE_PROVIDER:
+        set_image_provider_env(user_config.IMAGE_PROVIDER)
+    if user_config.PIXABAY_API_KEY:
+        set_pixabay_api_key_env(user_config.PIXABAY_API_KEY)
     if user_config.PEXELS_API_KEY:
         set_pexels_api_key_env(user_config.PEXELS_API_KEY)

--- a/servers/nextjs/app/api/user-config/route.ts
+++ b/servers/nextjs/app/api/user-config/route.ts
@@ -1,36 +1,36 @@
-import { NextResponse } from 'next/server';
-import fs from 'fs';
+import { NextResponse } from "next/server";
+import fs from "fs";
 
 const userConfigPath = process.env.USER_CONFIG_PATH!;
-const canChangeKeys = process.env.CAN_CHANGE_KEYS !== 'false';
-
+const canChangeKeys = process.env.CAN_CHANGE_KEYS !== "false";
+console.log("UserConfigPath:", userConfigPath);
 export async function GET() {
   if (!canChangeKeys) {
     return NextResponse.json({
-      error: 'You are not allowed to access this resource',
-    })
+      error: "You are not allowed to access this resource",
+    });
   }
 
   if (!fs.existsSync(userConfigPath)) {
-    return NextResponse.json({})
+    return NextResponse.json({});
   }
-  const configData = fs.readFileSync(userConfigPath, 'utf-8')
-  return NextResponse.json(JSON.parse(configData))
+  const configData = fs.readFileSync(userConfigPath, "utf-8");
+  return NextResponse.json(JSON.parse(configData));
 }
 
 export async function POST(request: Request) {
   if (!canChangeKeys) {
     return NextResponse.json({
-      error: 'You are not allowed to access this resource',
-    })
+      error: "You are not allowed to access this resource",
+    });
   }
 
-  const userConfig = await request.json()
+  const userConfig = await request.json();
 
-  let existingConfig: LLMConfig = {}
+  let existingConfig: LLMConfig = {};
   if (fs.existsSync(userConfigPath)) {
-    const configData = fs.readFileSync(userConfigPath, 'utf-8')
-    existingConfig = JSON.parse(configData)
+    const configData = fs.readFileSync(userConfigPath, "utf-8");
+    existingConfig = JSON.parse(configData);
   }
   const mergedConfig: LLMConfig = {
     LLM: userConfig.LLM || existingConfig.LLM,
@@ -39,11 +39,18 @@ export async function POST(request: Request) {
     OLLAMA_URL: userConfig.OLLAMA_URL || existingConfig.OLLAMA_URL,
     OLLAMA_MODEL: userConfig.OLLAMA_MODEL || existingConfig.OLLAMA_MODEL,
     CUSTOM_LLM_URL: userConfig.CUSTOM_LLM_URL || existingConfig.CUSTOM_LLM_URL,
-    CUSTOM_LLM_API_KEY: userConfig.CUSTOM_LLM_API_KEY || existingConfig.CUSTOM_LLM_API_KEY,
+    CUSTOM_LLM_API_KEY:
+      userConfig.CUSTOM_LLM_API_KEY || existingConfig.CUSTOM_LLM_API_KEY,
     CUSTOM_MODEL: userConfig.CUSTOM_MODEL || existingConfig.CUSTOM_MODEL,
+    PIXABAY_API_KEY:
+      userConfig.PIXABAY_API_KEY || existingConfig.PIXABAY_API_KEY,
+    IMAGE_PROVIDER: userConfig.IMAGE_PROVIDER || existingConfig.IMAGE_PROVIDER,
     PEXELS_API_KEY: userConfig.PEXELS_API_KEY || existingConfig.PEXELS_API_KEY,
-    USE_CUSTOM_URL: userConfig.USE_CUSTOM_URL === undefined ? existingConfig.USE_CUSTOM_URL : userConfig.USE_CUSTOM_URL,
-  }
-  fs.writeFileSync(userConfigPath, JSON.stringify(mergedConfig))
-  return NextResponse.json(mergedConfig)
-} 
+    USE_CUSTOM_URL:
+      userConfig.USE_CUSTOM_URL === undefined
+        ? existingConfig.USE_CUSTOM_URL
+        : userConfig.USE_CUSTOM_URL,
+  };
+  fs.writeFileSync(userConfigPath, JSON.stringify(mergedConfig));
+  return NextResponse.json(mergedConfig);
+}

--- a/servers/nextjs/app/settings/SettingPage.tsx
+++ b/servers/nextjs/app/settings/SettingPage.tsx
@@ -50,9 +50,9 @@ const IMAGE_PROVIDERS: Record<string, ImageProviderConfig> = {
     placeholder: "Enter your OpenAI API key",
     apiKeyField: "OPENAI_API_KEY",
   },
-  imagen: {
-    title: "imagen",
-    description: "Required for using Imagen services from Google",
+  gemini_flash: {
+    title: "gemini_flash",
+    description: "Required for using Gemini Flash services from Google",
     placeholder: "Enter your Google API key",
     apiKeyField: "GOOGLE_API_KEY",
   },
@@ -943,7 +943,7 @@ const SettingsPage = () => {
                   return <></>;
                 }
 
-                if (provider.title === "imagen" && llmConfig.LLM === "google") {
+                if (provider.title === "gemini_flash" && llmConfig.LLM === "google") {
                   return <> </>;
                 }
 

--- a/servers/nextjs/app/settings/SettingPage.tsx
+++ b/servers/nextjs/app/settings/SettingPage.tsx
@@ -1,735 +1,1044 @@
-'use client';
+"use client";
 import React, { useState, useEffect } from "react";
 import Header from "../dashboard/components/Header";
 import Wrapper from "@/components/Wrapper";
-import { Settings, Key, Loader2, Check, ChevronsUpDown } from 'lucide-react';
-import { toast } from '@/hooks/use-toast';
+import { Settings, Key, Loader2, Check, ChevronsUpDown } from "lucide-react";
+import { toast } from "@/hooks/use-toast";
 import { RootState } from "@/store/store";
 import { useSelector } from "react-redux";
 import { handleSaveLLMConfig } from "@/utils/storeHelpers";
 import { useRouter } from "next/navigation";
-import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import {
-    Command,
-    CommandEmpty,
-    CommandGroup,
-    CommandInput,
-    CommandItem,
-    CommandList,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
 } from "@/components/ui/command";
 import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { Switch } from "@/components/ui/switch";
 
+const IMAGE_PROVIDERS: Record<string, ImageProviderConfig> = {
+  pexels: {
+    title: "pexels",
+    description: "Required for using Pexels services",
+    placeholder: "Enter your Pexels API key",
+    apiKeyField: "PEXELS_API_KEY",
+  },
+  pixabay: {
+    title: "pixabay",
+    description: "Required for using Pixabay services",
+    placeholder: "Enter your Pixabay API key",
+    apiKeyField: "PIXABAY_API_KEY",
+  },
+  "dall-e-3": {
+    title: "dall-e-3",
+    description: "Required for using DALL-E 3 image generation OpenAI services",
+    placeholder: "Enter your OpenAI API key",
+    apiKeyField: "OPENAI_API_KEY",
+  },
+  imagen: {
+    title: "imagen",
+    description: "Required for using Imagen services from Google",
+    placeholder: "Enter your Google API key",
+    apiKeyField: "GOOGLE_API_KEY",
+  },
+};
+
 const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
-    openai: {
-        title: "OpenAI API Key",
-        description: "Required for using OpenAI services",
-        placeholder: "Enter your OpenAI API key",
-    },
-    google: {
-        title: "Google API Key",
-        description: "Required for using Google services",
-        placeholder: "Enter your Google API key",
-    },
-    ollama: {
-        title: "Ollama API Key",
-        description: "Required for using Ollama services",
-        placeholder: "Choose a model",
-    },
-    custom: {
-        title: "Custom Model Configuration",
-        description: "Configure your own OpenAI-compatible model",
-        placeholder: "Enter your custom model details",
-    }
+  openai: {
+    title: "OpenAI API Key",
+    description: "Required for using OpenAI services",
+    placeholder: "Enter your OpenAI API key",
+  },
+  google: {
+    title: "Google API Key",
+    description: "Required for using Google services",
+    placeholder: "Enter your Google API key",
+  },
+  ollama: {
+    title: "Ollama API Key",
+    description: "Required for using Ollama services",
+    placeholder: "Choose a model",
+  },
+  custom: {
+    title: "Custom Model Configuration",
+    description: "Configure your own OpenAI-compatible model",
+    placeholder: "Enter your custom model details",
+  },
 };
 
 interface ProviderConfig {
-    title: string;
-    description: string;
-    placeholder: string;
+  title: string;
+  description: string;
+  placeholder: string;
+}
+interface ImageProviderConfig {
+  title: string;
+  description: string;
+  placeholder: string;
+  apiKeyField?: keyof LLMConfig;
 }
 
 const SettingsPage = () => {
-    const router = useRouter();
+  const router = useRouter();
+  const [openImageProviderSelect, setOpenImageProviderSelect] = useState(false);
 
-    const userConfigState = useSelector((state: RootState) => state.userConfig);
-    const [llmConfig, setLlmConfig] = useState(userConfigState.llm_config);
-    const canChangeKeys = userConfigState.can_change_keys;
-    const [ollamaModels, setOllamaModels] = useState<{
-        label: string;
-        value: string;
-        description: string;
-        size: string;
-        icon: string;
-    }[]>([]);
-    const [customModels, setCustomModels] = useState<string[]>([]);
-    const [downloadingModel, setDownloadingModel] = useState({
-        name: '',
-        size: null,
-        downloaded: null,
-        status: '',
-        done: false,
+  const userConfigState = useSelector((state: RootState) => state.userConfig);
+  const [llmConfig, setLlmConfig] = useState(userConfigState.llm_config);
+  const canChangeKeys = userConfigState.can_change_keys;
+  const [ollamaModels, setOllamaModels] = useState<
+    {
+      label: string;
+      value: string;
+      description: string;
+      size: string;
+      icon: string;
+    }[]
+  >([]);
+  const [customModels, setCustomModels] = useState<string[]>([]);
+  const [downloadingModel, setDownloadingModel] = useState({
+    name: "",
+    size: null,
+    downloaded: null,
+    status: "",
+    done: false,
+  });
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [openModelSelect, setOpenModelSelect] = useState(false);
+  const [useCustomOllamaUrl, setUseCustomOllamaUrl] = useState<boolean>(
+    userConfigState.llm_config.USE_CUSTOM_URL || false
+  );
+  const [customModelsLoading, setCustomModelsLoading] =
+    useState<boolean>(false);
+  const [customModelsChecked, setCustomModelsChecked] =
+    useState<boolean>(false);
+
+  const input_field_changed = (new_value: string, field: string) => {
+    if (field === "openai_api_key") {
+      setLlmConfig({ ...llmConfig, OPENAI_API_KEY: new_value });
+    } else if (field === "google_api_key") {
+      setLlmConfig({ ...llmConfig, GOOGLE_API_KEY: new_value });
+    } else if (field === "ollama_url") {
+      setLlmConfig({ ...llmConfig, OLLAMA_URL: new_value });
+    } else if (field === "ollama_model") {
+      setLlmConfig({ ...llmConfig, OLLAMA_MODEL: new_value });
+    } else if (field === "custom_llm_url") {
+      setLlmConfig({ ...llmConfig, CUSTOM_LLM_URL: new_value });
+    } else if (field === "custom_llm_api_key") {
+      setLlmConfig({ ...llmConfig, CUSTOM_LLM_API_KEY: new_value });
+    } else if (field === "custom_model") {
+      setLlmConfig({ ...llmConfig, CUSTOM_MODEL: new_value });
+    } else if (field === "pexels_api_key") {
+      setLlmConfig({ ...llmConfig, PEXELS_API_KEY: new_value });
+    } else if (field === "pixabay_api_key") {
+      setLlmConfig({ ...llmConfig, PIXABAY_API_KEY: new_value });
+    }
+  };
+
+  const handleSaveConfig = async () => {
+    try {
+      await handleSaveLLMConfig(llmConfig);
+      if (llmConfig.LLM === "ollama") {
+        setIsLoading(true);
+        await pullOllamaModels();
+      }
+      toast({
+        title: "Success",
+        description: "Configuration saved successfully",
+      });
+      setIsLoading(false);
+      router.back();
+    } catch (error) {
+      console.error("Error:", error);
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to save configuration",
+        variant: "destructive",
+      });
+      setIsLoading(false);
+    }
+  };
+
+  const fetchOllamaModelsWithConfig = async (config: any) => {
+    try {
+      const response = await fetch("/api/v1/ppt/ollama/list-supported-models");
+      const data = await response.json();
+      setOllamaModels(data.models);
+
+      // Check if currently selected model is still available
+      if (config.OLLAMA_MODEL && data.models.length > 0) {
+        const isModelAvailable = data.models.some(
+          (model: any) => model.value === config.OLLAMA_MODEL
+        );
+        if (!isModelAvailable) {
+          setLlmConfig({ ...config, OLLAMA_MODEL: "" });
+        }
+      }
+    } catch (error) {
+      console.error("Error fetching ollama models:", error);
+    }
+  };
+
+  const changeProvider = (provider: string) => {
+    const newConfig = { ...llmConfig, LLM: provider };
+    setLlmConfig(newConfig);
+    if (provider === "ollama") {
+      // Use the new config to avoid stale state issues
+      fetchOllamaModelsWithConfig(newConfig);
+    }
+  };
+
+  const resetDownloadingModel = () => {
+    setDownloadingModel({
+      name: "",
+      size: null,
+      downloaded: null,
+      status: "",
+      done: false,
     });
-    const [isLoading, setIsLoading] = useState<boolean>(false);
-    const [openModelSelect, setOpenModelSelect] = useState(false);
-    const [useCustomOllamaUrl, setUseCustomOllamaUrl] = useState<boolean>(userConfigState.llm_config.USE_CUSTOM_URL || false);
-    const [customModelsLoading, setCustomModelsLoading] = useState<boolean>(false);
-    const [customModelsChecked, setCustomModelsChecked] = useState<boolean>(false);
+  };
 
-    const input_field_changed = (new_value: string, field: string) => {
-        if (field === 'openai_api_key') {
-            setLlmConfig({ ...llmConfig, OPENAI_API_KEY: new_value });
-        } else if (field === 'google_api_key') {
-            setLlmConfig({ ...llmConfig, GOOGLE_API_KEY: new_value });
-        } else if (field === 'ollama_url') {
-            setLlmConfig({ ...llmConfig, OLLAMA_URL: new_value });
-        } else if (field === 'ollama_model') {
-            setLlmConfig({ ...llmConfig, OLLAMA_MODEL: new_value });
-        } else if (field === 'custom_llm_url') {
-            setLlmConfig({ ...llmConfig, CUSTOM_LLM_URL: new_value });
-        } else if (field === 'custom_llm_api_key') {
-            setLlmConfig({ ...llmConfig, CUSTOM_LLM_API_KEY: new_value });
-        } else if (field === 'custom_model') {
-            setLlmConfig({ ...llmConfig, CUSTOM_MODEL: new_value });
-        } else if (field === 'pexels_api_key') {
-            setLlmConfig({ ...llmConfig, PEXELS_API_KEY: new_value });
-        }
-    }
-
-    const handleSaveConfig = async () => {
+  const pullOllamaModels = async (): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      const interval = setInterval(async () => {
         try {
-            await handleSaveLLMConfig(llmConfig);
-            if (llmConfig.LLM === 'ollama') {
-                setIsLoading(true);
-                await pullOllamaModels();
-            }
-            toast({
-                title: 'Success',
-                description: 'Configuration saved successfully',
-            });
-            setIsLoading(false);
-            router.back();
-        } catch (error) {
-            console.error('Error:', error);
-            toast({
-                title: 'Error',
-                description: error instanceof Error ? error.message : 'Failed to save configuration',
-                variant: 'destructive',
-            });
-            setIsLoading(false);
-        }
-    };
-
-    const fetchOllamaModelsWithConfig = async (config: any) => {
-        try {
-            const response = await fetch('/api/v1/ppt/ollama/list-supported-models');
+          const response = await fetch(
+            `/api/v1/ppt/ollama/pull-model?name=${llmConfig.OLLAMA_MODEL}`
+          );
+          if (response.status === 200) {
             const data = await response.json();
-            setOllamaModels(data.models);
-
-            // Check if currently selected model is still available
-            if (config.OLLAMA_MODEL && data.models.length > 0) {
-                const isModelAvailable = data.models.some((model: any) => model.value === config.OLLAMA_MODEL);
-                if (!isModelAvailable) {
-                    setLlmConfig({ ...config, OLLAMA_MODEL: '' });
-                }
+            if (data.done && data.status !== "error") {
+              clearInterval(interval);
+              setDownloadingModel(data);
+              resolve();
+            } else if (data.status === "error") {
+              clearInterval(interval);
+              resetDownloadingModel();
+              reject(new Error("Error occurred while pulling model"));
+            } else {
+              setDownloadingModel(data);
             }
+          } else {
+            clearInterval(interval);
+            resetDownloadingModel();
+            if (response.status === 403) {
+              reject(new Error("Request to Ollama Not Authorized"));
+            }
+            reject(new Error("Error occurred while pulling model"));
+          }
         } catch (error) {
-            console.error('Error fetching ollama models:', error);
+          clearInterval(interval);
+          resetDownloadingModel();
+          reject(error);
         }
-    }
+      }, 1000);
+    });
+  };
 
-    const changeProvider = (provider: string) => {
-        const newConfig = { ...llmConfig, LLM: provider };
-        setLlmConfig(newConfig);
-        if (provider === 'ollama') {
-            // Use the new config to avoid stale state issues
-            fetchOllamaModelsWithConfig(newConfig);
+  const fetchOllamaModels = async () => {
+    await fetchOllamaModelsWithConfig(llmConfig);
+  };
+
+  const fetchCustomModels = async () => {
+    try {
+      setCustomModelsLoading(true);
+      const response = await fetch("/api/v1/ppt/models/list/custom", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          url: llmConfig.CUSTOM_LLM_URL || "",
+          api_key: llmConfig.CUSTOM_LLM_API_KEY || "",
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      setCustomModels(data);
+      // Only set customModelsChecked to true if the API call succeeds
+      setCustomModelsChecked(true);
+
+      // Check if currently selected model is still available
+      if (llmConfig.CUSTOM_MODEL && data.length > 0) {
+        const isModelAvailable = data.includes(llmConfig.CUSTOM_MODEL);
+        if (!isModelAvailable) {
+          setLlmConfig({ ...llmConfig, CUSTOM_MODEL: "" });
+          toast({
+            title: "Model Unavailable",
+            description: `The selected model "${llmConfig.CUSTOM_MODEL}" is no longer available. Please select a different model.`,
+            variant: "destructive",
+          });
         }
+      }
+    } catch (error) {
+      console.error("Error fetching custom models:", error);
+      // Don't set customModelsChecked to true on error, so the button remains visible
+      setCustomModels([]);
+      toast({
+        title: "Error",
+        description:
+          "Failed to fetch available models. Please check your URL and API key.",
+        variant: "destructive",
+      });
+    } finally {
+      setCustomModelsLoading(false);
     }
+  };
 
-    const resetDownloadingModel = () => {
-        setDownloadingModel({
-            name: '',
-            size: null,
-            downloaded: null,
-            status: '',
-            done: false,
-        });
+  const setOllamaConfig = () => {
+    if (!useCustomOllamaUrl) {
+      setLlmConfig({
+        ...llmConfig,
+        OLLAMA_URL: "http://localhost:11434",
+        USE_CUSTOM_URL: false,
+      });
+    } else {
+      setLlmConfig({ ...llmConfig, USE_CUSTOM_URL: true });
     }
+  };
 
-    const pullOllamaModels = async (): Promise<void> => {
-        return new Promise((resolve, reject) => {
-            const interval = setInterval(async () => {
-                try {
-                    const response = await fetch(`/api/v1/ppt/ollama/pull-model?name=${llmConfig.OLLAMA_MODEL}`);
-                    if (response.status === 200) {
-                        const data = await response.json();
-                        if (data.done && data.status !== 'error') {
-                            clearInterval(interval);
-                            setDownloadingModel(data);
-                            resolve();
-                        } else if (data.status === 'error') {
-                            clearInterval(interval);
-                            resetDownloadingModel();
-                            reject(new Error('Error occurred while pulling model'));
-                        } else {
-                            setDownloadingModel(data);
-                        }
-                    } else {
-                        clearInterval(interval);
-                        resetDownloadingModel();
-                        if (response.status === 403) {
-                            reject(new Error('Request to Ollama Not Authorized'));
-                        }
-                        reject(new Error('Error occurred while pulling model'));
-                    }
-                } catch (error) {
-                    clearInterval(interval);
-                    resetDownloadingModel();
-                    reject(error);
-                }
-            }, 1000);
-        });
-    }
+  const onCustomModelInfoChange = (value: string, field: string) => {
+    setCustomModels([]);
+    setCustomModelsChecked(false);
+    setLlmConfig({
+      ...llmConfig,
+      CUSTOM_MODEL: "",
+      CUSTOM_LLM_URL:
+        field === "custom_llm_url" ? value : llmConfig.CUSTOM_LLM_URL,
+      CUSTOM_LLM_API_KEY:
+        field === "custom_llm_api_key" ? value : llmConfig.CUSTOM_LLM_API_KEY,
+    });
+  };
 
-    const fetchOllamaModels = async () => {
-        await fetchOllamaModelsWithConfig(llmConfig);
-    }
-
-    const fetchCustomModels = async () => {
-        try {
-            setCustomModelsLoading(true);
-            const response = await fetch('/api/v1/ppt/models/list/custom', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    url: llmConfig.CUSTOM_LLM_URL || '',
-                    api_key: llmConfig.CUSTOM_LLM_API_KEY || ''
-                })
-            });
-            
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            
-            const data = await response.json();
-            setCustomModels(data);
-            // Only set customModelsChecked to true if the API call succeeds
-            setCustomModelsChecked(true);
-
-            // Check if currently selected model is still available
-            if (llmConfig.CUSTOM_MODEL && data.length > 0) {
-                const isModelAvailable = data.includes(llmConfig.CUSTOM_MODEL);
-                if (!isModelAvailable) {
-                    setLlmConfig({ ...llmConfig, CUSTOM_MODEL: '' });
-                    toast({
-                        title: 'Model Unavailable',
-                        description: `The selected model "${llmConfig.CUSTOM_MODEL}" is no longer available. Please select a different model.`,
-                        variant: 'destructive',
-                    });
-                }
-            }
-        } catch (error) {
-            console.error('Error fetching custom models:', error);
-            // Don't set customModelsChecked to true on error, so the button remains visible
-            setCustomModels([]);
-            toast({
-                title: 'Error',
-                description: 'Failed to fetch available models. Please check your URL and API key.',
-                variant: 'destructive',
-            });
-        } finally {
-            setCustomModelsLoading(false);
-        }
-    }
-
-    const setOllamaConfig = () => {
-        if (!useCustomOllamaUrl) {
-            setLlmConfig({ ...llmConfig, OLLAMA_URL: 'http://localhost:11434', USE_CUSTOM_URL: false });
-        } else {
-            setLlmConfig({ ...llmConfig, USE_CUSTOM_URL: true });
-        }
-    }
-
-    const onCustomModelInfoChange = (value: string, field: string) => {
-        setCustomModels([]);
-        setCustomModelsChecked(false);
-        setLlmConfig({ ...llmConfig, CUSTOM_MODEL: '', CUSTOM_LLM_URL: field === 'custom_llm_url' ? value : llmConfig.CUSTOM_LLM_URL, CUSTOM_LLM_API_KEY: field === 'custom_llm_api_key' ? value : llmConfig.CUSTOM_LLM_API_KEY });
-    }
-
-    useEffect(() => {
-
-        if (!canChangeKeys) {
-            router.push("/dashboard");
-        }
-        if (userConfigState.llm_config.LLM === 'ollama') {
-            fetchOllamaModels();
-        } else if (userConfigState.llm_config.LLM === 'custom' &&
-            userConfigState.llm_config.CUSTOM_MODEL &&
-            userConfigState.llm_config.CUSTOM_LLM_URL) {
-            fetchCustomModels();
-        }
-    }, [userConfigState.llm_config.LLM]);
-
-    useEffect(() => {
-        setOllamaConfig();
-    }, [useCustomOllamaUrl]);
-
-
+  useEffect(() => {
     if (!canChangeKeys) {
-        return null;
+      router.push("/dashboard");
     }
+    if (userConfigState.llm_config.LLM === "ollama") {
+      fetchOllamaModels();
+    } else if (
+      userConfigState.llm_config.LLM === "custom" &&
+      userConfigState.llm_config.CUSTOM_MODEL &&
+      userConfigState.llm_config.CUSTOM_LLM_URL
+    ) {
+      fetchCustomModels();
+    }
+  }, [userConfigState.llm_config.LLM]);
 
-    return (
-        <div className="min-h-screen bg-[#E9E8F8] font-instrument_sans">
-            <Header />
-            <Wrapper className="lg:w-[80%]">
-                <div className="py-8 space-y-6">
-                    {/* Settings Header */}
-                    <div className="flex items-center gap-3 mb-6">
-                        <Settings className="w-8 h-8 text-blue-600" />
-                        <h1 className="text-2xl font-semibold text-gray-900">Settings</h1>
+  useEffect(() => {
+    setOllamaConfig();
+  }, [useCustomOllamaUrl]);
+
+  if (!canChangeKeys) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-[#E9E8F8] font-instrument_sans">
+      <Header />
+      <Wrapper className="lg:w-[80%]">
+        <div className="py-8 space-y-6">
+          {/* Settings Header */}
+          <div className="flex items-center gap-3 mb-6">
+            <Settings className="w-8 h-8 text-blue-600" />
+            <h1 className="text-2xl font-semibold text-gray-900">Settings</h1>
+          </div>
+
+          {/* API Configuration Section */}
+          <div className="bg-white rounded-xl shadow-sm p-6">
+            <div className="flex items-center gap-3 mb-6">
+              <Key className="w-5 h-5 text-blue-600" />
+              <h2 className="text-lg font-medium text-gray-900">
+                API Configuration
+              </h2>
+            </div>
+
+            {/* Provider Selection */}
+            <div className="mb-8">
+              <label className="block text-sm font-medium text-gray-700 mb-3">
+                Select AI Provider
+              </label>
+              <div className="grid grid-cols-2 gap-4">
+                {Object.keys(PROVIDER_CONFIGS).map((provider) => (
+                  <button
+                    key={provider}
+                    onClick={() => changeProvider(provider)}
+                    className={`relative p-4 rounded-lg border-2 transition-all duration-200 ${
+                      llmConfig.LLM === provider
+                        ? "border-blue-500 bg-blue-50"
+                        : "border-gray-200 hover:border-blue-200 hover:bg-gray-50"
+                    }`}
+                  >
+                    <div className="flex items-center justify-center gap-3">
+                      <span
+                        className={`font-medium text-center ${
+                          llmConfig.LLM === provider
+                            ? "text-blue-700"
+                            : "text-gray-700"
+                        }`}
+                      >
+                        {provider === "openai"
+                          ? "OpenAI"
+                          : provider.charAt(0).toUpperCase() +
+                            provider.slice(1)}
+                      </span>
                     </div>
+                  </button>
+                ))}
+              </div>
+            </div>
 
-                    {/* API Configuration Section */}
-                    <div className="bg-white rounded-xl shadow-sm p-6">
-                        <div className="flex items-center gap-3 mb-6">
-                            <Key className="w-5 h-5 text-blue-600" />
-                            <h2 className="text-lg font-medium text-gray-900">API Configuration</h2>
-                        </div>
-
-                        {/* Provider Selection */}
-                        <div className="mb-8">
-                            <label className="block text-sm font-medium text-gray-700 mb-3">
-                                Select AI Provider
-                            </label>
-                            <div className="grid grid-cols-2 gap-4">
-                                {Object.keys(PROVIDER_CONFIGS).map((provider) => (
-                                    <button
-                                        key={provider}
-                                        onClick={() => changeProvider(provider)}
-                                        className={`relative p-4 rounded-lg border-2 transition-all duration-200 ${llmConfig.LLM === provider
-                                            ? "border-blue-500 bg-blue-50"
-                                            : "border-gray-200 hover:border-blue-200 hover:bg-gray-50"
-                                            }`}
-                                    >
-                                        <div className="flex items-center justify-center gap-3">
-                                            <span
-                                                className={`font-medium text-center ${llmConfig.LLM === provider
-                                                    ? "text-blue-700"
-                                                    : "text-gray-700"
-                                                    }`}
-                                            >
-                                                {provider === 'openai' ? 'OpenAI' : provider.charAt(0).toUpperCase() + provider.slice(1)}
-                                            </span>
-                                        </div>
-                                    </button>
-                                ))}
-                            </div>
-                        </div>
-
-                        {/* API Key Input */}
-                        {llmConfig.LLM !== 'ollama' && llmConfig.LLM !== 'custom' && (
-                            <div className="space-y-6">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        {PROVIDER_CONFIGS[llmConfig.LLM!].title}
-                                    </label>
-                                    <div className="relative">
-                                        <input
-                                            type="text"
-                                            value={llmConfig.LLM === 'openai' ? llmConfig.OPENAI_API_KEY || '' : llmConfig.GOOGLE_API_KEY || ''}
-                                            onChange={(e) => input_field_changed(e.target.value, llmConfig.LLM === 'openai' ? 'openai_api_key' : 'google_api_key')}
-                                            className="w-full px-4 py-2.5 border border-gray-300 outline-none rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                            placeholder={PROVIDER_CONFIGS[llmConfig.LLM!].placeholder}
-                                        />
-                                    </div>
-                                    <p className="mt-2 text-sm text-gray-500">{PROVIDER_CONFIGS[llmConfig.LLM!].description}</p>
-                                </div>
-                            </div>
-                        )}
-
-                        {/* Ollama Configuration */}
-                        {llmConfig.LLM === 'ollama' && (
-                            <div className="space-y-6">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        Choose a supported model
-                                    </label>
-                                    <div className="w-full">
-                                        {ollamaModels.length > 0 ? (
-                                            <Popover open={openModelSelect} onOpenChange={setOpenModelSelect}>
-                                                <PopoverTrigger asChild>
-                                                    <Button
-                                                        variant="outline"
-                                                        role="combobox"
-                                                        aria-expanded={openModelSelect}
-                                                        className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
-                                                    >
-                                                        <div className="flex gap-3 items-center">
-                                                            {llmConfig.OLLAMA_MODEL && (
-                                                                <div className="w-6 h-6 rounded-lg flex items-center justify-center flex-shrink-0">
-                                                                    <img
-                                                                        src={ollamaModels.find(m => m.value === llmConfig.OLLAMA_MODEL)?.icon}
-                                                                        alt={`${llmConfig.OLLAMA_MODEL} icon`}
-                                                                        className="rounded-sm"
-                                                                    />
-                                                                </div>
-                                                            )}
-                                                            <span className="text-sm font-medium text-gray-900">
-                                                                {llmConfig.OLLAMA_MODEL ? (
-                                                                    ollamaModels.find(m => m.value === llmConfig.OLLAMA_MODEL)?.label || llmConfig.OLLAMA_MODEL
-                                                                ) : (
-                                                                    'Select a model'
-                                                                )}
-                                                            </span>
-                                                            {llmConfig.OLLAMA_MODEL && (
-                                                                <span className="text-xs text-gray-500 bg-gray-100 rounded-full px-2 py-1">
-                                                                    {ollamaModels.find(m => m.value === llmConfig.OLLAMA_MODEL)?.size}
-                                                                </span>
-                                                            )}
-                                                        </div>
-                                                        <ChevronsUpDown className="w-4 h-4 text-gray-500" />
-                                                    </Button>
-                                                </PopoverTrigger>
-                                                <PopoverContent className="p-0" align="start" style={{ width: 'var(--radix-popover-trigger-width)' }}>
-                                                    <Command>
-                                                        <CommandInput placeholder="Search model..." />
-                                                        <CommandList>
-                                                            <CommandEmpty>No model found.</CommandEmpty>
-                                                            <CommandGroup>
-                                                                {ollamaModels.map((model, index) => (
-                                                                    <CommandItem
-                                                                        key={index}
-                                                                        value={model.value}
-                                                                        onSelect={(value) => {
-                                                                            setLlmConfig({ ...llmConfig, OLLAMA_MODEL: value });
-                                                                            setOpenModelSelect(false);
-                                                                        }}
-                                                                    >
-                                                                        <Check
-                                                                            className={cn(
-                                                                                "mr-2 h-4 w-4",
-                                                                                llmConfig.OLLAMA_MODEL === model.value ? "opacity-100" : "opacity-0"
-                                                                            )}
-                                                                        />
-                                                                        <div className="flex gap-3 items-center">
-                                                                            <div className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0">
-                                                                                <img
-                                                                                    src={model.icon}
-                                                                                    alt={`${model.label} icon`}
-                                                                                    className="rounded-sm"
-                                                                                />
-                                                                            </div>
-                                                                            <div className="flex flex-col space-y-1 flex-1">
-                                                                                <div className="flex items-center justify-between gap-2">
-                                                                                    <span className="text-sm font-medium text-gray-900 capitalize">
-                                                                                        {model.label}
-                                                                                    </span>
-                                                                                    <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded-full">
-                                                                                        {model.size}
-                                                                                    </span>
-                                                                                </div>
-                                                                                <span className="text-xs text-gray-600 leading-relaxed">
-                                                                                    {model.description}
-                                                                                </span>
-                                                                            </div>
-                                                                        </div>
-                                                                    </CommandItem>
-                                                                ))}
-                                                            </CommandGroup>
-                                                        </CommandList>
-                                                    </Command>
-                                                </PopoverContent>
-                                            </Popover>
-                                        ) : (
-                                            <div className="w-full border border-gray-300 rounded-lg p-4">
-                                                <div className="flex items-center space-x-3">
-                                                    <div className="w-4 h-4 bg-gray-200 rounded-full animate-pulse"></div>
-                                                    <div className="flex-1 space-y-2">
-                                                        <div className="h-4 bg-gray-200 rounded animate-pulse"></div>
-                                                        <div className="h-3 bg-gray-200 rounded w-3/4 animate-pulse"></div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        )}
-                                    </div>
-                                    {ollamaModels.length === 0 && (
-                                        <p className="mt-2 text-sm text-gray-500">
-                                            Loading available models...
-                                        </p>
-                                    )}
-                                </div>
-
-                                {/* Custom Ollama URL Configuration */}
-                                <div>
-                                    <div className="flex items-center justify-between mb-4 bg-green-50 p-2 rounded-sm">
-                                        <label className="text-sm font-medium text-gray-700">
-                                            Use custom Ollama URL
-                                        </label>
-                                        <Switch
-                                            checked={useCustomOllamaUrl}
-                                            onCheckedChange={setUseCustomOllamaUrl}
-                                        />
-                                    </div>
-                                    {useCustomOllamaUrl && (
-                                        <>
-                                            <div className="mb-4">
-                                                <label className="block text-sm font-medium text-gray-700 mb-2">
-                                                    Ollama URL
-                                                </label>
-                                                <div className="relative">
-                                                    <input
-                                                        type="text"
-                                                        required
-                                                        placeholder="Enter your Ollama URL"
-                                                        className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                                        value={llmConfig.OLLAMA_URL || ''}
-                                                        onChange={(e) => input_field_changed(e.target.value, 'ollama_url')}
-                                                    />
-                                                </div>
-                                                <p className="mt-2 text-sm text-gray-500 flex items-center gap-2">
-                                                    <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
-                                                    Change this if you are using a custom Ollama instance
-                                                </p>
-                                            </div>
-
-                                        </>
-                                    )}
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        Pexels API Key (optional)
-                                    </label>
-                                    <div className="relative">
-                                        <input
-                                            type="text"
-                                            required
-                                            placeholder="Enter your Pexels API key"
-                                            className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                            value={llmConfig.PEXELS_API_KEY || ''}
-                                            onChange={(e) => input_field_changed(e.target.value, 'pexels_api_key')}
-                                        />
-                                    </div>
-                                    <p className="mt-2 text-sm text-gray-500">Provide a Pexels API key to generate presentation images</p>
-                                </div>
-                            </div>
-                        )}
-
-                        {/* Custom Model Configuration */}
-                        {llmConfig.LLM === 'custom' && (
-                            <div className="space-y-6">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        OpenAI Compatible URL
-                                    </label>
-                                    <div className="relative">
-                                        <input
-                                            type="text"
-                                            required
-                                            placeholder="Enter your URL"
-                                            className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                            value={llmConfig.CUSTOM_LLM_URL || ''}
-                                            onChange={(e) => onCustomModelInfoChange(e.target.value, 'custom_llm_url')}
-                                        />
-                                    </div>
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        OpenAI Compatible API Key
-                                    </label>
-                                    <div className="relative">
-                                        <input
-                                            type="text"
-                                            placeholder="Enter your API key"
-                                            className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                            value={llmConfig.CUSTOM_LLM_API_KEY || ''}
-                                            onChange={(e) => onCustomModelInfoChange(e.target.value, 'custom_llm_api_key')}
-                                        />
-                                    </div>
-                                </div>
-
-                                {/* Model selection dropdown - show if models are available or if there's a selected model */}
-                                {((customModelsChecked && customModels.length > 0) || llmConfig.CUSTOM_MODEL) && (
-                                    <div>
-                                        <div className="mb-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-                                            <p className="text-sm text-amber-800">
-                                                <strong>Important:</strong> Only models with function calling capabilities (tool calls) or JSON schema support will work.
-                                            </p>
-                                        </div>
-                                        <label className="block text-sm font-medium text-gray-700 mb-2">
-                                            Select Model
-                                        </label>
-                                        <div className="w-full">
-                                            <Popover open={openModelSelect} onOpenChange={setOpenModelSelect}>
-                                                <PopoverTrigger asChild>
-                                                    <Button
-                                                        variant="outline"
-                                                        role="combobox"
-                                                        aria-expanded={openModelSelect}
-                                                        className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
-                                                    >
-                                                        <span className="text-sm font-medium text-gray-900">
-                                                            {llmConfig.CUSTOM_MODEL || 'Select a model'}
-                                                        </span>
-                                                        <ChevronsUpDown className="w-4 h-4 text-gray-500" />
-                                                    </Button>
-                                                </PopoverTrigger>
-                                                <PopoverContent className="p-0" align="start" style={{ width: 'var(--radix-popover-trigger-width)' }}>
-                                                    <Command>
-                                                        <CommandInput placeholder="Search model..." />
-                                                        <CommandList>
-                                                            <CommandEmpty>No model found.</CommandEmpty>
-                                                            <CommandGroup>
-                                                                {customModels.map((model, index) => (
-                                                                    <CommandItem
-                                                                        key={index}
-                                                                        value={model}
-                                                                        onSelect={(value) => {
-                                                                            setLlmConfig({ ...llmConfig, CUSTOM_MODEL: value });
-                                                                            setOpenModelSelect(false);
-                                                                        }}
-                                                                    >
-                                                                        <Check
-                                                                            className={cn(
-                                                                                "mr-2 h-4 w-4",
-                                                                                llmConfig.CUSTOM_MODEL === model ? "opacity-100" : "opacity-0"
-                                                                            )}
-                                                                        />
-                                                                        <span className="text-sm font-medium text-gray-900">
-                                                                            {model}
-                                                                        </span>
-                                                                    </CommandItem>
-                                                                ))}
-                                                            </CommandGroup>
-                                                        </CommandList>
-                                                    </Command>
-                                                </PopoverContent>
-                                            </Popover>
-                                        </div>
-                                    </div>
-                                )}
-
-                                {/* Check for available models button - show when no models checked or no models found, and no model is selected */}
-                                {(!customModelsChecked || (customModelsChecked && customModels.length === 0)) && !llmConfig.CUSTOM_MODEL && (
-                                    <div>
-                                        <button
-                                            onClick={fetchCustomModels}
-                                            disabled={customModelsLoading || !llmConfig.CUSTOM_LLM_URL}
-                                            className={`w-full py-2.5 px-4 rounded-lg transition-all duration-200 border-2 font-semibold ${customModelsLoading || !llmConfig.CUSTOM_LLM_URL
-                                                ? 'bg-gray-100 border-gray-300 cursor-not-allowed text-gray-500'
-                                                : 'bg-white border-blue-600 text-blue-600 hover:bg-blue-50 focus:ring-2 focus:ring-blue-500/20'
-                                                }`}
-                                        >
-                                            {customModelsLoading ? (
-                                                <div className="flex items-center justify-center gap-2">
-                                                    <Loader2 className="w-4 h-4 animate-spin" />
-                                                    Checking for models...
-                                                </div>
-                                            ) : (
-                                                'Check for available models'
-                                            )}
-                                        </button>
-                                    </div>
-                                )}
-
-                                {/* Show message if no models found */}
-                                {customModelsChecked && customModels.length === 0 && (
-                                    <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-                                        <p className="text-sm text-yellow-800">
-                                            No models found. Please make sure models are available.
-                                        </p>
-                                    </div>
-                                )}
-
-                                {/* Refresh models button - show when there's a selected model but we want to refresh */}
-                                {llmConfig.CUSTOM_MODEL && customModelsChecked && (
-                                    <div>
-                                        <button
-                                            onClick={fetchCustomModels}
-                                            disabled={customModelsLoading || !llmConfig.CUSTOM_LLM_URL}
-                                            className={`w-full py-2.5 px-4 rounded-lg transition-all duration-200 border-2 font-semibold ${customModelsLoading || !llmConfig.CUSTOM_LLM_URL
-                                                ? 'bg-gray-100 border-gray-300 cursor-not-allowed text-gray-500'
-                                                : 'bg-white border-gray-600 text-gray-600 hover:bg-gray-50 focus:ring-2 focus:ring-gray-500/20'
-                                                }`}
-                                        >
-                                            {customModelsLoading ? (
-                                                <div className="flex items-center justify-center gap-2">
-                                                    <Loader2 className="w-4 h-4 animate-spin" />
-                                                    Refreshing models...
-                                                </div>
-                                            ) : (
-                                                'Refresh Available Models'
-                                            )}
-                                        </button>
-                                    </div>
-                                )}
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        Pexels API Key (optional)
-                                    </label>
-                                    <div className="relative">
-                                        <input
-                                            type="text"
-                                            required
-                                            placeholder="Enter your Pexels API key"
-                                            className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                            value={llmConfig.PEXELS_API_KEY || ''}
-                                            onChange={(e) => input_field_changed(e.target.value, 'pexels_api_key')}
-                                        />
-                                    </div>
-                                    <p className="mt-2 text-sm text-gray-500">Provide a Pexels API key to generate presentation images</p>
-                                </div>
-                            </div>
-                        )}
-
-                        {/* Save Button */}
-                        <button
-                            onClick={handleSaveConfig}
-                            disabled={isLoading || (llmConfig.LLM === 'ollama' && !llmConfig.OLLAMA_MODEL) || (llmConfig.LLM === 'custom' && !llmConfig.CUSTOM_MODEL)}
-                            className={`mt-8 w-full font-semibold py-3 px-4 rounded-lg transition-all duration-500 ${isLoading || (llmConfig.LLM === 'ollama' && !llmConfig.OLLAMA_MODEL) || (llmConfig.LLM === 'custom' && !llmConfig.CUSTOM_MODEL)
-                                ? 'bg-gray-400 cursor-not-allowed'
-                                : 'bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 focus:ring-4 focus:ring-blue-200'
-                                } text-white`}
-                        >
-                            {isLoading ? (
-                                <div className="flex items-center justify-center gap-2">
-                                    <Loader2 className="w-4 h-4 animate-spin" />
-                                    {llmConfig.LLM === 'ollama' && downloadingModel.downloaded || 0 > 0
-                                        ? `Downloading Model (${(((downloadingModel.downloaded || 0) / (downloadingModel.size || 1)) * 100).toFixed(0)}%)`
-                                        : 'Saving Configuration...'
-                                    }
-                                </div>
-                            ) : (
-                                (llmConfig.LLM === 'ollama' && !llmConfig.OLLAMA_MODEL) || (llmConfig.LLM === 'custom' && !llmConfig.CUSTOM_MODEL)
-                                    ? 'Please Select a Model'
-                                    : 'Save Configuration'
-                            )}
-                        </button>
-
-                        {
-                            llmConfig.LLM === 'ollama' && downloadingModel.status && downloadingModel.status !== 'pulled' && (
-                                <div className="mt-3 text-sm bg-green-100 rounded-lg p-2 font-semibold capitalize text-center text-gray-600">
-                                    {downloadingModel.status}
-                                </div>
-                            )
-                        }
-                    </div>
+            {/* API Key Input */}
+            {llmConfig.LLM !== "ollama" && llmConfig.LLM !== "custom" && (
+              <div className="space-y-6">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    {PROVIDER_CONFIGS[llmConfig.LLM!].title}
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      value={
+                        llmConfig.LLM === "openai"
+                          ? llmConfig.OPENAI_API_KEY || ""
+                          : llmConfig.GOOGLE_API_KEY || ""
+                      }
+                      onChange={(e) =>
+                        input_field_changed(
+                          e.target.value,
+                          llmConfig.LLM === "openai"
+                            ? "openai_api_key"
+                            : "google_api_key"
+                        )
+                      }
+                      className="w-full px-4 py-2.5 border border-gray-300 outline-none rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                      placeholder={PROVIDER_CONFIGS[llmConfig.LLM!].placeholder}
+                    />
+                  </div>
+                  <p className="mt-2 text-sm text-gray-500">
+                    {PROVIDER_CONFIGS[llmConfig.LLM!].description}
+                  </p>
                 </div>
-            </Wrapper>
+              </div>
+            )}
+
+            {/* Ollama Configuration */}
+            {llmConfig.LLM === "ollama" && (
+              <div className="space-y-6">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Choose a supported model
+                  </label>
+                  <div className="w-full">
+                    {ollamaModels.length > 0 ? (
+                      <Popover
+                        open={openModelSelect}
+                        onOpenChange={setOpenModelSelect}
+                      >
+                        <PopoverTrigger asChild>
+                          <Button
+                            variant="outline"
+                            role="combobox"
+                            aria-expanded={openModelSelect}
+                            className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
+                          >
+                            <div className="flex gap-3 items-center">
+                              {llmConfig.OLLAMA_MODEL && (
+                                <div className="w-6 h-6 rounded-lg flex items-center justify-center flex-shrink-0">
+                                  <img
+                                    src={
+                                      ollamaModels.find(
+                                        (m) =>
+                                          m.value === llmConfig.OLLAMA_MODEL
+                                      )?.icon
+                                    }
+                                    alt={`${llmConfig.OLLAMA_MODEL} icon`}
+                                    className="rounded-sm"
+                                  />
+                                </div>
+                              )}
+                              <span className="text-sm font-medium text-gray-900">
+                                {llmConfig.OLLAMA_MODEL
+                                  ? ollamaModels.find(
+                                      (m) => m.value === llmConfig.OLLAMA_MODEL
+                                    )?.label || llmConfig.OLLAMA_MODEL
+                                  : "Select a model"}
+                              </span>
+                              {llmConfig.OLLAMA_MODEL && (
+                                <span className="text-xs text-gray-500 bg-gray-100 rounded-full px-2 py-1">
+                                  {
+                                    ollamaModels.find(
+                                      (m) => m.value === llmConfig.OLLAMA_MODEL
+                                    )?.size
+                                  }
+                                </span>
+                              )}
+                            </div>
+                            <ChevronsUpDown className="w-4 h-4 text-gray-500" />
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent
+                          className="p-0"
+                          align="start"
+                          style={{
+                            width: "var(--radix-popover-trigger-width)",
+                          }}
+                        >
+                          <Command>
+                            <CommandInput placeholder="Search model..." />
+                            <CommandList>
+                              <CommandEmpty>No model found.</CommandEmpty>
+                              <CommandGroup>
+                                {ollamaModels.map((model, index) => (
+                                  <CommandItem
+                                    key={index}
+                                    value={model.value}
+                                    onSelect={(value) => {
+                                      setLlmConfig({
+                                        ...llmConfig,
+                                        OLLAMA_MODEL: value,
+                                      });
+                                      setOpenModelSelect(false);
+                                    }}
+                                  >
+                                    <Check
+                                      className={cn(
+                                        "mr-2 h-4 w-4",
+                                        llmConfig.OLLAMA_MODEL === model.value
+                                          ? "opacity-100"
+                                          : "opacity-0"
+                                      )}
+                                    />
+                                    <div className="flex gap-3 items-center">
+                                      <div className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0">
+                                        <img
+                                          src={model.icon}
+                                          alt={`${model.label} icon`}
+                                          className="rounded-sm"
+                                        />
+                                      </div>
+                                      <div className="flex flex-col space-y-1 flex-1">
+                                        <div className="flex items-center justify-between gap-2">
+                                          <span className="text-sm font-medium text-gray-900 capitalize">
+                                            {model.label}
+                                          </span>
+                                          <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded-full">
+                                            {model.size}
+                                          </span>
+                                        </div>
+                                        <span className="text-xs text-gray-600 leading-relaxed">
+                                          {model.description}
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </CommandItem>
+                                ))}
+                              </CommandGroup>
+                            </CommandList>
+                          </Command>
+                        </PopoverContent>
+                      </Popover>
+                    ) : (
+                      <div className="w-full border border-gray-300 rounded-lg p-4">
+                        <div className="flex items-center space-x-3">
+                          <div className="w-4 h-4 bg-gray-200 rounded-full animate-pulse"></div>
+                          <div className="flex-1 space-y-2">
+                            <div className="h-4 bg-gray-200 rounded animate-pulse"></div>
+                            <div className="h-3 bg-gray-200 rounded w-3/4 animate-pulse"></div>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                  {ollamaModels.length === 0 && (
+                    <p className="mt-2 text-sm text-gray-500">
+                      Loading available models...
+                    </p>
+                  )}
+                </div>
+
+                {/* Custom Ollama URL Configuration */}
+                <div>
+                  <div className="flex items-center justify-between mb-4 bg-green-50 p-2 rounded-sm">
+                    <label className="text-sm font-medium text-gray-700">
+                      Use custom Ollama URL
+                    </label>
+                    <Switch
+                      checked={useCustomOllamaUrl}
+                      onCheckedChange={setUseCustomOllamaUrl}
+                    />
+                  </div>
+                  {useCustomOllamaUrl && (
+                    <>
+                      <div className="mb-4">
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                          Ollama URL
+                        </label>
+                        <div className="relative">
+                          <input
+                            type="text"
+                            required
+                            placeholder="Enter your Ollama URL"
+                            className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                            value={llmConfig.OLLAMA_URL || ""}
+                            onChange={(e) =>
+                              input_field_changed(e.target.value, "ollama_url")
+                            }
+                          />
+                        </div>
+                        <p className="mt-2 text-sm text-gray-500 flex items-center gap-2">
+                          <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
+                          Change this if you are using a custom Ollama instance
+                        </p>
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Pexels API Key (optional)
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      required
+                      placeholder="Enter your Pexels API key"
+                      className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                      value={llmConfig.PEXELS_API_KEY || ""}
+                      onChange={(e) =>
+                        input_field_changed(e.target.value, "pexels_api_key")
+                      }
+                    />
+                  </div>
+                  <p className="mt-2 text-sm text-gray-500">
+                    Provide a Pexels API key to generate presentation images
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* Custom Model Configuration */}
+            {llmConfig.LLM === "custom" && (
+              <div className="space-y-6">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    OpenAI Compatible URL
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      required
+                      placeholder="Enter your URL"
+                      className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                      value={llmConfig.CUSTOM_LLM_URL || ""}
+                      onChange={(e) =>
+                        onCustomModelInfoChange(
+                          e.target.value,
+                          "custom_llm_url"
+                        )
+                      }
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    OpenAI Compatible API Key
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      placeholder="Enter your API key"
+                      className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                      value={llmConfig.CUSTOM_LLM_API_KEY || ""}
+                      onChange={(e) =>
+                        onCustomModelInfoChange(
+                          e.target.value,
+                          "custom_llm_api_key"
+                        )
+                      }
+                    />
+                  </div>
+                </div>
+
+                {/* Model selection dropdown - show if models are available or if there's a selected model */}
+                {((customModelsChecked && customModels.length > 0) ||
+                  llmConfig.CUSTOM_MODEL) && (
+                  <div>
+                    <div className="mb-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                      <p className="text-sm text-amber-800">
+                        <strong>Important:</strong> Only models with function
+                        calling capabilities (tool calls) or JSON schema support
+                        will work.
+                      </p>
+                    </div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">
+                      Select Model
+                    </label>
+                    <div className="w-full">
+                      <Popover
+                        open={openModelSelect}
+                        onOpenChange={setOpenModelSelect}
+                      >
+                        <PopoverTrigger asChild>
+                          <Button
+                            variant="outline"
+                            role="combobox"
+                            aria-expanded={openModelSelect}
+                            className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
+                          >
+                            <span className="text-sm font-medium text-gray-900">
+                              {llmConfig.CUSTOM_MODEL || "Select a model"}
+                            </span>
+                            <ChevronsUpDown className="w-4 h-4 text-gray-500" />
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent
+                          className="p-0"
+                          align="start"
+                          style={{
+                            width: "var(--radix-popover-trigger-width)",
+                          }}
+                        >
+                          <Command>
+                            <CommandInput placeholder="Search model..." />
+                            <CommandList>
+                              <CommandEmpty>No model found.</CommandEmpty>
+                              <CommandGroup>
+                                {customModels.map((model, index) => (
+                                  <CommandItem
+                                    key={index}
+                                    value={model}
+                                    onSelect={(value) => {
+                                      setLlmConfig({
+                                        ...llmConfig,
+                                        CUSTOM_MODEL: value,
+                                      });
+                                      setOpenModelSelect(false);
+                                    }}
+                                  >
+                                    <Check
+                                      className={cn(
+                                        "mr-2 h-4 w-4",
+                                        llmConfig.CUSTOM_MODEL === model
+                                          ? "opacity-100"
+                                          : "opacity-0"
+                                      )}
+                                    />
+                                    <span className="text-sm font-medium text-gray-900">
+                                      {model}
+                                    </span>
+                                  </CommandItem>
+                                ))}
+                              </CommandGroup>
+                            </CommandList>
+                          </Command>
+                        </PopoverContent>
+                      </Popover>
+                    </div>
+                  </div>
+                )}
+
+                {/* Check for available models button - show when no models checked or no models found, and no model is selected */}
+                {(!customModelsChecked ||
+                  (customModelsChecked && customModels.length === 0)) &&
+                  !llmConfig.CUSTOM_MODEL && (
+                    <div>
+                      <button
+                        onClick={fetchCustomModels}
+                        disabled={
+                          customModelsLoading || !llmConfig.CUSTOM_LLM_URL
+                        }
+                        className={`w-full py-2.5 px-4 rounded-lg transition-all duration-200 border-2 font-semibold ${
+                          customModelsLoading || !llmConfig.CUSTOM_LLM_URL
+                            ? "bg-gray-100 border-gray-300 cursor-not-allowed text-gray-500"
+                            : "bg-white border-blue-600 text-blue-600 hover:bg-blue-50 focus:ring-2 focus:ring-blue-500/20"
+                        }`}
+                      >
+                        {customModelsLoading ? (
+                          <div className="flex items-center justify-center gap-2">
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                            Checking for models...
+                          </div>
+                        ) : (
+                          "Check for available models"
+                        )}
+                      </button>
+                    </div>
+                  )}
+
+                {/* Show message if no models found */}
+                {customModelsChecked && customModels.length === 0 && (
+                  <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
+                    <p className="text-sm text-yellow-800">
+                      No models found. Please make sure models are available.
+                    </p>
+                  </div>
+                )}
+
+                {/* Refresh models button - show when there's a selected model but we want to refresh */}
+                {llmConfig.CUSTOM_MODEL && customModelsChecked && (
+                  <div>
+                    <button
+                      onClick={fetchCustomModels}
+                      disabled={
+                        customModelsLoading || !llmConfig.CUSTOM_LLM_URL
+                      }
+                      className={`w-full py-2.5 px-4 rounded-lg transition-all duration-200 border-2 font-semibold ${
+                        customModelsLoading || !llmConfig.CUSTOM_LLM_URL
+                          ? "bg-gray-100 border-gray-300 cursor-not-allowed text-gray-500"
+                          : "bg-white border-gray-600 text-gray-600 hover:bg-gray-50 focus:ring-2 focus:ring-gray-500/20"
+                      }`}
+                    >
+                      {customModelsLoading ? (
+                        <div className="flex items-center justify-center gap-2">
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                          Refreshing models...
+                        </div>
+                      ) : (
+                        "Refresh Available Models"
+                      )}
+                    </button>
+                  </div>
+                )}
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Pexels API Key (optional)
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      required
+                      placeholder="Enter your Pexels API key"
+                      className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                      value={llmConfig.PEXELS_API_KEY || ""}
+                      onChange={(e) =>
+                        input_field_changed(e.target.value, "pexels_api_key")
+                      }
+                    />
+                  </div>
+                  <p className="mt-2 text-sm text-gray-500">
+                    Provide a Pexels API key to generate presentation images
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* Image Provider Selection */}
+            <div className="mb-8 mt-8">
+              <label className="block text-sm font-medium text-gray-700 mb-3">
+                Select Image Provider
+              </label>
+              <div className="w-full">
+                <Popover
+                  open={openImageProviderSelect}
+                  onOpenChange={setOpenImageProviderSelect}
+                >
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      role="combobox"
+                      aria-expanded={openImageProviderSelect}
+                      className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
+                    >
+                      <div className="flex gap-3 items-center">
+                        <span className="text-sm font-medium text-gray-900">
+                          {llmConfig.IMAGE_PROVIDER
+                            ? IMAGE_PROVIDERS[llmConfig.IMAGE_PROVIDER]
+                                ?.title || llmConfig.IMAGE_PROVIDER
+                            : "Select image provider"}
+                        </span>
+                      </div>
+                      <ChevronsUpDown className="w-4 h-4 text-gray-500" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="p-0"
+                    align="start"
+                    style={{ width: "var(--radix-popover-trigger-width)" }}
+                  >
+                    <Command>
+                      <CommandInput placeholder="Search provider..." />
+                      <CommandList>
+                        <CommandEmpty>No provider found.</CommandEmpty>
+                        <CommandGroup>
+                          {Object.values(IMAGE_PROVIDERS).map(
+                            (provider, index) => (
+                              <CommandItem
+                                key={index}
+                                value={provider.title}
+                                onSelect={(value) => {
+                                  console.log("Image Provider", value);
+                                  setLlmConfig({
+                                    ...llmConfig,
+                                    IMAGE_PROVIDER: value,
+                                  });
+                                  console.log("LLM config", llmConfig);
+                                  setOpenImageProviderSelect(false);
+                                }}
+                              >
+                                <Check
+                                  className={cn(
+                                    "mr-2 h-4 w-4",
+                                    llmConfig.IMAGE_PROVIDER === provider.title
+                                      ? "opacity-100"
+                                      : "opacity-0"
+                                  )}
+                                />
+                                <div className="flex gap-3 items-center">
+                                  <div className="flex flex-col space-y-1 flex-1">
+                                    <div className="flex items-center justify-between gap-2">
+                                      <span className="text-sm font-medium text-gray-900 capitalize">
+                                        {provider.title}
+                                      </span>
+                                    </div>
+                                    <span className="text-xs text-gray-600 leading-relaxed">
+                                      {provider.description}
+                                    </span>
+                                  </div>
+                                </div>
+                              </CommandItem>
+                            )
+                          )}
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
+              </div>
+            </div>
+            {/* Dynamic API Key Input for Image Provider */}
+            {llmConfig.IMAGE_PROVIDER &&
+              IMAGE_PROVIDERS[llmConfig.IMAGE_PROVIDER] &&
+              (() => {
+                const provider = IMAGE_PROVIDERS[llmConfig.IMAGE_PROVIDER];
+                // Show info message when using same API key as main provider
+                if (
+                  provider.title === "dall-e-3" &&
+                  llmConfig.LLM === "openai"
+                ) {
+                  return <></>;
+                }
+
+                if (provider.title === "imagen" && llmConfig.LLM === "google") {
+                  return <> </>;
+                }
+
+                // Show API key input for other providers
+                return (
+                  <div className="mb-8">
+                    <label className="block text-sm font-medium text-gray-700 mb-2">
+                      {provider.apiKeyField?.replace("_", " ")}
+                    </label>
+                    <div className="relative">
+                      <input
+                        type="text"
+                        placeholder={`Enter your ${provider.title} API key`}
+                        className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                        value={
+                          provider.apiKeyField === "PEXELS_API_KEY"
+                            ? llmConfig.PEXELS_API_KEY || ""
+                            : provider.apiKeyField === "PIXABAY_API_KEY"
+                            ? llmConfig.PIXABAY_API_KEY || ""
+                            : ""
+                        }
+                        onChange={(e) => {
+                          if (provider.apiKeyField === "PEXELS_API_KEY") {
+                            input_field_changed(
+                              e.target.value,
+                              "pexels_api_key"
+                            );
+                          } else if (
+                            provider.apiKeyField === "PIXABAY_API_KEY"
+                          ) {
+                            input_field_changed(
+                              e.target.value,
+                              "pixabay_api_key"
+                            );
+                          }
+                        }}
+                      />
+                    </div>
+                    <p className="mt-2 text-sm text-gray-500 flex items-center gap-2">
+                      <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
+                      API key for {provider.title} image generation
+                    </p>
+                  </div>
+                );
+              })()}
+
+            {/* Save Button */}
+            <button
+              onClick={handleSaveConfig}
+              disabled={
+                isLoading ||
+                (llmConfig.LLM === "ollama" && !llmConfig.OLLAMA_MODEL) ||
+                (llmConfig.LLM === "custom" && !llmConfig.CUSTOM_MODEL)
+              }
+              className={`mt-8 w-full font-semibold py-3 px-4 rounded-lg transition-all duration-500 ${
+                isLoading ||
+                (llmConfig.LLM === "ollama" && !llmConfig.OLLAMA_MODEL) ||
+                (llmConfig.LLM === "custom" && !llmConfig.CUSTOM_MODEL)
+                  ? "bg-gray-400 cursor-not-allowed"
+                  : "bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 focus:ring-4 focus:ring-blue-200"
+              } text-white`}
+            >
+              {isLoading ? (
+                <div className="flex items-center justify-center gap-2">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  {(llmConfig.LLM === "ollama" &&
+                    downloadingModel.downloaded) ||
+                  0 > 0
+                    ? `Downloading Model (${(
+                        ((downloadingModel.downloaded || 0) /
+                          (downloadingModel.size || 1)) *
+                        100
+                      ).toFixed(0)}%)`
+                    : "Saving Configuration..."}
+                </div>
+              ) : (llmConfig.LLM === "ollama" && !llmConfig.OLLAMA_MODEL) ||
+                (llmConfig.LLM === "custom" && !llmConfig.CUSTOM_MODEL) ? (
+                "Please Select a Model"
+              ) : (
+                "Save Configuration"
+              )}
+            </button>
+
+            {llmConfig.LLM === "ollama" &&
+              downloadingModel.status &&
+              downloadingModel.status !== "pulled" && (
+                <div className="mt-3 text-sm bg-green-100 rounded-lg p-2 font-semibold capitalize text-center text-gray-600">
+                  {downloadingModel.status}
+                </div>
+              )}
+          </div>
         </div>
-    );
+      </Wrapper>
+    </div>
+  );
 };
 
 export default SettingsPage;

--- a/servers/nextjs/components/Home.tsx
+++ b/servers/nextjs/components/Home.tsx
@@ -2,864 +2,1142 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "@/hooks/use-toast";
-import { Info, ExternalLink, PlayCircle, Loader2, Check, ChevronsUpDown } from "lucide-react";
+import {
+  Info,
+  ExternalLink,
+  PlayCircle,
+  Loader2,
+  Check,
+  ChevronsUpDown,
+} from "lucide-react";
 import Link from "next/link";
 import {
-    Accordion,
-    AccordionContent,
-    AccordionItem,
-    AccordionTrigger,
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
 } from "@/components/ui/accordion";
 import { useSelector } from "react-redux";
 import { RootState } from "@/store/store";
 import { handleSaveLLMConfig } from "@/utils/storeHelpers";
-import { Select, SelectContent, SelectItem, SelectTrigger } from "./ui/select";
 import { Button } from "./ui/button";
 import {
-    Command,
-    CommandEmpty,
-    CommandGroup,
-    CommandInput,
-    CommandItem,
-    CommandList,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
 } from "./ui/command";
-import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from "./ui/popover";
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { cn } from "@/lib/utils";
 import { Switch } from "./ui/switch";
 import { setLLMConfig } from "@/store/slices/userConfig";
 
 interface ModelOption {
-    value: string;
-    label: string;
-    description?: string;
-    icon?: string;
-    size: string;
+  value: string;
+  label: string;
+  description?: string;
+  icon?: string;
+  size: string;
+}
+
+interface ImageProviderOption {
+  value: string;
+  label: string;
+  description?: string;
+  icon?: string;
+  requiresApiKey?: boolean;
+  apiKeyField?: keyof LLMConfig;
 }
 
 interface ProviderConfig {
-    textModels: ModelOption[];
-    imageModels: ModelOption[];
-    apiGuide: {
-        title: string;
-        steps: string[];
-        videoUrl?: string;
-        docsUrl: string;
-    };
+  textModels: ModelOption[];
+  imageModels: ModelOption[];
+  apiGuide: {
+    title: string;
+    steps: string[];
+    videoUrl?: string;
+    docsUrl: string;
+  };
 }
 
+const IMAGE_PROVIDERS: Record<string, ImageProviderOption> = {
+  pexels: {
+    value: "pexels",
+    label: "Pexels",
+    description: "Free stock photo and video platform",
+    icon: "/icons/pexels.png",
+    requiresApiKey: true,
+    apiKeyField: "PEXELS_API_KEY",
+  },
+  pixabay: {
+    value: "pixabay",
+    label: "Pixabay",
+    description: "Free images and videos",
+    icon: "/icons/pixabay.png",
+    requiresApiKey: true,
+    apiKeyField: "PIXABAY_API_KEY",
+  },
+  "dall-e-3": {
+    value: "dall-e-3",
+    label: "DALL-E 3",
+    description: "OpenAI's latest image generation model",
+    icon: "/icons/dall-e.png",
+    requiresApiKey: true,
+    apiKeyField: "OPENAI_API_KEY",
+  },
+  imagen: {
+    value: "imagen",
+    label: "Imagen",
+    description: "Google's primary image generation model",
+    icon: "/icons/google.png",
+    requiresApiKey: true,
+    apiKeyField: "GOOGLE_API_KEY",
+  },
+};
+
 const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
-    openai: {
-        textModels: [
-            {
-                value: "gpt-4",
-                label: "GPT-4",
-                description: "Most capable model, best for complex tasks",
-                icon: "/icons/openai.png",
-                size: "8GB",
-            },
-        ],
-        imageModels: [
-            {
-                value: "dall-e-3",
-                label: "DALL-E 3",
-                description: "Latest version with highest quality",
-                icon: "/icons/dall-e.png",
-                size: "8GB",
-            },
-        ],
-        apiGuide: {
-            title: "How to get your OpenAI API Key",
-            steps: [
-                "Go to platform.openai.com and sign in or create an account",
-                'Click on your profile icon and select "View API keys"',
-                'Click "Create new secret key" and give it a name',
-                "Copy your API key immediately (you won't be able to see it again)",
-                "Make sure you have sufficient credits in your account",
-            ],
-            videoUrl: "https://www.youtube.com/watch?v=OB99E7Y1cMA",
-            docsUrl: "https://platform.openai.com/docs/api-reference/authentication",
-        },
+  openai: {
+    textModels: [
+      {
+        value: "gpt-4",
+        label: "GPT-4",
+        description: "Most capable model, best for complex tasks",
+        icon: "/icons/openai.png",
+        size: "8GB",
+      },
+    ],
+    imageModels: [
+      {
+        value: "dall-e-3",
+        label: "DALL-E 3",
+        description: "Latest version with highest quality",
+        icon: "/icons/dall-e.png",
+        size: "8GB",
+      },
+    ],
+    apiGuide: {
+      title: "How to get your OpenAI API Key",
+      steps: [
+        "Go to platform.openai.com and sign in or create an account",
+        'Click on your profile icon and select "View API keys"',
+        'Click "Create new secret key" and give it a name',
+        "Copy your API key immediately (you won't be able to see it again)",
+        "Make sure you have sufficient credits in your account",
+      ],
+      videoUrl: "https://www.youtube.com/watch?v=OB99E7Y1cMA",
+      docsUrl: "https://platform.openai.com/docs/api-reference/authentication",
     },
-    google: {
-        textModels: [
-            {
-                value: "gemini-pro",
-                label: "Gemini Pro",
-                description: "Balanced model for most tasks",
-                icon: "/icons/google.png",
-                size: "8GB",
-            },
-        ],
-        imageModels: [
-            {
-                value: "imagen",
-                label: "Imagen",
-                description: "Google's primary image generation model",
-                icon: "/icons/google.png",
-                size: "8GB",
-            },
-        ],
-        apiGuide: {
-            title: "How to get your Google AI Studio API Key",
-            steps: [
-                "Visit aistudio.google.com",
-                'Click on "Get API key" in the top navigation',
-                'Click "Create API key" on the next page',
-                'Choose either "Create API Key in new Project" or select an existing project',
-                "Copy your API key - you're ready to go!",
-            ],
-            videoUrl: "https://www.youtube.com/watch?v=o8iyrtQyrZM&t=66s",
-            docsUrl: "https://aistudio.google.com/app/apikey",
-        },
+  },
+  google: {
+    textModels: [
+      {
+        value: "gemini-pro",
+        label: "Gemini Pro",
+        description: "Balanced model for most tasks",
+        icon: "/icons/google.png",
+        size: "8GB",
+      },
+    ],
+    imageModels: [
+      {
+        value: "imagen",
+        label: "Imagen",
+        description: "Google's primary image generation model",
+        icon: "/icons/google.png",
+        size: "8GB",
+      },
+    ],
+    apiGuide: {
+      title: "How to get your Google AI Studio API Key",
+      steps: [
+        "Visit aistudio.google.com",
+        'Click on "Get API key" in the top navigation',
+        'Click "Create API key" on the next page',
+        'Choose either "Create API Key in new Project" or select an existing project',
+        "Copy your API key - you're ready to go!",
+      ],
+      videoUrl: "https://www.youtube.com/watch?v=o8iyrtQyrZM&t=66s",
+      docsUrl: "https://aistudio.google.com/app/apikey",
     },
-    ollama: {
-        textModels: [],
-        imageModels: [
-            {
-                value: "pexels",
-                label: "Pexels",
-                description: "Pexels is a free stock photo and video platform that allows you to download high-quality images and videos for free.",
-                icon: "/icons/pexels.png",
-                size: "8GB",
-            },
-        ],
-        apiGuide: {
-            title: "How to get your Pexels API Key",
-            steps: [
-                "Visit pexels.com",
-                'Click on "Get API key" in the top navigation',
-                "Copy your API key - you're ready to go!",
-            ],
-            videoUrl: "https://www.youtube.com/watch?v=o8iyrtQyrZM&t=66s",
-            docsUrl: "https://www.pexels.com/api/documentation/",
-        },
+  },
+  ollama: {
+    textModels: [],
+    imageModels: [
+      {
+        value: "pexels",
+        label: "Pexels",
+        description:
+          "Pexels is a free stock photo and video platform that allows you to download high-quality images and videos for free.",
+        icon: "/icons/pexels.png",
+        size: "8GB",
+      },
+    ],
+    apiGuide: {
+      title: "How to get your Pexels API Key",
+      steps: [
+        "Visit pexels.com",
+        'Click on "Get API key" in the top navigation',
+        "Copy your API key - you're ready to go!",
+      ],
+      videoUrl: "https://www.youtube.com/watch?v=o8iyrtQyrZM&t=66s",
+      docsUrl: "https://www.pexels.com/api/documentation/",
     },
-    custom: {
-        textModels: [],
-        imageModels: [
-            {
-                value: "pexels",
-                label: "Pexels",
-                description: "Pexels is a free stock photo and video platform that allows you to download high-quality images and videos for free.",
-                icon: "/icons/pexels.png",
-                size: "8GB",
-            },
-        ],
-        apiGuide: {
-            title: "How to get your Pexels API Key",
-            steps: [
-                "Visit pexels.com",
-                'Click on "Get API key" in the top navigation',
-                "Copy your API key - you're ready to go!",
-            ],
-            videoUrl: "https://www.youtube.com/watch?v=o8iyrtQyrZM&t=66s",
-            docsUrl: "https://www.pexels.com/api/documentation/",
-        },
+  },
+  custom: {
+    textModels: [],
+    imageModels: [
+      {
+        value: "pexels",
+        label: "Pexels",
+        description:
+          "Pexels is a free stock photo and video platform that allows you to download high-quality images and videos for free.",
+        icon: "/icons/pexels.png",
+        size: "8GB",
+      },
+    ],
+    apiGuide: {
+      title: "How to get your Pexels API Key",
+      steps: [
+        "Visit pexels.com",
+        'Click on "Get API key" in the top navigation',
+        "Copy your API key - you're ready to go!",
+      ],
+      videoUrl: "https://www.youtube.com/watch?v=o8iyrtQyrZM&t=66s",
+      docsUrl: "https://www.pexels.com/api/documentation/",
     },
+  },
 };
 
 export default function Home() {
-    const router = useRouter();
-    const config = useSelector((state: RootState) => state.userConfig);
-    const [llmConfig, setLlmConfig] = useState(config.llm_config);
-    const [ollamaModels, setOllamaModels] = useState<{
-        label: string;
-        value: string;
-        description: string;
-        size: string;
-        icon: string;
-    }[]>([]);
-    const [customModels, setCustomModels] = useState<string[]>([]);
-    const [downloadingModel, setDownloadingModel] = useState({
-        name: '',
-        size: null,
-        downloaded: null,
-        status: '',
-        done: false,
+  const router = useRouter();
+  const [openImageProviderSelect, setOpenImageProviderSelect] = useState(false);
+  const config = useSelector((state: RootState) => state.userConfig);
+  const [llmConfig, setLlmConfig] = useState({...config.llm_config,
+    IMAGE_PROVIDER: "dall-e-3",
+  });
+  const [ollamaModels, setOllamaModels] = useState<
+    {
+      label: string;
+      value: string;
+      description: string;
+      size: string;
+      icon: string;
+    }[]
+  >([]);
+  const [customModels, setCustomModels] = useState<string[]>([]);
+  const [downloadingModel, setDownloadingModel] = useState({
+    name: "",
+    size: null,
+    downloaded: null,
+    status: "",
+    done: false,
+  });
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [openModelSelect, setOpenModelSelect] = useState(false);
+  const [useCustomOllamaUrl, setUseCustomOllamaUrl] = useState<boolean>(
+    llmConfig.USE_CUSTOM_URL || false
+  );
+  const [customModelsLoading, setCustomModelsLoading] =
+    useState<boolean>(false);
+  const [customModelsChecked, setCustomModelsChecked] =
+    useState<boolean>(false);
+
+  const canChangeKeys = config.can_change_keys;
+
+  const input_field_changed = (new_value: string, field: string) => {
+    if (field === "openai_api_key") {
+      setLlmConfig({ ...llmConfig, OPENAI_API_KEY: new_value });
+    } else if (field === "google_api_key") {
+      setLlmConfig({ ...llmConfig, GOOGLE_API_KEY: new_value });
+    } else if (field === "ollama_url") {
+      setLlmConfig({ ...llmConfig, OLLAMA_URL: new_value });
+    } else if (field === "ollama_model") {
+      setLlmConfig({ ...llmConfig, OLLAMA_MODEL: new_value });
+    } else if (field === "custom_llm_url") {
+      setLlmConfig({ ...llmConfig, CUSTOM_LLM_URL: new_value });
+    } else if (field === "custom_llm_api_key") {
+      setLlmConfig({ ...llmConfig, CUSTOM_LLM_API_KEY: new_value });
+    } else if (field === "custom_model") {
+      setLlmConfig({ ...llmConfig, CUSTOM_MODEL: new_value });
+    } else if (field === "pexels_api_key") {
+      setLlmConfig({ ...llmConfig, PEXELS_API_KEY: new_value });
+    } else if (field === "pixabay_api_key") {
+      setLlmConfig({ ...llmConfig, PIXABAY_API_KEY: new_value });
+    }
+  };
+
+  const handleSaveConfig = async () => {
+    try {
+      await handleSaveLLMConfig(llmConfig);
+      if (llmConfig.LLM === "ollama") {
+        setIsLoading(true);
+        await pullOllamaModels();
+      }
+      toast({
+        title: "Success",
+        description: "Configuration saved successfully",
+      });
+      setIsLoading(false);
+      router.push("/upload");
+    } catch (error) {
+      console.error("Error:", error);
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to save configuration",
+        variant: "destructive",
+      });
+      setIsLoading(false);
+    }
+  };
+
+  const fetchOllamaModelsWithConfig = async (config: any) => {
+    try {
+      const response = await fetch("/api/v1/ppt/ollama/list-supported-models");
+      const data = await response.json();
+      setOllamaModels(data.models || []);
+
+      // Check if currently selected model is still available
+      if (config.OLLAMA_MODEL && data.models && data.models.length > 0) {
+        const isModelAvailable = data.models.some(
+          (model: any) => model.value === config.OLLAMA_MODEL
+        );
+        if (!isModelAvailable) {
+          setLlmConfig({ ...config, OLLAMA_MODEL: "" });
+        }
+      }
+    } catch (error) {
+      console.error("Error fetching ollama models:", error);
+      setOllamaModels([]); // Ensure we always set an empty array on error
+    }
+  };
+
+  const changeProvider = (provider: string) => {
+    const newConfig = { ...llmConfig, LLM: provider };
+
+    // Auto Select appropriate provider based on the text models
+    if (provider === "openai") {
+      newConfig.IMAGE_PROVIDER = "dall-e-3";
+    } else if (provider === "google") {
+      newConfig.IMAGE_PROVIDER = "imagen";
+    } else {
+      newConfig.IMAGE_PROVIDER = "pexels"; // default for ollama and custom
+    }
+
+    setLlmConfig(newConfig);
+    if (provider === "ollama") {
+      // Use the new config to avoid stale state issues
+      fetchOllamaModelsWithConfig(newConfig);
+    }
+  };
+
+  const resetDownloadingModel = () => {
+    setDownloadingModel({
+      name: "",
+      size: null,
+      downloaded: null,
+      status: "",
+      done: false,
     });
-    const [isLoading, setIsLoading] = useState<boolean>(false);
-    const [openModelSelect, setOpenModelSelect] = useState(false);
-    const [useCustomOllamaUrl, setUseCustomOllamaUrl] = useState<boolean>(llmConfig.USE_CUSTOM_URL || false);
-    const [customModelsLoading, setCustomModelsLoading] = useState<boolean>(false);
-    const [customModelsChecked, setCustomModelsChecked] = useState<boolean>(false);
+  };
 
-    const canChangeKeys = config.can_change_keys;
-
-    const input_field_changed = (new_value: string, field: string) => {
-        if (field === 'openai_api_key') {
-            setLlmConfig({ ...llmConfig, OPENAI_API_KEY: new_value });
-        } else if (field === 'google_api_key') {
-            setLlmConfig({ ...llmConfig, GOOGLE_API_KEY: new_value });
-        } else if (field === 'ollama_url') {
-            setLlmConfig({ ...llmConfig, OLLAMA_URL: new_value });
-        } else if (field === 'ollama_model') {
-            setLlmConfig({ ...llmConfig, OLLAMA_MODEL: new_value });
-        } else if (field === 'custom_llm_url') {
-            setLlmConfig({ ...llmConfig, CUSTOM_LLM_URL: new_value });
-        } else if (field === 'custom_llm_api_key') {
-            setLlmConfig({ ...llmConfig, CUSTOM_LLM_API_KEY: new_value });
-        } else if (field === 'custom_model') {
-            setLlmConfig({ ...llmConfig, CUSTOM_MODEL: new_value });
-        } else if (field === 'pexels_api_key') {
-            setLlmConfig({ ...llmConfig, PEXELS_API_KEY: new_value });
-        }
-    }
-
-    const handleSaveConfig = async () => {
+  const pullOllamaModels = async (): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      const interval = setInterval(async () => {
         try {
-            await handleSaveLLMConfig(llmConfig);
-            if (llmConfig.LLM === 'ollama') {
-                setIsLoading(true);
-                await pullOllamaModels();
-            }
-            toast({
-                title: 'Success',
-                description: 'Configuration saved successfully',
-            });
-            setIsLoading(false);
-            router.push("/upload");
-        } catch (error) {
-            console.error('Error:', error);
-            toast({
-                title: 'Error',
-                description: error instanceof Error ? error.message : 'Failed to save configuration',
-                variant: 'destructive',
-            });
-            setIsLoading(false);
-        }
-    };
-
-    const fetchOllamaModelsWithConfig = async (config: any) => {
-        try {
-            const response = await fetch('/api/v1/ppt/ollama/list-supported-models');
+          const response = await fetch(
+            `/api/v1/ppt/ollama/pull-model?name=${llmConfig.OLLAMA_MODEL}`
+          );
+          if (response.status === 200) {
             const data = await response.json();
-            setOllamaModels(data.models);
-
-            // Check if currently selected model is still available
-            if (config.OLLAMA_MODEL && data.models.length > 0) {
-                const isModelAvailable = data.models.some((model: any) => model.value === config.OLLAMA_MODEL);
-                if (!isModelAvailable) {
-                    setLlmConfig({ ...config, OLLAMA_MODEL: '' });
-                }
+            if (data.done && data.status !== "error") {
+              clearInterval(interval);
+              setDownloadingModel(data);
+              resolve();
+            } else if (data.status === "error") {
+              clearInterval(interval);
+              resetDownloadingModel();
+              reject(new Error("Error occurred while pulling model"));
+            } else {
+              setDownloadingModel(data);
             }
-        } catch (error) {
-            console.error('Error fetching ollama models:', error);
-        }
-    }
-
-    const changeProvider = (provider: string) => {
-        const newConfig = { ...llmConfig, LLM: provider };
-        setLlmConfig(newConfig);
-        if (provider === 'ollama') {
-            // Use the new config to avoid stale state issues
-            fetchOllamaModelsWithConfig(newConfig);
-        }
-    }
-
-    const resetDownloadingModel = () => {
-        setDownloadingModel({
-            name: '',
-            size: null,
-            downloaded: null,
-            status: '',
-            done: false,
-        });
-    }
-
-    const pullOllamaModels = async (): Promise<void> => {
-        return new Promise((resolve, reject) => {
-            const interval = setInterval(async () => {
-                try {
-                    const response = await fetch(`/api/v1/ppt/ollama/pull-model?name=${llmConfig.OLLAMA_MODEL}`);
-                    if (response.status === 200) {
-                        const data = await response.json();
-                        if (data.done && data.status !== 'error') {
-                            clearInterval(interval);
-                            setDownloadingModel(data);
-                            resolve();
-                        } else if (data.status === 'error') {
-                            clearInterval(interval);
-                            resetDownloadingModel();
-                            reject(new Error('Error occurred while pulling model'));
-                        } else {
-                            setDownloadingModel(data);
-                        }
-                    } else {
-                        clearInterval(interval);
-                        resetDownloadingModel();
-                        if (response.status === 403) {
-                            reject(new Error('Request to Ollama Not Authorized'));
-                        }
-                        reject(new Error('Error occurred while pulling model'));
-                    }
-                } catch (error) {
-                    clearInterval(interval);
-                    resetDownloadingModel();
-                    reject(error);
-                }
-            }, 1000);
-        });
-    }
-
-    const fetchOllamaModels = async () => {
-        await fetchOllamaModelsWithConfig(llmConfig);
-    }
-
-    const fetchCustomModels = async () => {
-        try {
-            setCustomModelsLoading(true);
-            const response = await fetch('/api/v1/ppt/models/list/custom', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    url: llmConfig.CUSTOM_LLM_URL || '',
-                    api_key: llmConfig.CUSTOM_LLM_API_KEY || ''
-                })
-            });
-            
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
+          } else {
+            clearInterval(interval);
+            resetDownloadingModel();
+            if (response.status === 403) {
+              reject(new Error("Request to Ollama Not Authorized"));
             }
-            
-            const data = await response.json();
-            setCustomModels(data);
-            // Only set customModelsChecked to true if the API call succeeds
-            setCustomModelsChecked(true);
+            reject(new Error("Error occurred while pulling model"));
+          }
         } catch (error) {
-            console.error('Error fetching custom models:', error);
-            // Don't set customModelsChecked to true on error, so the button remains visible
-            setCustomModels([]);
-            toast({
-                title: 'Error',
-                description: 'Failed to fetch available models. Please check your URL and API key.',
-                variant: 'destructive',
-            });
-        } finally {
-            setCustomModelsLoading(false);
+          clearInterval(interval);
+          resetDownloadingModel();
+          reject(error);
         }
+      }, 1000);
+    });
+  };
+
+  const fetchOllamaModels = async () => {
+    await fetchOllamaModelsWithConfig(llmConfig);
+  };
+
+  const fetchCustomModels = async () => {
+    try {
+      setCustomModelsLoading(true);
+      const response = await fetch("/api/v1/ppt/models/list/custom", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          url: llmConfig.CUSTOM_LLM_URL || "",
+          api_key: llmConfig.CUSTOM_LLM_API_KEY || "",
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      setCustomModels(data);
+      // Only set customModelsChecked to true if the API call succeeds
+      setCustomModelsChecked(true);
+    } catch (error) {
+      console.error("Error fetching custom models:", error);
+      // Don't set customModelsChecked to true on error, so the button remains visible
+      setCustomModels([]);
+      toast({
+        title: "Error",
+        description:
+          "Failed to fetch available models. Please check your URL and API key.",
+        variant: "destructive",
+      });
+    } finally {
+      setCustomModelsLoading(false);
     }
+  };
 
-    const setOllamaConfig = () => {
-        if (!useCustomOllamaUrl) {
-            setLlmConfig({ ...llmConfig, OLLAMA_URL: 'http://localhost:11434', USE_CUSTOM_URL: false });
-        } else {
-            setLlmConfig({ ...llmConfig, USE_CUSTOM_URL: true });
-        }
+  const setOllamaConfig = () => {
+    if (!useCustomOllamaUrl) {
+      setLlmConfig({
+        ...llmConfig,
+        OLLAMA_URL: "http://localhost:11434",
+        USE_CUSTOM_URL: false,
+      });
+    } else {
+      setLlmConfig({ ...llmConfig, USE_CUSTOM_URL: true });
     }
+  };
 
-    useEffect(() => {
-        if (!canChangeKeys) {
-            router.push("/upload");
-        }
-        if (llmConfig.LLM === 'ollama') {
-            fetchOllamaModels();
-        }
-    }, []);
-
-    useEffect(() => {
-        setOllamaConfig();
-    }, [useCustomOllamaUrl]);
-
-    // Reset custom models when URL or API key changes
-    useEffect(() => {
-        if (llmConfig.LLM === 'custom') {
-            setCustomModels([]);
-            setCustomModelsChecked(false);
-            setLlmConfig({ ...llmConfig, CUSTOM_MODEL: '' });
-        }
-    }, [llmConfig.CUSTOM_LLM_URL, llmConfig.CUSTOM_LLM_API_KEY]);
-
+  useEffect(() => {
     if (!canChangeKeys) {
-        return null;
+      router.push("/upload");
     }
+    if (llmConfig.LLM === "ollama") {
+      fetchOllamaModels();
+    }
+  }, []);
 
-    return (
-        <div className="min-h-screen bg-gradient-to-b font-instrument_sans from-gray-50 to-white">
-            <main className="container mx-auto px-4 py-12 max-w-3xl">
-                {/* Branding Header */}
-                <div className="text-center mb-12">
-                    <div className="flex items-center justify-center gap-3 mb-4">
-                        <img src="/Logo.png" alt="Presenton Logo" className="" />
-                    </div>
-                    <p className="text-gray-600 text-lg">
-                        Open-source AI presentation generator
-                    </p>
-                </div>
+  useEffect(() => {
+    setOllamaConfig();
+  }, [useCustomOllamaUrl]);
 
-                {/* Main Configuration Card */}
-                <div className="bg-white rounded-xl shadow-lg border border-gray-100 p-8">
-                    {/* Provider Selection */}
-                    <div className="mb-8">
-                        <label className="block text-sm font-medium text-gray-700 mb-3">
-                            Select AI Provider
-                        </label>
-                        <div className="grid grid-cols-2 gap-4">
-                            {Object.keys(PROVIDER_CONFIGS).map((provider) => (
-                                <button
-                                    key={provider}
-                                    onClick={() => changeProvider(provider)}
-                                    className={`relative p-4 rounded-lg border-2 transition-all duration-200 ${llmConfig.LLM === provider
-                                        ? "border-blue-500 bg-blue-50"
-                                        : "border-gray-200 hover:border-blue-200 hover:bg-gray-50"
-                                        }`}
-                                >
-                                    <div className="flex items-center justify-center gap-3">
-                                        <span
-                                            className={`font-medium text-center ${llmConfig.LLM === provider
-                                                ? "text-blue-700"
-                                                : "text-gray-700"
-                                                }`}
-                                        >
-                                            {provider === 'openai' ? 'OpenAI' : provider.charAt(0).toUpperCase() + provider.slice(1)}
-                                        </span>
-                                    </div>
-                                </button>
-                            ))}
-                        </div>
-                    </div>
+  // Reset custom models when URL or API key changes
+  useEffect(() => {
+    if (llmConfig.LLM === "custom") {
+      setCustomModels([]);
+      setCustomModelsChecked(false);
+      setLlmConfig({ ...llmConfig, CUSTOM_MODEL: "" });
+    }
+  }, [llmConfig.CUSTOM_LLM_URL, llmConfig.CUSTOM_LLM_API_KEY]);
 
-                    {/* API Key Input */}
-                    {llmConfig.LLM !== 'ollama' && llmConfig.LLM !== 'custom' && <div className="mb-8">
-                        <label className="block text-sm font-medium text-gray-700 mb-2">
-                            {llmConfig.LLM!.charAt(0).toUpperCase() +
-                                llmConfig.LLM!.slice(1)}{" "}
-                            API Key
-                        </label>
-                        <div className="relative">
-                            <input
-                                type="text"
-                                value={llmConfig.LLM === 'openai' ? llmConfig.OPENAI_API_KEY || '' : llmConfig.GOOGLE_API_KEY || ''}
-                                onChange={(e) => input_field_changed(e.target.value, llmConfig.LLM === 'openai' ? 'openai_api_key' : 'google_api_key')}
-                                className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                placeholder="Enter your API key"
-                            />
-                        </div>
-                        <p className="mt-2 text-sm text-gray-500 flex items-center gap-2">
-                            <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
-                            Your API key will be stored locally and never shared
-                        </p>
-                    </div>}
-                    {
-                        llmConfig.LLM === 'ollama' && (<div>
-                            <div className="mb-8">
-                                <label className="block text-sm font-medium text-gray-700 mb-3">
-                                    Choose a supported model
-                                </label>
-                                <div className="w-full">
-                                    {ollamaModels.length > 0 ? (
-                                        <Popover open={openModelSelect} onOpenChange={setOpenModelSelect}>
-                                            <PopoverTrigger asChild>
-                                                <Button
-                                                    variant="outline"
-                                                    role="combobox"
-                                                    aria-expanded={openModelSelect}
-                                                    className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
-                                                >
-                                                    <div className="flex gap-3 items-center">
-                                                        {llmConfig.OLLAMA_MODEL && (
-                                                            <div className="w-6 h-6 rounded-lg flex items-center justify-center flex-shrink-0">
-                                                                <img
-                                                                    src={ollamaModels.find(m => m.value === llmConfig.OLLAMA_MODEL)?.icon}
-                                                                    alt={`${llmConfig.OLLAMA_MODEL} icon`}
-                                                                    className="rounded-sm"
-                                                                />
-                                                            </div>
-                                                        )}
-                                                        <span className="text-sm font-medium text-gray-900">
-                                                            {llmConfig.OLLAMA_MODEL ? (
-                                                                ollamaModels.find(m => m.value === llmConfig.OLLAMA_MODEL)?.label || llmConfig.OLLAMA_MODEL
-                                                            ) : (
-                                                                'Select a model'
-                                                            )}
-                                                        </span>
-                                                        {llmConfig.OLLAMA_MODEL && (
-                                                            <span className="text-xs text-gray-500 bg-gray-100 rounded-full px-2 py-1">
-                                                                {ollamaModels.find(m => m.value === llmConfig.OLLAMA_MODEL)?.size}
-                                                            </span>
-                                                        )}
-                                                    </div>
-                                                    <ChevronsUpDown className="w-4 h-4 text-gray-500" />
-                                                </Button>
-                                            </PopoverTrigger>
-                                            <PopoverContent className="p-0" align="start" style={{ width: 'var(--radix-popover-trigger-width)' }}>
-                                                <Command>
-                                                    <CommandInput placeholder="Search model..." />
-                                                    <CommandList>
-                                                        <CommandEmpty>No model found.</CommandEmpty>
-                                                        <CommandGroup>
-                                                            {ollamaModels.map((model, index) => (
-                                                                <CommandItem
-                                                                    key={index}
-                                                                    value={model.value}
-                                                                    onSelect={(value) => {
-                                                                        input_field_changed(value, 'ollama_model');
-                                                                        setOpenModelSelect(false);
-                                                                    }}
-                                                                >
-                                                                    <Check
-                                                                        className={cn(
-                                                                            "mr-2 h-4 w-4",
-                                                                            llmConfig.OLLAMA_MODEL === model.value ? "opacity-100" : "opacity-0"
-                                                                        )}
-                                                                    />
-                                                                    <div className="flex gap-3 items-center">
-                                                                        <div className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0">
-                                                                            <img
-                                                                                src={model.icon}
-                                                                                alt={`${model.label} icon`}
-                                                                                className="rounded-sm"
-                                                                            />
-                                                                        </div>
-                                                                        <div className="flex flex-col space-y-1 flex-1">
-                                                                            <div className="flex items-center justify-between gap-2">
-                                                                                <span className="text-sm font-medium text-gray-900 capitalize">
-                                                                                    {model.label}
-                                                                                </span>
-                                                                                <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded-full">
-                                                                                    {model.size}
-                                                                                </span>
-                                                                            </div>
-                                                                            <span className="text-xs text-gray-600 leading-relaxed">
-                                                                                {model.description}
-                                                                            </span>
-                                                                        </div>
-                                                                    </div>
-                                                                </CommandItem>
-                                                            ))}
-                                                        </CommandGroup>
-                                                    </CommandList>
-                                                </Command>
-                                            </PopoverContent>
-                                        </Popover>
-                                    ) : (
-                                        <div className="w-full border border-gray-300 rounded-lg p-4">
-                                            <div className="flex items-center space-x-3">
-                                                <div className="w-4 h-4 bg-gray-200 rounded-full animate-pulse"></div>
-                                                <div className="flex-1 space-y-2">
-                                                    <div className="h-4 bg-gray-200 rounded animate-pulse"></div>
-                                                    <div className="h-3 bg-gray-200 rounded w-3/4 animate-pulse"></div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                                {ollamaModels.length === 0 && (
-                                    <p className="mt-2 text-sm text-gray-500">
-                                        Loading available models...
-                                    </p>
-                                )}
-                            </div>
-                            <div className="mb-8">
-                                <div className="flex items-center justify-between mb-4 bg-green-50 p-2 rounded-sm">
-                                    <label className="text-sm font-medium text-gray-700">
-                                        Use custom Ollama URL
-                                    </label>
-                                    <Switch
-                                        checked={useCustomOllamaUrl}
-                                        onCheckedChange={setUseCustomOllamaUrl}
-                                    />
-                                </div>
-                                {useCustomOllamaUrl && (
-                                    <>
-                                        <div className="mb-4">
-                                            <label className="block text-sm font-medium text-gray-700 mb-2">
-                                                Ollama URL
-                                            </label>
-                                            <div className="relative">
-                                                <input
-                                                    type="text"
-                                                    required
-                                                    placeholder="Enter your Ollama URL"
-                                                    className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                                    value={llmConfig.OLLAMA_URL || ''}
-                                                    onChange={(e) => input_field_changed(e.target.value, 'ollama_url')}
-                                                />
-                                            </div>
-                                            <p className="mt-2 text-sm text-gray-500 flex items-center gap-2">
-                                                <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
-                                                Change this if you are using a custom Ollama instance
-                                            </p>
-                                        </div>
-                                    </>
-                                )}
-                            </div>
-                            <div className="mb-8">
-                                <label className="block text-sm font-medium text-gray-700 mb-2">
-                                    Pexels API Key (optional)
-                                </label>
-                                <div className="relative">
-                                    <input
-                                        type="text"
-                                        required
-                                        placeholder="Enter your Pexels API key"
-                                        className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                        value={llmConfig.PEXELS_API_KEY || ''}
-                                        onChange={(e) => input_field_changed(e.target.value, 'pexels_api_key')}
-                                    />
-                                </div>
-                                <p className="mt-2 text-sm text-gray-500 flex items-center gap-2">
-                                    <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
-                                    Provide a Pexels API key to generate presentation images
-                                </p>
-                            </div>
-                        </div>)
-                    }
-                    {
-                        llmConfig.LLM === 'custom' && (
-                            <>
-                                <div className="mb-4">
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        OpenAI Compatible URL
-                                    </label>
-                                    <div className="relative">
-                                        <input
-                                            type="text"
-                                            required
-                                            placeholder="Enter your URL"
-                                            className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                            value={llmConfig.CUSTOM_LLM_URL || ''}
-                                            onChange={(e) => input_field_changed(e.target.value, 'custom_llm_url')}
-                                        />
-                                    </div>
-                                </div>
-                                <div className="mb-4">
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        OpenAI Compatible API Key (optional)
-                                    </label>
-                                    <div className="relative">
-                                        <input
-                                            type="text"
-                                            required
-                                            placeholder="Enter your API Key"
-                                            className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                            value={llmConfig.CUSTOM_LLM_API_KEY || ''}
-                                            onChange={(e) => input_field_changed(e.target.value, 'custom_llm_api_key')}
-                                        />
-                                    </div>
-                                </div>
+  // Load default image provider based on LLM selection
+  // useEffect(() => {
+  //   if (llmConfig.LLM && !llmConfig.IMAGE_PROVIDER) {
+  //     let defaultImageProvider = "";
+  //     if (llmConfig.LLM === "openai") {
+  //       defaultImageProvider = "dall-e-3";
+  //     } else if (llmConfig.LLM === "google") {
+  //       defaultImageProvider = "imagen";
+  //     } else {
+  //       defaultImageProvider = "pexels"; // default for ollama and custom
+  //     }
 
-                                {/* Model selection dropdown - only show if models are available */}
-                                {customModelsChecked && customModels.length > 0 && (
-                                    <div className="mb-4">
-                                        <div className="mb-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-                                            <p className="text-sm text-amber-800">
-                                                <strong>Important:</strong> Only models with function calling capabilities (tool calls) or JSON schema support will work.
-                                            </p>
-                                        </div>
-                                        <label className="block text-sm font-medium text-gray-700 mb-2">
-                                            Select Model
-                                        </label>
-                                        <div className="w-full">
-                                            <Popover open={openModelSelect} onOpenChange={setOpenModelSelect}>
-                                                <PopoverTrigger asChild>
-                                                    <Button
-                                                        variant="outline"
-                                                        role="combobox"
-                                                        aria-expanded={openModelSelect}
-                                                        className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
-                                                    >
-                                                        <span className="text-sm font-medium text-gray-900">
-                                                            {llmConfig.CUSTOM_MODEL || 'Select a model'}
-                                                        </span>
-                                                        <ChevronsUpDown className="w-4 h-4 text-gray-500" />
-                                                    </Button>
-                                                </PopoverTrigger>
-                                                <PopoverContent className="p-0" align="start" style={{ width: 'var(--radix-popover-trigger-width)' }}>
-                                                    <Command>
-                                                        <CommandInput placeholder="Search model..." />
-                                                        <CommandList>
-                                                            <CommandEmpty>No model found.</CommandEmpty>
-                                                            <CommandGroup>
-                                                                {customModels.map((model, index) => (
-                                                                    <CommandItem
-                                                                        key={index}
-                                                                        value={model}
-                                                                        onSelect={(value) => {
-                                                                            input_field_changed(value, 'custom_model');
-                                                                            setOpenModelSelect(false);
-                                                                        }}
-                                                                    >
-                                                                        <Check
-                                                                            className={cn(
-                                                                                "mr-2 h-4 w-4",
-                                                                                llmConfig.CUSTOM_MODEL === model ? "opacity-100" : "opacity-0"
-                                                                            )}
-                                                                        />
-                                                                        <span className="text-sm font-medium text-gray-900">
-                                                                            {model}
-                                                                        </span>
-                                                                    </CommandItem>
-                                                                ))}
-                                                            </CommandGroup>
-                                                        </CommandList>
-                                                    </Command>
-                                                </PopoverContent>
-                                            </Popover>
-                                        </div>
-                                    </div>
-                                )}
+  //     setLlmConfig((prev) => ({
+  //       ...prev,
+  //       IMAGE_PROVIDER: defaultImageProvider,
+  //     }));
+  //   }
+  // }, [llmConfig.LLM]);
 
-                                {/* Check for available models button - show when no models checked or no models found */}
-                                {(!customModelsChecked || (customModelsChecked && customModels.length === 0)) && (
-                                    <div className="mb-4">
-                                        <button
-                                            onClick={fetchCustomModels}
-                                            disabled={customModelsLoading || !llmConfig.CUSTOM_LLM_URL}
-                                            className={`w-full py-2.5 px-4 rounded-lg transition-all duration-200 border-2 ${customModelsLoading || !llmConfig.CUSTOM_LLM_URL
-                                                ? 'bg-gray-100 border-gray-300 cursor-not-allowed text-gray-500'
-                                                : 'bg-white border-blue-600 text-blue-600 hover:bg-blue-50 focus:ring-2 focus:ring-blue-500/20'
-                                                }`}
-                                        >
-                                            {customModelsLoading ? (
-                                                <div className="flex items-center justify-center gap-2">
-                                                    <Loader2 className="w-4 h-4 animate-spin" />
-                                                    Checking for models...
-                                                </div>
-                                            ) : (
-                                                'Check for available models'
-                                            )}
-                                        </button>
-                                    </div>
-                                )}
+  if (!canChangeKeys) {
+    return null;
+  }
 
-                                {/* Show message if no models found */}
-                                {customModelsChecked && customModels.length === 0 && (
-                                    <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-                                        <p className="text-sm text-yellow-800">
-                                            No models found. Please make sure models are available.
-                                        </p>
-                                    </div>
-                                )}
-
-                                <div className="mb-8">
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        Pexels API Key (optional)
-                                    </label>
-                                    <div className="relative">
-                                        <input
-                                            type="text"
-                                            required
-                                            placeholder="Enter your Pexels API key"
-                                            className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
-                                            value={llmConfig.PEXELS_API_KEY || ''}
-                                            onChange={(e) => input_field_changed(e.target.value, 'pexels_api_key')}
-                                        />
-                                    </div>
-                                    <p className="mt-2 text-sm text-gray-500 flex items-center gap-2">
-                                        <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
-                                        Provide a Pexels API key to generate presentation images
-                                    </p>
-                                </div>
-                            </>
-                        )
-                    }
-
-                    {/* Model Information */}
-                    <div className="mb-8 p-4 bg-blue-50 rounded-lg border border-blue-100">
-                        <div className="flex items-start gap-3">
-                            <Info className="w-5 h-5 text-blue-500 mt-0.5" />
-                            <div>
-                                <h3 className="text-sm font-medium text-blue-900 mb-1">
-                                    Selected Models
-                                </h3>
-                                <p className="text-sm text-blue-700">
-                                    Using {llmConfig.LLM === 'ollama' ? llmConfig.OLLAMA_MODEL ?? '_____' : llmConfig.LLM === 'custom' ? llmConfig.CUSTOM_MODEL ?? '_____' : PROVIDER_CONFIGS[llmConfig.LLM!].textModels[0].label} for text
-                                    generation and {PROVIDER_CONFIGS[llmConfig.LLM!].imageModels[0].label} for
-                                    images
-                                </p>
-                                <p className="text-sm text-blue-600 mt-2 opacity-75">
-                                    We've pre-selected the best models for optimal presentation
-                                    generation
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                    {/* API Guide Section */}
-                    <Accordion type="single" collapsible className="mb-8 bg-gray-50 rounded-lg border border-gray-200">
-                        <AccordionItem value="guide" className="border-none">
-                            <AccordionTrigger className="px-6 py-4 hover:no-underline">
-                                <div className="flex items-start gap-3">
-                                    <Info className="w-5 h-5 text-blue-600 mt-1" />
-                                    <h3 className="text-lg font-medium text-gray-900">
-                                        {PROVIDER_CONFIGS[llmConfig.LLM!].apiGuide.title}
-                                    </h3>
-                                </div>
-                            </AccordionTrigger>
-                            <AccordionContent className="px-6 pb-6">
-                                <div className="space-y-4">
-                                    <ol className="list-decimal list-inside space-y-2 text-gray-600">
-                                        {PROVIDER_CONFIGS[llmConfig.LLM!].apiGuide.steps.map((step, index) => (
-                                            <li key={index} className="text-sm">
-                                                {step}
-                                            </li>
-                                        ))}
-                                    </ol>
-
-                                    <div className="flex flex-col sm:flex-row gap-4 mt-6">
-                                        {PROVIDER_CONFIGS[llmConfig.LLM!].apiGuide.videoUrl && (
-                                            <Link
-                                                href={PROVIDER_CONFIGS[llmConfig.LLM!].apiGuide.videoUrl!}
-                                                target="_blank"
-                                                className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-700 transition-colors"
-                                            >
-                                                <PlayCircle className="w-4 h-4" />
-                                                Watch Video Tutorial
-                                                <ExternalLink className="w-3 h-3" />
-                                            </Link>
-                                        )}
-                                        <Link
-                                            href={PROVIDER_CONFIGS[llmConfig.LLM!].apiGuide.docsUrl}
-                                            target="_blank"
-                                            className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-700 transition-colors"
-                                        >
-                                            <span>Official Documentation</span>
-                                            <ExternalLink className="w-3 h-3" />
-                                        </Link>
-                                    </div>
-                                </div>
-                            </AccordionContent>
-                        </AccordionItem>
-                    </Accordion>
-
-                    {/* Save Button */}
-                    <button
-                        onClick={handleSaveConfig}
-                        disabled={isLoading || (llmConfig.LLM === 'ollama' && !llmConfig.OLLAMA_MODEL) || (llmConfig.LLM === 'custom' && !llmConfig.CUSTOM_MODEL)}
-                        className={`mt-8 w-full font-semibold py-3 px-4 rounded-lg transition-all duration-500 ${isLoading || (llmConfig.LLM === 'ollama' && !llmConfig.OLLAMA_MODEL) || (llmConfig.LLM === 'custom' && !llmConfig.CUSTOM_MODEL)
-                            ? 'bg-gray-400 cursor-not-allowed'
-                            : 'bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 focus:ring-4 focus:ring-blue-200'
-                            } text-white`}
-                    >
-                        {isLoading ? (
-                            <div className="flex items-center justify-center gap-2">
-                                <Loader2 className="w-4 h-4 animate-spin" />
-                                {llmConfig.LLM === 'ollama' && downloadingModel.downloaded || 0 > 0
-                                    ? `Downloading Model (${(((downloadingModel.downloaded || 0) / (downloadingModel.size || 1)) * 100).toFixed(0)}%)`
-                                    : 'Saving Configuration...'
-                                }
-                            </div>
-                        ) : (
-                            (llmConfig.LLM === 'ollama' && !llmConfig.OLLAMA_MODEL) || (llmConfig.LLM === 'custom' && !llmConfig.CUSTOM_MODEL)
-                                ? 'Please Select a Model'
-                                : 'Save Configuration'
-                        )}
-                    </button>
-
-                    {
-                        llmConfig.LLM === 'ollama' && downloadingModel.status && downloadingModel.status !== 'pulled' && (
-                            <div className="mt-3 text-sm bg-green-100 rounded-lg p-2 font-semibold capitalize text-center text-gray-600">
-                                {downloadingModel.status}
-                            </div>
-                        )
-                    }
-                </div>
-            </main>
+  return (
+    <div className="min-h-screen bg-gradient-to-b font-instrument_sans from-gray-50 to-white">
+      <main className="container mx-auto px-4 py-12 max-w-3xl">
+        {/* Branding Header */}
+        <div className="text-center mb-12">
+          <div className="flex items-center justify-center gap-3 mb-4">
+            <img src="/Logo.png" alt="Presenton Logo" className="" />
+          </div>
+          <p className="text-gray-600 text-lg">
+            Open-source AI presentation generator
+          </p>
         </div>
-    );
+
+        {/* Main Configuration Card */}
+        <div className="bg-white rounded-xl shadow-lg border border-gray-100 p-8">
+          {/* Provider Selection */}
+          <div className="mb-8">
+            <label className="block text-sm font-medium text-gray-700 mb-3">
+              Select AI Provider
+            </label>
+            <div className="grid grid-cols-2 gap-4">
+              {Object.keys(PROVIDER_CONFIGS).map((provider) => (
+                <button
+                  key={provider}
+                  onClick={() => changeProvider(provider)}
+                  className={`relative p-4 rounded-lg border-2 transition-all duration-200 ${
+                    llmConfig.LLM === provider
+                      ? "border-blue-500 bg-blue-50"
+                      : "border-gray-200 hover:border-blue-200 hover:bg-gray-50"
+                  }`}
+                >
+                  <div className="flex items-center justify-center gap-3">
+                    <span
+                      className={`font-medium text-center ${
+                        llmConfig.LLM === provider
+                          ? "text-blue-700"
+                          : "text-gray-700"
+                      }`}
+                    >
+                      {provider === "openai"
+                        ? "OpenAI"
+                        : provider.charAt(0).toUpperCase() + provider.slice(1)}
+                    </span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* API Key Input */}
+          {llmConfig.LLM !== "ollama" && llmConfig.LLM !== "custom" && (
+            <div className="mb-8">
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                {llmConfig.LLM!.charAt(0).toUpperCase() +
+                  llmConfig.LLM!.slice(1)}{" "}
+                API Key
+              </label>
+              <div className="relative">
+                <input
+                  type="text"
+                  value={
+                    llmConfig.LLM === "openai"
+                      ? llmConfig.OPENAI_API_KEY || ""
+                      : llmConfig.GOOGLE_API_KEY || ""
+                  }
+                  onChange={(e) =>
+                    input_field_changed(
+                      e.target.value,
+                      llmConfig.LLM === "openai"
+                        ? "openai_api_key"
+                        : "google_api_key"
+                    )
+                  }
+                  className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                  placeholder="Enter your API key"
+                />
+              </div>
+              <p className="mt-2 text-sm text-gray-500 flex items-center gap-2">
+                <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
+                Your API key will be stored locally and never shared
+              </p>
+            </div>
+          )}
+          {llmConfig.LLM === "ollama" && (
+            <div>
+              <div className="mb-8">
+                <label className="block text-sm font-medium text-gray-700 mb-3">
+                  Choose a supported model
+                </label>
+                <div className="w-full">
+                  {ollamaModels && ollamaModels.length > 0 ? (
+                    <Popover
+                      open={openModelSelect}
+                      onOpenChange={setOpenModelSelect}
+                    >
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          role="combobox"
+                          aria-expanded={openModelSelect}
+                          className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
+                        >
+                          <div className="flex gap-3 items-center">
+                            {llmConfig.OLLAMA_MODEL && (
+                              <div className="w-6 h-6 rounded-lg flex items-center justify-center flex-shrink-0">
+                                <img
+                                  src={
+                                    ollamaModels?.find(
+                                      (m) => m.value === llmConfig.OLLAMA_MODEL
+                                    )?.icon
+                                  }
+                                  alt={`${llmConfig.OLLAMA_MODEL} icon`}
+                                  className="rounded-sm"
+                                />
+                              </div>
+                            )}
+                            <span className="text-sm font-medium text-gray-900">
+                              {llmConfig.OLLAMA_MODEL
+                                ? ollamaModels?.find(
+                                    (m) => m.value === llmConfig.OLLAMA_MODEL
+                                  )?.label || llmConfig.OLLAMA_MODEL
+                                : "Select a model"}
+                            </span>
+                            {llmConfig.OLLAMA_MODEL && (
+                              <span className="text-xs text-gray-500 bg-gray-100 rounded-full px-2 py-1">
+                                {
+                                  ollamaModels?.find(
+                                    (m) => m.value === llmConfig.OLLAMA_MODEL
+                                  )?.size
+                                }
+                              </span>
+                            )}
+                          </div>
+                          <ChevronsUpDown className="w-4 h-4 text-gray-500" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        className="p-0"
+                        align="start"
+                        style={{ width: "var(--radix-popover-trigger-width)" }}
+                      >
+                        <Command>
+                          <CommandInput placeholder="Search model..." />
+                          <CommandList>
+                            <CommandEmpty>No model found.</CommandEmpty>
+                            <CommandGroup>
+                              {ollamaModels?.map((model, index) => (
+                                <CommandItem
+                                  key={index}
+                                  value={model.value}
+                                  onSelect={(value) => {
+                                    input_field_changed(value, "ollama_model");
+                                    setOpenModelSelect(false);
+                                  }}
+                                >
+                                  <Check
+                                    className={cn(
+                                      "mr-2 h-4 w-4",
+                                      llmConfig.OLLAMA_MODEL === model.value
+                                        ? "opacity-100"
+                                        : "opacity-0"
+                                    )}
+                                  />
+                                  <div className="flex gap-3 items-center">
+                                    <div className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0">
+                                      <img
+                                        src={model.icon}
+                                        alt={`${model.label} icon`}
+                                        className="rounded-sm"
+                                      />
+                                    </div>
+                                    <div className="flex flex-col space-y-1 flex-1">
+                                      <div className="flex items-center justify-between gap-2">
+                                        <span className="text-sm font-medium text-gray-900 capitalize">
+                                          {model.label}
+                                        </span>
+                                        <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded-full">
+                                          {model.size}
+                                        </span>
+                                      </div>
+                                      <span className="text-xs text-gray-600 leading-relaxed">
+                                        {model.description}
+                                      </span>
+                                    </div>
+                                  </div>
+                                </CommandItem>
+                              ))}
+                            </CommandGroup>
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
+                  ) : (
+                    <div className="w-full border border-gray-300 rounded-lg p-4">
+                      <div className="flex items-center space-x-3">
+                        <div className="w-4 h-4 bg-gray-200 rounded-full animate-pulse"></div>
+                        <div className="flex-1 space-y-2">
+                          <div className="h-4 bg-gray-200 rounded animate-pulse"></div>
+                          <div className="h-3 bg-gray-200 rounded w-3/4 animate-pulse"></div>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+                {(!ollamaModels || ollamaModels.length === 0) && (
+                  <p className="mt-2 text-sm text-gray-500">
+                    Loading available models...
+                  </p>
+                )}
+              </div>
+              <div className="mb-8">
+                <div className="flex items-center justify-between mb-4 bg-green-50 p-2 rounded-sm">
+                  <label className="text-sm font-medium text-gray-700">
+                    Use custom Ollama URL
+                  </label>
+                  <Switch
+                    checked={useCustomOllamaUrl}
+                    onCheckedChange={setUseCustomOllamaUrl}
+                  />
+                </div>
+                {useCustomOllamaUrl && (
+                  <>
+                    <div className="mb-4">
+                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                        Ollama URL
+                      </label>
+                      <div className="relative">
+                        <input
+                          type="text"
+                          required
+                          placeholder="Enter your Ollama URL"
+                          className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                          value={llmConfig.OLLAMA_URL || ""}
+                          onChange={(e) =>
+                            input_field_changed(e.target.value, "ollama_url")
+                          }
+                        />
+                      </div>
+                      <p className="mt-2 text-sm text-gray-500 flex items-center gap-2">
+                        <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
+                        Change this if you are using a custom Ollama instance
+                      </p>
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+          {llmConfig.LLM === "custom" && (
+            <>
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  OpenAI Compatible URL
+                </label>
+                <div className="relative">
+                  <input
+                    type="text"
+                    required
+                    placeholder="Enter your URL"
+                    className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                    value={llmConfig.CUSTOM_LLM_URL || ""}
+                    onChange={(e) =>
+                      input_field_changed(e.target.value, "custom_llm_url")
+                    }
+                  />
+                </div>
+              </div>
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  OpenAI Compatible API Key
+                </label>
+                <div className="relative">
+                  <input
+                    type="text"
+                    required
+                    placeholder="Enter your API Key"
+                    className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                    value={llmConfig.CUSTOM_LLM_API_KEY || ""}
+                    onChange={(e) =>
+                      input_field_changed(e.target.value, "custom_llm_api_key")
+                    }
+                  />
+                </div>
+              </div>
+
+              {/* Model selection dropdown - only show if models are available */}
+              {customModelsChecked && customModels.length > 0 && (
+                <div className="mb-4">
+                  <div className="mb-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                    <p className="text-sm text-amber-800">
+                      <strong>Important:</strong> Only models with function
+                      calling capabilities (tool calls) or JSON schema support
+                      will work.
+                    </p>
+                  </div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Select Model
+                  </label>
+                  <div className="w-full">
+                    <Popover
+                      open={openModelSelect}
+                      onOpenChange={setOpenModelSelect}
+                    >
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          role="combobox"
+                          aria-expanded={openModelSelect}
+                          className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
+                        >
+                          <span className="text-sm font-medium text-gray-900">
+                            {llmConfig.CUSTOM_MODEL || "Select a model"}
+                          </span>
+                          <ChevronsUpDown className="w-4 h-4 text-gray-500" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        className="p-0"
+                        align="start"
+                        style={{ width: "var(--radix-popover-trigger-width)" }}
+                      >
+                        <Command>
+                          <CommandInput placeholder="Search model..." />
+                          <CommandList>
+                            <CommandEmpty>No model found.</CommandEmpty>
+                            <CommandGroup>
+                              {customModels.map((model, index) => (
+                                <CommandItem
+                                  key={index}
+                                  value={model}
+                                  onSelect={(value) => {
+                                    input_field_changed(value, "custom_model");
+                                    setOpenModelSelect(false);
+                                  }}
+                                >
+                                  <Check
+                                    className={cn(
+                                      "mr-2 h-4 w-4",
+                                      llmConfig.CUSTOM_MODEL === model
+                                        ? "opacity-100"
+                                        : "opacity-0"
+                                    )}
+                                  />
+                                  <span className="text-sm font-medium text-gray-900">
+                                    {model}
+                                  </span>
+                                </CommandItem>
+                              ))}
+                            </CommandGroup>
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
+                  </div>
+                </div>
+              )}
+
+              {/* Check for available models button - show when no models checked or no models found */}
+              {(!customModelsChecked ||
+                (customModelsChecked && customModels.length === 0)) && (
+                <div className="mb-4">
+                  <button
+                    onClick={fetchCustomModels}
+                    disabled={customModelsLoading || !llmConfig.CUSTOM_LLM_URL}
+                    className={`w-full py-2.5 px-4 rounded-lg transition-all duration-200 border-2 ${
+                      customModelsLoading || !llmConfig.CUSTOM_LLM_URL
+                        ? "bg-gray-100 border-gray-300 cursor-not-allowed text-gray-500"
+                        : "bg-white border-blue-600 text-blue-600 hover:bg-blue-50 focus:ring-2 focus:ring-blue-500/20"
+                    }`}
+                  >
+                    {customModelsLoading ? (
+                      <div className="flex items-center justify-center gap-2">
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        Checking for models...
+                      </div>
+                    ) : (
+                      "Check for available models"
+                    )}
+                  </button>
+                </div>
+              )}
+
+              {/* Show message if no models found */}
+              {customModelsChecked && customModels.length === 0 && (
+                <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
+                  <p className="text-sm text-yellow-800">
+                    No models found. Please make sure models are available.
+                  </p>
+                </div>
+              )}
+            </>
+          )}
+          {/* Image Provider Selection */}
+          <div className="mb-8">
+            <label className="block text-sm font-medium text-gray-700 mb-3">
+              Select Image Provider
+            </label>
+            <div className="w-full">
+              <Popover
+                open={openImageProviderSelect}
+                onOpenChange={setOpenImageProviderSelect}
+              >
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={openImageProviderSelect}
+                    className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
+                  >
+                    <div className="flex gap-3 items-center">
+                      <span className="text-sm font-medium text-gray-900">
+                        {llmConfig.IMAGE_PROVIDER
+                          ? IMAGE_PROVIDERS[llmConfig.IMAGE_PROVIDER]?.label ||
+                            llmConfig.IMAGE_PROVIDER
+                          : "Select image provider"}
+                      </span>
+                    </div>
+                    <ChevronsUpDown className="w-4 h-4 text-gray-500" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  className="p-0"
+                  align="start"
+                  style={{ width: "var(--radix-popover-trigger-width)" }}
+                >
+                  <Command>
+                    <CommandInput placeholder="Search provider..." />
+                    <CommandList>
+                      <CommandEmpty>No provider found.</CommandEmpty>
+                      <CommandGroup>
+                        {Object.values(IMAGE_PROVIDERS).map(
+                          (provider, index) => (
+                            <CommandItem
+                              key={index}
+                              value={provider.value}
+                              onSelect={(value) => {
+                                console.log("Image Provider", value)
+                                setLlmConfig({
+                                  ...llmConfig,
+                                  IMAGE_PROVIDER: value,
+                                });
+                                console.log("LLM config", llmConfig)
+                                setOpenImageProviderSelect(false);
+                              }}
+                            >
+                              <Check
+                                className={cn(
+                                  "mr-2 h-4 w-4",
+                                  llmConfig.IMAGE_PROVIDER === provider.value
+                                    ? "opacity-100"
+                                    : "opacity-0"
+                                )}
+                              />
+                              <div className="flex gap-3 items-center">
+                                <div className="flex flex-col space-y-1 flex-1">
+                                  <div className="flex items-center justify-between gap-2">
+                                    <span className="text-sm font-medium text-gray-900 capitalize">
+                                      {provider.label}
+                                    </span>
+                                  </div>
+                                  <span className="text-xs text-gray-600 leading-relaxed">
+                                    {provider.description}
+                                  </span>
+                                </div>
+                              </div>
+                            </CommandItem>
+                          )
+                        )}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+            </div>
+          </div>
+
+          {/* Dynamic API Key Input for Image Provider */}
+          {llmConfig.IMAGE_PROVIDER &&
+            IMAGE_PROVIDERS[llmConfig.IMAGE_PROVIDER] &&
+            (() => {
+              const provider = IMAGE_PROVIDERS[llmConfig.IMAGE_PROVIDER];
+
+              // Show info message when using same API key as main provider
+              if (provider.value === "dall-e-3" && llmConfig.LLM === "openai") {
+                return <></>;
+              }
+
+              if (provider.value === "imagen" && llmConfig.LLM === "google") {
+                return <> </>;
+              }
+
+              // Show API key input for other providers
+              return (
+                <div className="mb-8">
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    {provider.apiKeyField?.replace("_", " ")}
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      placeholder={`Enter your ${provider.label} API key`}
+                      className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                      value={
+                        provider.apiKeyField === "PEXELS_API_KEY"
+                          ? llmConfig.PEXELS_API_KEY || ""
+                          : provider.apiKeyField === "PIXABAY_API_KEY"
+                          ? llmConfig.PIXABAY_API_KEY || ""
+                          : ""
+                      }
+                      onChange={(e) => {
+                        if (provider.apiKeyField === "PEXELS_API_KEY") {
+                          input_field_changed(e.target.value, "pexels_api_key");
+                        } else if (provider.apiKeyField === "PIXABAY_API_KEY") {
+                          input_field_changed(
+                            e.target.value,
+                            "pixabay_api_key"
+                          );
+                        }
+                      }}
+                    />
+                  </div>
+                  <p className="mt-2 text-sm text-gray-500 flex items-center gap-2">
+                    <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
+                    API key for {provider.label} image generation
+                  </p>
+                </div>
+              );
+            })()}
+
+          {/* Model Information */}
+          <div className="mb-8 p-4 bg-blue-50 rounded-lg border border-blue-100">
+            <div className="flex items-start gap-3">
+              <Info className="w-5 h-5 text-blue-500 mt-0.5" />
+              <div>
+                <h3 className="text-sm font-medium text-blue-900 mb-1">
+                  Selected Models
+                </h3>
+                <p className="text-sm text-blue-700">
+                  Using{" "}
+                  {llmConfig.LLM === "ollama"
+                    ? llmConfig.OLLAMA_MODEL ?? "_____"
+                    : llmConfig.LLM === "custom"
+                    ? llmConfig.CUSTOM_MODEL ?? "_____"
+                    : PROVIDER_CONFIGS[llmConfig.LLM!].textModels[0].label}{" "}
+                  for text generation and{" "}
+                  {llmConfig.IMAGE_PROVIDER &&
+                  IMAGE_PROVIDERS[llmConfig.IMAGE_PROVIDER]
+                    ? IMAGE_PROVIDERS[llmConfig.IMAGE_PROVIDER].label
+                    : "_____"}{" "}
+                  for images
+                </p>
+                <p className="text-sm text-blue-600 mt-2 opacity-75">
+                  We've pre-selected the best models for optimal presentation
+                  generation
+                </p>
+              </div>
+            </div>
+          </div>
+          {/* API Guide Section */}
+          <Accordion
+            type="single"
+            collapsible
+            className="mb-8 bg-gray-50 rounded-lg border border-gray-200"
+          >
+            <AccordionItem value="guide" className="border-none">
+              <AccordionTrigger className="px-6 py-4 hover:no-underline">
+                <div className="flex items-start gap-3">
+                  <Info className="w-5 h-5 text-blue-600 mt-1" />
+                  <h3 className="text-lg font-medium text-gray-900">
+                    {PROVIDER_CONFIGS[llmConfig.LLM!].apiGuide.title}
+                  </h3>
+                </div>
+              </AccordionTrigger>
+              <AccordionContent className="px-6 pb-6">
+                <div className="space-y-4">
+                  <ol className="list-decimal list-inside space-y-2 text-gray-600">
+                    {PROVIDER_CONFIGS[llmConfig.LLM!].apiGuide.steps.map(
+                      (step, index) => (
+                        <li key={index} className="text-sm">
+                          {step}
+                        </li>
+                      )
+                    )}
+                  </ol>
+
+                  <div className="flex flex-col sm:flex-row gap-4 mt-6">
+                    {PROVIDER_CONFIGS[llmConfig.LLM!].apiGuide.videoUrl && (
+                      <Link
+                        href={
+                          PROVIDER_CONFIGS[llmConfig.LLM!].apiGuide.videoUrl!
+                        }
+                        target="_blank"
+                        className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-700 transition-colors"
+                      >
+                        <PlayCircle className="w-4 h-4" />
+                        Watch Video Tutorial
+                        <ExternalLink className="w-3 h-3" />
+                      </Link>
+                    )}
+                    <Link
+                      href={PROVIDER_CONFIGS[llmConfig.LLM!].apiGuide.docsUrl}
+                      target="_blank"
+                      className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-700 transition-colors"
+                    >
+                      <span>Official Documentation</span>
+                      <ExternalLink className="w-3 h-3" />
+                    </Link>
+                  </div>
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+
+          {/* Save Button */}
+          <button
+            onClick={handleSaveConfig}
+            disabled={
+              isLoading ||
+              (llmConfig.LLM === "ollama" && !llmConfig.OLLAMA_MODEL) ||
+              (llmConfig.LLM === "custom" && !llmConfig.CUSTOM_MODEL)
+            }
+            className={`mt-8 w-full font-semibold py-3 px-4 rounded-lg transition-all duration-500 ${
+              isLoading ||
+              (llmConfig.LLM === "ollama" && !llmConfig.OLLAMA_MODEL) ||
+              (llmConfig.LLM === "custom" && !llmConfig.CUSTOM_MODEL)
+                ? "bg-gray-400 cursor-not-allowed"
+                : "bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 focus:ring-4 focus:ring-blue-200"
+            } text-white`}
+          >
+            {isLoading ? (
+              <div className="flex items-center justify-center gap-2">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                {(llmConfig.LLM === "ollama" && downloadingModel.downloaded) ||
+                0 > 0
+                  ? `Downloading Model (${(
+                      ((downloadingModel.downloaded || 0) /
+                        (downloadingModel.size || 1)) *
+                      100
+                    ).toFixed(0)}%)`
+                  : "Saving Configuration..."}
+              </div>
+            ) : (llmConfig.LLM === "ollama" && !llmConfig.OLLAMA_MODEL) ||
+              (llmConfig.LLM === "custom" && !llmConfig.CUSTOM_MODEL) ? (
+              "Please Select a Model"
+            ) : (
+              "Save Configuration"
+            )}
+          </button>
+
+          {llmConfig.LLM === "ollama" &&
+            downloadingModel.status &&
+            downloadingModel.status !== "pulled" && (
+              <div className="mt-3 text-sm bg-green-100 rounded-lg p-2 font-semibold capitalize text-center text-gray-600">
+                {downloadingModel.status}
+              </div>
+            )}
+        </div>
+      </main>
+    </div>
+  );
 }

--- a/servers/nextjs/components/Home.tsx
+++ b/servers/nextjs/components/Home.tsx
@@ -87,9 +87,9 @@ const IMAGE_PROVIDERS: Record<string, ImageProviderOption> = {
     requiresApiKey: true,
     apiKeyField: "OPENAI_API_KEY",
   },
-  imagen: {
-    value: "imagen",
-    label: "Imagen",
+  gemini_flash: {
+    value: "gemini_flash",
+    label: "Gemini Flash",
     description: "Google's primary image generation model",
     icon: "/icons/google.png",
     requiresApiKey: true,
@@ -142,8 +142,8 @@ const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
     ],
     imageModels: [
       {
-        value: "imagen",
-        label: "Imagen",
+        value: "gemini_flash",
+        label: "Gemini Flash",
         description: "Google's primary image generation model",
         icon: "/icons/google.png",
         size: "8GB",
@@ -323,7 +323,7 @@ export default function Home() {
     if (provider === "openai") {
       newConfig.IMAGE_PROVIDER = "dall-e-3";
     } else if (provider === "google") {
-      newConfig.IMAGE_PROVIDER = "imagen";
+      newConfig.IMAGE_PROVIDER = "gemini_flash";
     } else {
       newConfig.IMAGE_PROVIDER = "pexels"; // default for ollama and custom
     }
@@ -967,7 +967,7 @@ export default function Home() {
                 return <></>;
               }
 
-              if (provider.value === "imagen" && llmConfig.LLM === "google") {
+              if (provider.value === "gemini_flash" && llmConfig.LLM === "google") {
                 return <> </>;
               }
 

--- a/servers/nextjs/types/global.d.ts
+++ b/servers/nextjs/types/global.d.ts
@@ -22,6 +22,8 @@ interface LLMConfig {
   CUSTOM_LLM_URL?: string;
   CUSTOM_LLM_API_KEY?: string;
   CUSTOM_MODEL?: string;
+  IMAGE_PROVIDER?: string;
+  PIXABAY_API_KEY?: string;
   PEXELS_API_KEY?: string;
 
   // Only used in UI settings

--- a/servers/nextjs/utils/storeHelpers.ts
+++ b/servers/nextjs/utils/storeHelpers.ts
@@ -3,29 +3,68 @@ import { store } from "@/store/store";
 
 export const handleSaveLLMConfig = async (llmConfig: LLMConfig) => {
   if (!hasValidLLMConfig(llmConfig)) {
-    throw new Error('Provided configuration is not valid');
+    throw new Error("Provided configuration is not valid");
   }
-
-  await fetch('/api/user-config', {
-    method: 'POST',
-    body: JSON.stringify(llmConfig)
+  console.log("StoreHelperLLMConfig: Saving LLM config", llmConfig);
+  await fetch("/api/user-config", {
+    method: "POST",
+    body: JSON.stringify(llmConfig),
   });
 
   store.dispatch(setLLMConfig(llmConfig));
-}
+};
 
 export const hasValidLLMConfig = (llmConfig: LLMConfig) => {
   if (!llmConfig.LLM) return false;
+  if (!llmConfig.IMAGE_PROVIDER) return false;
   const OPENAI_API_KEY = llmConfig.OPENAI_API_KEY;
   const GOOGLE_API_KEY = llmConfig.GOOGLE_API_KEY;
 
-  const isOllamaConfigValid = llmConfig.OLLAMA_MODEL !== '' && llmConfig.OLLAMA_MODEL !== null && llmConfig.OLLAMA_MODEL !== undefined && llmConfig.OLLAMA_URL !== '' && llmConfig.OLLAMA_URL !== null && llmConfig.OLLAMA_URL !== undefined;
-  const isCustomConfigValid = llmConfig.CUSTOM_LLM_URL !== '' && llmConfig.CUSTOM_LLM_URL !== null && llmConfig.CUSTOM_LLM_URL !== undefined && llmConfig.CUSTOM_MODEL !== '' && llmConfig.CUSTOM_MODEL !== null && llmConfig.CUSTOM_MODEL !== undefined;
+  const isOllamaConfigValid =
+    llmConfig.OLLAMA_MODEL !== "" &&
+    llmConfig.OLLAMA_MODEL !== null &&
+    llmConfig.OLLAMA_MODEL !== undefined &&
+    llmConfig.OLLAMA_URL !== "" &&
+    llmConfig.OLLAMA_URL !== null &&
+    llmConfig.OLLAMA_URL !== undefined;
 
-  return llmConfig.LLM === 'openai' ?
-    OPENAI_API_KEY !== '' && OPENAI_API_KEY !== null && OPENAI_API_KEY !== undefined :
-    llmConfig.LLM === 'google' ?
-      GOOGLE_API_KEY !== '' && GOOGLE_API_KEY !== null && GOOGLE_API_KEY !== undefined :
-      llmConfig.LLM === 'ollama' ? isOllamaConfigValid :
-        llmConfig.LLM === 'custom' ? isCustomConfigValid : false;
-}
+  const isCustomConfigValid =
+    llmConfig.CUSTOM_LLM_URL !== "" &&
+    llmConfig.CUSTOM_LLM_URL !== null &&
+    llmConfig.CUSTOM_LLM_URL !== undefined &&
+    llmConfig.CUSTOM_MODEL !== "" &&
+    llmConfig.CUSTOM_MODEL !== null &&
+    llmConfig.CUSTOM_MODEL !== undefined;
+
+  const isImageConfigValid = () => {
+    switch (llmConfig.IMAGE_PROVIDER) {
+      case "pexels":
+        return llmConfig.PEXELS_API_KEY && llmConfig.PEXELS_API_KEY !== "";
+      case "pixabay":
+        return llmConfig.PIXABAY_API_KEY && llmConfig.PIXABAY_API_KEY !== "";
+      case "dall-e-3":
+        return OPENAI_API_KEY && OPENAI_API_KEY !== "";
+      case "imagen":
+        return GOOGLE_API_KEY && GOOGLE_API_KEY !== "";
+      default:
+        return false;
+    }
+  };
+
+  const isLLMConfigValid =
+    llmConfig.LLM === "openai"
+      ? OPENAI_API_KEY !== "" &&
+        OPENAI_API_KEY !== null &&
+        OPENAI_API_KEY !== undefined
+      : llmConfig.LLM === "google"
+      ? GOOGLE_API_KEY !== "" &&
+        GOOGLE_API_KEY !== null &&
+        GOOGLE_API_KEY !== undefined
+      : llmConfig.LLM === "ollama"
+      ? isOllamaConfigValid
+      : llmConfig.LLM === "custom"
+      ? isCustomConfigValid
+      : false;
+
+  return isLLMConfigValid && isImageConfigValid();
+};

--- a/servers/nextjs/utils/storeHelpers.ts
+++ b/servers/nextjs/utils/storeHelpers.ts
@@ -44,7 +44,7 @@ export const hasValidLLMConfig = (llmConfig: LLMConfig) => {
         return llmConfig.PIXABAY_API_KEY && llmConfig.PIXABAY_API_KEY !== "";
       case "dall-e-3":
         return OPENAI_API_KEY && OPENAI_API_KEY !== "";
-      case "imagen":
+      case "gemini_flash":
         return GOOGLE_API_KEY && GOOGLE_API_KEY !== "";
       default:
         return false;

--- a/start.js
+++ b/start.js
@@ -1,3 +1,5 @@
+/* This script starts the FastAPI and Next.js servers, setting up user configuration if necessary. It reads environment variables to configure API keys and other settings, ensuring that the user configuration file is created if it doesn't exist. The script also handles the starting of both servers and keeps the Node.js process alive until one of the servers exits. */
+
 const path = require('path');
 const { spawn } = require('child_process');
 const fs = require('fs');
@@ -43,12 +45,13 @@ const setupUserConfigFromEnv = () => {
     CUSTOM_LLM_API_KEY: process.env.CUSTOM_LLM_API_KEY || existingConfig.CUSTOM_LLM_API_KEY,
     CUSTOM_MODEL: process.env.CUSTOM_MODEL || existingConfig.CUSTOM_MODEL,
     PEXELS_API_KEY: process.env.PEXELS_API_KEY || existingConfig.PEXELS_API_KEY,
+    PIXABAY_API_KEY: process.env.PIXABAY_API_KEY || existingConfig.PIXABAY_API_KEY,
+    IMAGE_PROVIDER: process.env.IMAGE_PROVIDER || existingConfig.IMAGE_PROVIDER,
     USE_CUSTOM_URL: process.env.USE_CUSTOM_URL || existingConfig.USE_CUSTOM_URL,
   };
 
   fs.writeFileSync(userConfigPath, JSON.stringify(userConfig));
 }
-
 const startServers = async () => {
 
   const fastApiProcess = spawn(


### PR DESCRIPTION
### What does this PR do?

- Adds ability to select different providers/models for text and image generation separately.
- Updates config UI and generation pipeline to decouple selection logic.
- Adds support for future extensions like Pexels/Pixabay or custom image.

### 🧪 Test Coverage

- Added test cases for image generation pipeline.
- Validated correct provider selection logic through unit tests.

### 🔗 Related Issue

Closes #53