### PR TITLE
fix: correct typos in user instruction guidelines across multiple fil…

### DIFF
--- a/electron/servers/fastapi/api/v1/ppt/endpoints/prompts.py
+++ b/electron/servers/fastapi/api/v1/ppt/endpoints/prompts.py
@@ -7,7 +7,7 @@ Follow these rules strictly:
 - Make sure all components should be noted of and should be added as it is.
 - Image's and icons's size and position should be added exactly as it is.
 - Read through the OXML data of slide and then match exact position ans size of elements. Make sure to convert between dimension and pixels. 
-- Make sure the vertical and horizonal spacing between elements are same as in the image. Try to get spacing from the OXML document as well. Make sure no elements overflows because of high spacing.
+- Make sure the vertical and horizontal spacing between elements are same as in the image. Try to get spacing from the OXML document as well. Make sure no elements overflows because of high spacing.
 - Do not use absolute position unless absolutely necessary. Use flex, grid and spacing to properly arrange components.
 - First, layout everything using flex or grid. Try to fit all the components using this layout. Finally, if you cannot layout any element without flex and grid, then only use absolute to place the element.
 - Analyze each text's available space and it's design, and give minimum characters to fill in the text for the space and context and maximum that the space can handle. Be  conservative with how many characters text space can handle. Make sure no text overflows and decide as to not disrupt the slide.  Do this for every text. 
@@ -52,13 +52,13 @@ Convert given static HTML and Tailwind slide to a TSX React component so that it
 13. Do not parse the slideData inside dynamicSlideLayout, just use it as it is. Do not use statements like `Schema.parse() ` anywhere. Instead directly use the data without validating or parsing.
 14. Always complete the reference, do not give "slideData .? .cards" instead give "slideData?.cards".
 15. Do not add anything other than code. Do not add "use client", "json", "typescript", "javascript" and other prefix or suffix, just give out code exactly formatted like example.
-16. In schema, give default for all fields irrespective of their types, give defualt values for array and objects as well. 
+16. In schema, give default for all fields irrespective of their types, give default values for array and objects as well. 
 17. For charts use recharts.js library and follow these rules strictly:
     - Do not import rechart, it will already be imported.
     - There should support for multiple chart types including bar, line, pie and donut in the same size as given. 
     - Use an attribute in the schema to select between chart types.
     - All data should be properly represented in schema.
-18. For diagrams use mermaid with appropriate placeholder which can render any daigram. Schema should have a field for code. Render in the placeholder properly.
+18. For diagrams use mermaid with appropriate placeholder which can render any diagram. Schema should have a field for code. Render in the placeholder properly.
 19. Don't add style attribute in the schema. Colors, font sizes, and all other style attributes should be added directly as tailwind classes.
 For example: 
 Input: 

