### PR TITLE
fix(fastapi): update sql alchemy fields to fix migration 

### DIFF
--- a/servers/fastapi/models/sql/presentation.py
+++ b/servers/fastapi/models/sql/presentation.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 import uuid
-from sqlalchemy import JSON, Column, DateTime, String
+from sqlalchemy import JSON, Column, DateTime, String, Text
 from sqlmodel import Boolean, Field, SQLModel
 
 from models.presentation_layout import PresentationLayoutModel
@@ -14,7 +14,7 @@ class PresentationModel(SQLModel, table=True):
     __tablename__ = "presentations"
 
     id: uuid.UUID = Field(primary_key=True, default_factory=uuid.uuid4)
-    content: str
+    content: str = Field(sa_column=Column(Text, nullable=False))
     n_slides: int
     language: str
     title: Optional[str] = None
@@ -35,9 +35,9 @@ class PresentationModel(SQLModel, table=True):
     )
     layout: Optional[dict] = Field(sa_column=Column(JSON), default=None)
     structure: Optional[dict] = Field(sa_column=Column(JSON), default=None)
-    instructions: Optional[str] = Field(sa_column=Column(String), default=None)
-    tone: Optional[str] = Field(sa_column=Column(String), default=None)
-    verbosity: Optional[str] = Field(sa_column=Column(String), default=None)
+    instructions: Optional[str] = Field(sa_column=Column(Text), default=None)
+    tone: Optional[str] = Field(sa_column=Column(String(128)), default=None)
+    verbosity: Optional[str] = Field(sa_column=Column(String(56)), default=None)
     include_table_of_contents: bool = Field(sa_column=Column(Boolean), default=False)
     include_title_slide: bool = Field(sa_column=Column(Boolean), default=True)
     web_search: bool = Field(sa_column=Column(Boolean), default=False)

--- a/servers/fastapi/models/sql/slide.py
+++ b/servers/fastapi/models/sql/slide.py
@@ -1,7 +1,7 @@
 from typing import Optional
 import uuid
 from sqlalchemy import ForeignKey
-from sqlmodel import Field, Column, JSON, SQLModel
+from sqlmodel import Field, Column, JSON, SQLModel, Text
 
 
 class SlideModel(SQLModel, table=True):
@@ -16,7 +16,7 @@ class SlideModel(SQLModel, table=True):
     index: int
     content: dict = Field(sa_column=Column(JSON))
     html_content: Optional[str]
-    speaker_note: Optional[str] = None
+    speaker_note: Optional[str] = Field(sa_column=Column(Text), default=None)
     properties: Optional[dict] = Field(sa_column=Column(JSON))
 
     def get_new_slide(self, presentation: uuid.UUID, content: Optional[dict] = None):


### PR DESCRIPTION
With a Mysql Database, there are some issues with the actual sql-alchemy types : 
- String shoud contains the length of the string
- some field doesnt have sql alchemy types and therefor the DB can pick a wrong type or a too small one
- we need Text for long fields as content, instructions, speaker notes