### PR TITLE
Refactor endpoints to use AsyncOpenAI and clean up code

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/slide_to_html.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/slide_to_html.py
@@ -5,7 +5,7 @@ from typing import Optional, List, Dict
 from uuid import UUID
 from fastapi import APIRouter, HTTPException, File, UploadFile, Form, Depends
 from pydantic import BaseModel
-from openai import OpenAI
+from openai import AsyncOpenAI
 from openai import APIError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, delete, func
@@ -20,7 +20,6 @@ from .prompts import (
 from models.sql.template import TemplateModel
 
 
-# Create separate routers for each functionality
 SLIDE_TO_HTML_ROUTER = APIRouter(prefix="/slide-to-html", tags=["slide-to-html"])
 HTML_TO_REACT_ROUTER = APIRouter(prefix="/html-to-react", tags=["html-to-react"])
 HTML_EDIT_ROUTER = APIRouter(prefix="/html-edit", tags=["html-edit"])
@@ -29,11 +28,10 @@ LAYOUT_MANAGEMENT_ROUTER = APIRouter(
 )
 
 
-# Request/Response models for slide-to-html endpoint
 class SlideToHtmlRequest(BaseModel):
-    image: str  # Partial path to image file (e.g., "/app_data/images/uuid/slide_1.png")
-    xml: str  # OXML content as text
-    fonts: Optional[List[str]] = None  # Optional normalized root fonts for this slide
+    image: str
+    xml: str
+    fonts: Optional[List[str]] = None
 
 
 class SlideToHtmlResponse(BaseModel):
@@ -41,17 +39,15 @@ class SlideToHtmlResponse(BaseModel):
     html: str
 
 
-# Request/Response models for html-edit endpoint
 class HtmlEditResponse(BaseModel):
     success: bool
     edited_html: str
     message: Optional[str] = None
 
 
-# Request/Response models for html-to-react endpoint
 class HtmlToReactRequest(BaseModel):
-    html: str  # HTML content to convert to React component
-    image: Optional[str] = None  # Optional image path to provide visual context
+    html: str
+    image: Optional[str] = None
 
 
 class HtmlToReactResponse(BaseModel):
@@ -60,13 +56,12 @@ class HtmlToReactResponse(BaseModel):
     message: Optional[str] = None
 
 
-# Request/Response models for layout management endpoints
 class LayoutData(BaseModel):
-    presentation: UUID  # UUID of the presentation
-    layout_id: str  # Unique identifier for the layout
-    layout_name: str  # Display name of the layout
-    layout_code: str  # TSX/React component code for the layout
-    fonts: Optional[List[str]] = None  # Optional list of font links
+    presentation: UUID
+    layout_id: str
+    layout_name: str
+    layout_code: str
+    fonts: Optional[List[str]] = None
 
 
 class SaveLayoutsRequest(BaseModel):
@@ -134,29 +129,11 @@ async def generate_html_from_slide(
     api_key: str,
     fonts: Optional[List[str]] = None,
 ) -> str:
-    """
-    Generate HTML content from slide image and XML using OpenAI GPT-5 Responses API.
-
-    Args:
-        base64_image: Base64 encoded image data
-        media_type: MIME type of the image (e.g., 'image/png')
-        xml_content: OXML content as text
-        api_key: OpenAI API key
-        fonts: Optional list of normalized root font families to prefer in output
-
-    Returns:
-        Generated HTML content as string
-
-    Raises:
-        HTTPException: If API call fails or no content is generated
-    """
-    print(
-        f"Generating HTML from slide image and XML using OpenAI GPT-5 Responses API..."
-    )
+    print("Generating HTML from slide image and XML using OpenAI GPT-5 Responses API...")
+    print(f"Image b64 length: {len(base64_image)}, XML length: {len(xml_content)}")
     try:
-        client = OpenAI(api_key=api_key)
+        client = AsyncOpenAI(api_key=api_key, timeout=300.0)
 
-        # Compose input for Responses API. Include system prompt, image (separate), OXML and optional fonts text.
         data_url = f"data:{media_type};base64,{base64_image}"
         fonts_text = (
             f"\nFONTS (Normalized root families used in this slide, use where it is required): {', '.join(fonts)}"
@@ -175,15 +152,15 @@ async def generate_html_from_slide(
             },
         ]
 
-        print("Making Responses API request for HTML generation...")
-        response = client.responses.create(
+        print("Making Responses API streaming request for HTML generation...")
+        async with client.responses.stream(
             model="gpt-5",
             input=input_payload,
             reasoning={"effort": "high"},
             text={"verbosity": "low"},
-        )
+        ) as stream:
+            response = await stream.get_final_response()
 
-        # Extract the response text
         html_content = (
             getattr(response, "output_text", None)
             or getattr(response, "text", None)
@@ -205,7 +182,6 @@ async def generate_html_from_slide(
             status_code=500, detail=f"OpenAI API error during HTML generation: {str(e)}"
         )
     except Exception as e:
-        # Handle various API errors
         error_msg = str(e)
         print(f"Exception occurred: {error_msg}")
         print(f"Exception type: {type(e)}")
@@ -232,25 +208,11 @@ async def generate_react_component_from_html(
     image_base64: Optional[str] = None,
     media_type: Optional[str] = None,
 ) -> str:
-    """
-    Convert HTML content to TSX React component using OpenAI GPT-5 Responses API.
-
-    Args:
-        html_content: Generated HTML content
-        api_key: OpenAI API key
-
-    Returns:
-        Generated TSX React component code as string
-
-    Raises:
-        HTTPException: If API call fails or no content is generated
-    """
     try:
-        client = OpenAI(api_key=api_key)
+        client = AsyncOpenAI(api_key=api_key, timeout=300.0)
 
-        print("Making Responses API request for React component generation...")
+        print("Making Responses API streaming request for React component generation...")
 
-        # Build payload with optional image
         content_parts = [{"type": "input_text", "text": f"HTML INPUT:\n{html_content}"}]
         if image_base64 and media_type:
             data_url = f"data:{media_type};base64,{image_base64}"
@@ -261,12 +223,13 @@ async def generate_react_component_from_html(
             {"role": "user", "content": content_parts},
         ]
 
-        response = client.responses.create(
+        async with client.responses.stream(
             model="gpt-5",
             input=input_payload,
             reasoning={"effort": "minimal"},
             text={"verbosity": "low"},
-        )
+        ) as stream:
+            response = await stream.get_final_response()
 
         react_content = (
             getattr(response, "output_text", None)
@@ -288,7 +251,6 @@ async def generate_react_component_from_html(
             .replace("javascript", "")
         )
 
-        # Filter out lines that start with import or export
         filtered_lines = []
         for line in react_content.split("\n"):
             stripped_line = line.strip()
@@ -302,6 +264,7 @@ async def generate_react_component_from_html(
         print(f"Filtered React content length: {len(filtered_react_content)}")
 
         return filtered_react_content
+
     except APIError as e:
         print(f"OpenAI API Error: {e}")
         raise HTTPException(
@@ -309,7 +272,6 @@ async def generate_react_component_from_html(
             detail=f"OpenAI API error during React generation: {str(e)}",
         )
     except Exception as e:
-        # Handle various API errors
         error_msg = str(e)
         print(f"Exception occurred: {error_msg}")
         print(f"Exception type: {type(e)}")
@@ -338,27 +300,10 @@ async def edit_html_with_images(
     prompt: str,
     api_key: str,
 ) -> str:
-    """
-    Edit HTML content based on one or two images and a text prompt using OpenAI GPT-5 Responses API.
-
-    Args:
-        current_ui_base64: Base64 encoded current UI image data
-        sketch_base64: Base64 encoded sketch/indication image data (optional)
-        media_type: MIME type of the images (e.g., 'image/png')
-        html_content: Current HTML content to edit
-        prompt: Text prompt describing the changes
-        api_key: OpenAI API key
-
-    Returns:
-        Edited HTML content as string
-
-    Raises:
-        HTTPException: If API call fails or no content is generated
-    """
     try:
-        client = OpenAI(api_key=api_key)
+        client = AsyncOpenAI(api_key=api_key, timeout=300.0)
 
-        print("Making Responses API request for HTML editing...")
+        print("Making Responses API streaming request for HTML editing...")
 
         current_data_url = f"data:{media_type};base64,{current_ui_base64}"
         sketch_data_url = (
@@ -373,7 +318,6 @@ async def edit_html_with_images(
             },
         ]
         if sketch_data_url:
-            # Insert sketch image after current UI image for context
             content_parts.insert(
                 1, {"type": "input_image", "image_url": sketch_data_url}
             )
@@ -383,12 +327,13 @@ async def edit_html_with_images(
             {"role": "user", "content": content_parts},
         ]
 
-        response = client.responses.create(
+        async with client.responses.stream(
             model="gpt-5",
             input=input_payload,
             reasoning={"effort": "low"},
             text={"verbosity": "low"},
-        )
+        ) as stream:
+            response = await stream.get_final_response()
 
         edited_html = (
             getattr(response, "output_text", None)
@@ -412,7 +357,6 @@ async def edit_html_with_images(
             status_code=500, detail=f"OpenAI API error during HTML editing: {str(e)}"
         )
     except Exception as e:
-        # Handle various API errors
         error_msg = str(e)
         print(f"Exception occurred: {error_msg}")
         print(f"Exception type: {type(e)}")
@@ -433,57 +377,38 @@ async def edit_html_with_images(
             )
 
 
-# ENDPOINT 1: Slide to HTML conversion
 @SLIDE_TO_HTML_ROUTER.post("/", response_model=SlideToHtmlResponse)
 async def convert_slide_to_html(request: SlideToHtmlRequest):
-    """
-    Convert a slide image and its OXML data to HTML using Anthropic Claude API.
-
-    Args:
-        request: JSON request containing image path and XML content
-
-    Returns:
-        SlideToHtmlResponse with generated HTML
-    """
     try:
-        # Get OpenAI API key from environment
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
             raise HTTPException(
                 status_code=500, detail="OPENAI_API_KEY environment variable not set"
             )
 
-        # Resolve image path to actual file system path
         image_path = request.image
 
-        # Handle different path formats
         if image_path.startswith("/app_data/images/"):
-            # Remove the /app_data/images/ prefix and join with actual images directory
-            relative_path = image_path[len("/app_data/images/") :]
+            relative_path = image_path[len("/app_data/images/"):]
             actual_image_path = os.path.join(get_images_directory(), relative_path)
         elif image_path.startswith("/static/"):
-            # Handle static files
-            relative_path = image_path[len("/static/") :]
+            relative_path = image_path[len("/static/"):]
             actual_image_path = os.path.join("static", relative_path)
         else:
-            # Assume it's already a full path or relative to images directory
             if os.path.isabs(image_path):
                 actual_image_path = image_path
             else:
                 actual_image_path = os.path.join(get_images_directory(), image_path)
 
-        # Check if image file exists
         if not os.path.exists(actual_image_path):
             raise HTTPException(
                 status_code=404, detail=f"Image file not found: {image_path}"
             )
 
-        # Read and encode image to base64
         with open(actual_image_path, "rb") as image_file:
             image_content = image_file.read()
         base64_image = base64.b64encode(image_content).decode("utf-8")
 
-        # Determine media type from file extension
         file_extension = os.path.splitext(actual_image_path)[1].lower()
         media_type_map = {
             ".png": "image/png",
@@ -494,7 +419,6 @@ async def convert_slide_to_html(request: SlideToHtmlRequest):
         }
         media_type = media_type_map.get(file_extension, "image/png")
 
-        # Generate HTML using the extracted function
         html_content = await generate_html_from_slide(
             base64_image=base64_image,
             media_type=media_type,
@@ -508,50 +432,35 @@ async def convert_slide_to_html(request: SlideToHtmlRequest):
         return SlideToHtmlResponse(success=True, html=html_content)
 
     except HTTPException:
-        # Re-raise HTTP exceptions as-is
         raise
     except Exception as e:
-        # Log the full error for debugging
         print(f"Unexpected error during slide to HTML processing: {str(e)}")
         raise HTTPException(
             status_code=500, detail=f"Error processing slide to HTML: {str(e)}"
         )
 
 
-# ENDPOINT 2: HTML to React component conversion
 @HTML_TO_REACT_ROUTER.post("/", response_model=HtmlToReactResponse)
 async def convert_html_to_react(request: HtmlToReactRequest):
-    """
-    Convert HTML content to TSX React component using Anthropic Claude API.
-
-    Args:
-        request: JSON request containing HTML content
-
-    Returns:
-        HtmlToReactResponse with generated React component
-    """
     try:
-        # Get OpenAI API key from environment
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
             raise HTTPException(
                 status_code=500, detail="OPENAI_API_KEY environment variable not set"
             )
 
-        # Validate HTML content
         if not request.html or not request.html.strip():
             raise HTTPException(status_code=400, detail="HTML content cannot be empty")
 
-        # Optionally resolve image and encode to base64
         image_b64 = None
         media_type = None
         if request.image:
             image_path = request.image
             if image_path.startswith("/app_data/images/"):
-                relative_path = image_path[len("/app_data/images/") :]
+                relative_path = image_path[len("/app_data/images/"):]
                 actual_image_path = os.path.join(get_images_directory(), relative_path)
             elif image_path.startswith("/static/"):
-                relative_path = image_path[len("/static/") :]
+                relative_path = image_path[len("/static/"):]
                 actual_image_path = os.path.join("static", relative_path)
             else:
                 actual_image_path = (
@@ -571,7 +480,6 @@ async def convert_html_to_react(request: HtmlToReactRequest):
                     ".webp": "image/webp",
                 }.get(ext, "image/png")
 
-        # Convert HTML to React component
         react_component = await generate_react_component_from_html(
             html_content=request.html,
             api_key=api_key,
@@ -588,17 +496,14 @@ async def convert_html_to_react(request: HtmlToReactRequest):
         )
 
     except HTTPException:
-        # Re-raise HTTP exceptions as-is
         raise
     except Exception as e:
-        # Log the full error for debugging
         print(f"Unexpected error during HTML to React processing: {str(e)}")
         raise HTTPException(
             status_code=500, detail=f"Error processing HTML to React: {str(e)}"
         )
 
 
-# ENDPOINT 3: HTML editing with images
 @HTML_EDIT_ROUTER.post("/", response_model=HtmlEditResponse)
 async def edit_html_with_images_endpoint(
     current_ui_image: UploadFile = File(..., description="Current UI image file"),
@@ -608,34 +513,19 @@ async def edit_html_with_images_endpoint(
     html: str = Form(..., description="Current HTML content to edit"),
     prompt: str = Form(..., description="Text prompt describing the changes"),
 ):
-    """
-    Edit HTML content based on one or two uploaded images and a text prompt using Anthropic Claude API.
-
-    Args:
-        current_ui_image: Uploaded current UI image file
-        sketch_image: Uploaded sketch/indication image file (optional)
-        html: Current HTML content to edit (form data)
-        prompt: Text prompt describing the changes (form data)
-
-    Returns:
-        HtmlEditResponse with edited HTML
-    """
     try:
-        # Get OpenAI API key from environment
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
             raise HTTPException(
                 status_code=500, detail="OPENAI_API_KEY environment variable not set"
             )
 
-        # Validate inputs
         if not html or not html.strip():
             raise HTTPException(status_code=400, detail="HTML content cannot be empty")
 
         if not prompt or not prompt.strip():
             raise HTTPException(status_code=400, detail="Text prompt cannot be empty")
 
-        # Validate current UI image file
         if (
             not current_ui_image.content_type
             or not current_ui_image.content_type.startswith("image/")
@@ -644,27 +534,22 @@ async def edit_html_with_images_endpoint(
                 status_code=400, detail="Current UI file must be an image"
             )
 
-        # Validate sketch image file only if provided
         if sketch_image and (
             not sketch_image.content_type
             or not sketch_image.content_type.startswith("image/")
         ):
             raise HTTPException(status_code=400, detail="Sketch file must be an image")
 
-        # Read and encode current UI image to base64
         current_ui_content = await current_ui_image.read()
         current_ui_base64 = base64.b64encode(current_ui_content).decode("utf-8")
 
-        # Read and encode sketch image to base64 only if provided
         sketch_base64 = None
         if sketch_image:
             sketch_content = await sketch_image.read()
             sketch_base64 = base64.b64encode(sketch_content).decode("utf-8")
 
-        # Use the content type from the uploaded files
         media_type = current_ui_image.content_type
 
-        # Edit HTML using the function
         edited_html = await edit_html_with_images(
             current_ui_base64=current_ui_base64,
             sketch_base64=sketch_base64,
@@ -681,17 +566,14 @@ async def edit_html_with_images_endpoint(
         )
 
     except HTTPException:
-        # Re-raise HTTP exceptions as-is
         raise
     except Exception as e:
-        # Log the full error for debugging
         print(f"Unexpected error during HTML editing: {str(e)}")
         raise HTTPException(
             status_code=500, detail=f"Error processing HTML editing: {str(e)}"
         )
 
 
-# ENDPOINT 4: Save layouts for a presentation
 @LAYOUT_MANAGEMENT_ROUTER.post(
     "/save-templates",
     response_model=SaveLayoutsResponse,
@@ -703,25 +585,11 @@ async def edit_html_with_images_endpoint(
 async def save_layouts(
     request: SaveLayoutsRequest, session: AsyncSession = Depends(get_async_session)
 ):
-    """
-    Save multiple layouts for presentations.
-
-    Args:
-        request: JSON request containing array of layout data
-        session: Database session
-
-    Returns:
-        SaveLayoutsResponse with success status and count of saved layouts
-
-    Raises:
-        HTTPException: 400 for validation errors, 500 for server errors
-    """
     try:
-        # Validate request data
         if not request.layouts:
             raise HTTPException(status_code=400, detail="Layouts array cannot be empty")
 
-        if len(request.layouts) > 50:  # Reasonable limit
+        if len(request.layouts) > 50:
             raise HTTPException(
                 status_code=400, detail="Cannot save more than 50 layouts at once"
             )
@@ -729,7 +597,6 @@ async def save_layouts(
         saved_count = 0
 
         for i, layout_data in enumerate(request.layouts):
-            # Validate individual layout data
             if (
                 not layout_data.presentation
                 or not str(layout_data.presentation).strip()
@@ -754,7 +621,6 @@ async def save_layouts(
                     status_code=400, detail=f"Layout {i+1}: layout_code cannot be empty"
                 )
 
-            # Check if layout already exists for this presentation and layout_id
             stmt = select(PresentationLayoutCodeModel).where(
                 PresentationLayoutCodeModel.presentation == layout_data.presentation,
                 PresentationLayoutCodeModel.layout_id == layout_data.layout_id,
@@ -763,13 +629,11 @@ async def save_layouts(
             existing_layout = result.scalar_one_or_none()
 
             if existing_layout:
-                # Update existing layout
                 existing_layout.layout_name = layout_data.layout_name
                 existing_layout.layout_code = layout_data.layout_code
                 existing_layout.fonts = layout_data.fonts
                 existing_layout.updated_at = datetime.now()
             else:
-                # Create new layout
                 new_layout = PresentationLayoutCodeModel(
                     presentation=layout_data.presentation,
                     layout_id=layout_data.layout_id,
@@ -790,7 +654,6 @@ async def save_layouts(
         )
 
     except HTTPException:
-        # Re-raise HTTP exceptions as-is
         await session.rollback()
         raise
     except Exception as e:
@@ -802,57 +665,36 @@ async def save_layouts(
         )
 
 
-# ENDPOINT 5: Get layouts for a presentation
 @LAYOUT_MANAGEMENT_ROUTER.get(
     "/get-templates/{presentation}",
     response_model=GetLayoutsResponse,
     responses={
         400: {"model": ErrorResponse, "description": "Invalid presentation ID"},
-        404: {
-            "model": ErrorResponse,
-            "description": "No layouts found for presentation",
-        },
+        404: {"model": ErrorResponse, "description": "No layouts found for presentation"},
         500: {"model": ErrorResponse, "description": "Internal server error"},
     },
 )
 async def get_layouts(
     presentation: UUID, session: AsyncSession = Depends(get_async_session)
 ):
-    """
-    Retrieve all layouts for a specific presentation.
-
-    Args:
-        presentation: UUID of the presentation
-        session: Database session
-
-    Returns:
-        GetLayoutsResponse with layouts data
-
-    Raises:
-        HTTPException: 404 if no layouts found, 400 for invalid UUID, 500 for server errors
-    """
     try:
-        # Validate presentation_id format (basic UUID check)
         if not presentation or len(str(presentation).strip()) == 0:
             raise HTTPException(
                 status_code=400, detail="Presentation ID cannot be empty"
             )
 
-        # Query layouts for the given presentation_id
         stmt = select(PresentationLayoutCodeModel).where(
             PresentationLayoutCodeModel.presentation == presentation
         )
         result = await session.execute(stmt)
         layouts_db = result.scalars().all()
 
-        # Check if any layouts were found
         if not layouts_db:
             raise HTTPException(
                 status_code=404,
                 detail=f"No layouts found for presentation ID: {presentation}",
             )
 
-        # Convert to response format
         layouts = [
             LayoutData(
                 presentation=layout.presentation,
@@ -864,14 +706,12 @@ async def get_layouts(
             for layout in layouts_db
         ]
 
-        # Aggregate unique fonts across all layouts
         aggregated_fonts: set[str] = set()
         for layout in layouts_db:
             if layout.fonts:
                 aggregated_fonts.update([f for f in layout.fonts if isinstance(f, str)])
         fonts_list = sorted(list(aggregated_fonts)) if aggregated_fonts else None
 
-        # Fetch template meta
         template_meta = await session.get(TemplateModel, presentation)
         template = None
         if template_meta:
@@ -891,7 +731,6 @@ async def get_layouts(
         )
 
     except HTTPException:
-        # Re-raise HTTP exceptions as-is
         raise
     except Exception as e:
         print(f"Error retrieving layouts for presentation {presentation}: {str(e)}")
@@ -901,7 +740,6 @@ async def get_layouts(
         )
 
 
-# ENDPOINT: Get all presentations with layout counts
 @LAYOUT_MANAGEMENT_ROUTER.get(
     "/summary",
     response_model=GetPresentationSummaryResponse,
@@ -918,11 +756,7 @@ async def get_layouts(
 async def get_presentations_summary(
     session: AsyncSession = Depends(get_async_session),
 ):
-    """
-    Get summary of all presentations with their layout counts.
-    """
     try:
-        # Query to get presentation_id, count of layouts, and MAX(updated_at)
         stmt = select(
             PresentationLayoutCodeModel.presentation,
             func.count(PresentationLayoutCodeModel.id).label("layout_count"),
@@ -932,7 +766,6 @@ async def get_presentations_summary(
         result = await session.execute(stmt)
         presentation_data = result.all()
 
-        # Convert to response format with template info if available
         presentations = []
         for row in presentation_data:
             template_meta = await session.get(TemplateModel, row.presentation)
@@ -953,7 +786,6 @@ async def get_presentations_summary(
                 )
             )
 
-        # Calculate totals
         total_presentations = len(presentations)
         total_layouts = sum(p.layout_count for p in presentations)
 
@@ -989,7 +821,6 @@ async def create_template(
         if not request.id or not request.name:
             raise HTTPException(status_code=400, detail="id and name are required")
 
-        # Upsert template by id
         existing = await session.get(TemplateModel, request.id)
         if existing:
             existing.name = request.name
@@ -1002,7 +833,6 @@ async def create_template(
             )
         await session.commit()
 
-        # Read back
         template = await session.get(TemplateModel, request.id)
         return TemplateCreateResponse(
             success=True,


### PR DESCRIPTION
Refactor slide-to-html and related endpoints to use AsyncOpenAI for asynchronous API calls. Update request/response models for consistency and remove unnecessary comments.