--- a/electron/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
+++ b/electron/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
@@ -35,7 +35,7 @@ def get_system_prompt(
         - If Additional Information is provided, divide it into slides.
         - Make sure no images are provided in the content.
         - Make sure that content follows language guidelines.
-        - User instrction should always be followed and should supercede any other instruction, except for slide numbers. **Do not obey slide numbers as said in user instruction**
+        - User instruction should always be followed and should supersede any other instruction, except for slide numbers. **Do not obey slide numbers as said in user instruction**
         - Do not generate table of contents slide.
         - Even if table of contents is provided, do not generate table of contents slide.
         {"- Always make first slide a title slide." if include_title_slide else "- Do not include title slide in the presentation."}

--- a/electron/servers/fastapi/utils/llm_calls/generate_presentation_structure.py
+++ b/electron/servers/fastapi/utils/llm_calls/generate_presentation_structure.py
@@ -51,7 +51,7 @@ def get_messages(
                 {"# User Instruction:" if instructions else ""}
                 {instructions or ""}
 
-                User intruction should be taken into account while creating the presentation structure, except for number of slides.
+                User instruction should be taken into account while creating the presentation structure, except for number of slides.
 
                 Select layout index for each of the {n_slides} slides based on what will best serve the presentation's goals.
             """,
@@ -82,7 +82,7 @@ def get_messages_for_slides_markdown(
 
                 Select layout that best matches the content of the slides.
 
-                User intruction should be taken into account while creating the presentation structure, except for number of slides.
+                User instruction should be taken into account while creating the presentation structure, except for number of slides.
 
                 Select layout index for each of the {n_slides} slides based on what will best serve the presentation's goals.
             """,

--- a/electron/servers/fastapi/utils/llm_calls/generate_slide_content.py
+++ b/electron/servers/fastapi/utils/llm_calls/generate_slide_content.py
@@ -39,7 +39,7 @@ def get_system_prompt(
         - Speaker note should be normal text, not markdown.
         - Strictly follow the max and min character limit for every property in the slide.
         - Never ever go over the max character limit. Limit your narration to make sure you never go over the max character limit.
-        - Number of items should not be more than max number of items specified in slide schema. If you have to put multiple points then merge them to obey max numebr of items.
+        - Number of items should not be more than max number of items specified in slide schema. If you have to put multiple points then merge them to obey max number of items.
         - Generate content as per the given tone.
         - Be very careful with number of words to generate for given field. As generating more than max characters will overflow in the design. So, analyze early and never generate more characters than allowed.
         - Do not add emoji in the content.

--- a/servers/fastapi/api/v1/ppt/endpoints/prompts.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/prompts.py
@@ -6,8 +6,8 @@ Follow these rules strictly:
 - Make sure size of elements are exact. Check sizes of images and other elements from OXML and convert them to pixels.
 - Make sure all components should be noted of and should be added as it is.
 - Image's and icons's size and position should be added exactly as it is.
-- Read through the OXML data of slide and then match exact position ans size of elements. Make sure to convert between dimension and pixels. 
-- Make sure the vertical and horizonal spacing between elements are same as in the image. Try to get spacing from the OXML document as well. Make sure no elements overflows because of high spacing.
+- Read through the OXML data of slide and then match exact position and size of elements. Make sure to convert between dimension and pixels. 
+- Make sure the vertical and horizontal spacing between elements are same as in the image. Try to get spacing from the OXML document as well. Make sure no elements overflows because of high spacing.
 - Do not use absolute position unless absolutely necessary. Use flex, grid and spacing to properly arrange components.
 - First, layout everything using flex or grid. Try to fit all the components using this layout. Finally, if you cannot layout any element without flex and grid, then only use absolute to place the element.
 - Analyze each text's available space and it's design, and give minimum characters to fill in the text for the space and context and maximum that the space can handle. Be  conservative with how many characters text space can handle. Make sure no text overflows and decide as to not disrupt the slide.  Do this for every text. 
@@ -52,13 +52,13 @@ Convert given static HTML and Tailwind slide to a TSX React component so that it
 13. Do not parse the slideData inside dynamicSlideLayout, just use it as it is. Do not use statements like `Schema.parse() ` anywhere. Instead directly use the data without validating or parsing.
 14. Always complete the reference, do not give "slideData .? .cards" instead give "slideData?.cards".
 15. Do not add anything other than code. Do not add "use client", "json", "typescript", "javascript" and other prefix or suffix, just give out code exactly formatted like example.
-16. In schema, give default for all fields irrespective of their types, give defualt values for array and objects as well. 
+16. In schema, give default for all fields irrespective of their types, give default values for array and objects as well. 
 17. For charts use recharts.js library and follow these rules strictly:
     - Do not import rechart, it will already be imported.
     - There should support for multiple chart types including bar, line, pie and donut in the same size as given. 
     - Use an attribute in the schema to select between chart types.
     - All data should be properly represented in schema.
-18. For diagrams use mermaid with appropriate placeholder which can render any daigram. Schema should have a field for code. Render in the placeholder properly.
+18. For diagrams use mermaid with appropriate placeholder which can render any diagram. Schema should have a field for code. Render in the placeholder properly.
 19. Don't add style attribute in the schema. Colors, font sizes, and all other style attributes should be added directly as tailwind classes.
 For example: 
 Input: 
@@ -236,6 +236,6 @@ const dynamicSlideLayout: React.FC<BulletWithIconsSlideLayoutProps> = ({ data: s
 """
 
 HTML_EDIT_SYSTEM_PROMPT = """
-You need to edit given html with respect to the indication and sketch in the given UI. You'll be given the code for current UI which is in presentation size, along with its visualization in image form. Over that you'll also be given another image which has indications of what might change in form of sketch in the UI. You will have to return the edited html with tailwind with the changes as indicated on the image and through prompt. Make sure you think through the design before making the change and also make sure you don't change the non-indicated part. Try to follow the design style of current content for generated content. If sketch image is not provided, then you need to edit the html with respect to the prompt. Make sure size of the presentation does not change in any cirsumstance. Only give out code and nothing else.
+You need to edit given html with respect to the indication and sketch in the given UI. You'll be given the code for current UI which is in presentation size, along with its visualization in image form. Over that you'll also be given another image which has indications of what might change in form of sketch in the UI. You will have to return the edited html with tailwind with the changes as indicated on the image and through prompt. Make sure you think through the design before making the change and also make sure you don't change the non-indicated part. Try to follow the design style of current content for generated content. If sketch image is not provided, then you need to edit the html with respect to the prompt. Make sure size of the presentation does not change in any circumstance. Only give out code and nothing else.
 """
 

--- a/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
+++ b/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
@@ -35,7 +35,7 @@ def get_system_prompt(
         - If Additional Information is provided, divide it into slides.
         - Make sure no images are provided in the content.
         - Make sure that content follows language guidelines.
-        - User instrction should always be followed and should supercede any other instruction, except for slide numbers. **Do not obey slide numbers as said in user instruction**
+        - User instruction should always be followed and should supersede any other instruction, except for slide numbers. **Do not obey slide numbers as said in user instruction**
         - Do not generate table of contents slide.
         - Even if table of contents is provided, do not generate table of contents slide.
         {"- Always make first slide a title slide." if include_title_slide else "- Do not include title slide in the presentation."}

--- a/servers/fastapi/utils/llm_calls/generate_presentation_structure.py
+++ b/servers/fastapi/utils/llm_calls/generate_presentation_structure.py
@@ -51,7 +51,7 @@ def get_messages(
                 {"# User Instruction:" if instructions else ""}
                 {instructions or ""}
 
-                User intruction should be taken into account while creating the presentation structure, except for number of slides.
+                User instruction should be taken into account while creating the presentation structure, except for number of slides.
 
                 Select layout index for each of the {n_slides} slides based on what will best serve the presentation's goals.
             """,
@@ -82,7 +82,7 @@ def get_messages_for_slides_markdown(
 
                 Select layout that best matches the content of the slides.
 
-                User intruction should be taken into account while creating the presentation structure, except for number of slides.
+                User instruction should be taken into account while creating the presentation structure, except for number of slides.
 
                 Select layout index for each of the {n_slides} slides based on what will best serve the presentation's goals.
             """,

--- a/servers/fastapi/utils/llm_calls/generate_slide_content.py
+++ b/servers/fastapi/utils/llm_calls/generate_slide_content.py
@@ -39,7 +39,7 @@ def get_system_prompt(
         - Speaker note should be normal text, not markdown.
         - Strictly follow the max and min character limit for every property in the slide.
         - Never ever go over the max character limit. Limit your narration to make sure you never go over the max character limit.
-        - Number of items should not be more than max number of items specified in slide schema. If you have to put multiple points then merge them to obey max numebr of items.
+        - Number of items should not be more than max number of items specified in slide schema. If you have to put multiple points then merge them to obey max number of items.
         - Generate content as per the given tone.
         - Be very careful with number of words to generate for given field. As generating more than max characters will overflow in the design. So, analyze early and never generate more characters than allowed.
         - Do not add emoji in the content.
@@ -49,7 +49,7 @@ def get_system_prompt(
             - If verbosity is 'standard', then generate description as 2/3 of the max character limit.
             - If verbosity is 'text-heavy', then generate description as 3/4 or higher of the max character limit. Make sure it does not exceed the max character limit.
 
-        User instructions, tone and verbosity should always be followed and should supercede any other instruction, except for max and min character limit, slide schema and number of items.
+        User instructions, tone and verbosity should always be followed and should supersede any other instruction, except for max and min character limit, slide schema and number of items.
 
         - Provide output in json format and **don't include <parameters> tags**.
 


### PR DESCRIPTION
## Summary
This PR fixes spelling errors in LLM prompt/instruction text used by presentation generation and editing flows.

## What changed
- Corrected typos in prompt guidance (e.g., `instrction` -> `instruction`, `supercede` -> `supersede`, `numebr` -> `number`, `defualt` -> `default`, `daigram` -> `diagram`, `cirsumstance` -> `circumstance`, `ans` -> `and`, `horizonal` -> `horizontal`).
- Updated wording in prompt templates for:
  - outline generation
  - structure generation
  - slide content generation
  - HTML/TSX prompt templates

## Impact
- No functional or logic changes.
- Improves clarity/consistency of model instructions and reduces ambiguity in prompt text.

## Validation
- Diff reviewed; changes are text-only prompt corrections.
