### PR TITLE
feat: improve handling of Anthropic responses and add retry logic for…

### DIFF
--- a/electron/servers/fastapi/services/llm_client.py
+++ b/electron/servers/fastapi/services/llm_client.py
@@ -967,7 +967,10 @@ class LLMClient:
             ],
         )
         tool_calls: List[AnthropicToolCall] = []
+        text_parts: List[str] = []
         for content in response.content:
+            if content.type == "text" and isinstance(content.text, str):
+                text_parts.append(content.text)
             if content.type == "tool_use":
                 tool_calls.append(
                     AnthropicToolCall(
@@ -1000,6 +1003,24 @@ class LLMClient:
             return await self._generate_anthropic_structured(
                 model=model,
                 messages=new_messages,
+                max_tokens=max_tokens,
+                response_format=response_format,
+                tools=tools,
+                depth=depth + 1,
+            )
+
+        text_content = "".join(text_parts).strip()
+        if text_content:
+            try:
+                return dict(dirtyjson.loads(text_content))
+            except Exception:
+                pass
+
+        if depth < 2:
+            await asyncio.sleep(0.4 * (depth + 1))
+            return await self._generate_anthropic_structured(
+                model=model,
+                messages=messages,
                 max_tokens=max_tokens,
                 response_format=response_format,
                 tools=tools,
@@ -1057,64 +1078,70 @@ class LLMClient:
     ) -> dict:
         parsed_tools = self.tool_calls_handler.parse_tools(tools)
 
-        content = None
-        match self.llm_provider:
-            case LLMProvider.OPENAI:
-                content = await self._generate_openai_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    strict=strict,
-                    tools=parsed_tools,
-                    max_tokens=max_tokens,
-                )
-            case LLMProvider.CODEX:
-                content = await self._generate_codex_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    strict=strict,
-                    tools=parsed_tools,
-                    max_tokens=max_tokens,
-                )
-            case LLMProvider.GOOGLE:
-                content = await self._generate_google_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    tools=parsed_tools,
-                    max_tokens=max_tokens,
-                )
-            case LLMProvider.ANTHROPIC:
-                content = await self._generate_anthropic_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    tools=parsed_tools,
-                    max_tokens=max_tokens,
-                )
-            case LLMProvider.OLLAMA:
-                content = await self._generate_ollama_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    strict=strict,
-                    max_tokens=max_tokens,
-                )
-            case LLMProvider.CUSTOM:
-                content = await self._generate_custom_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    strict=strict,
-                    max_tokens=max_tokens,
-                )
-        if content is None:
-            raise HTTPException(
-                status_code=400,
-                detail="LLM did not return any content",
-            )
-        return content
+        for attempt in range(3):
+            content = None
+            match self.llm_provider:
+                case LLMProvider.OPENAI:
+                    content = await self._generate_openai_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        strict=strict,
+                        tools=parsed_tools,
+                        max_tokens=max_tokens,
+                    )
+                case LLMProvider.CODEX:
+                    content = await self._generate_codex_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        strict=strict,
+                        tools=parsed_tools,
+                        max_tokens=max_tokens,
+                    )
+                case LLMProvider.GOOGLE:
+                    content = await self._generate_google_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        tools=parsed_tools,
+                        max_tokens=max_tokens,
+                    )
+                case LLMProvider.ANTHROPIC:
+                    content = await self._generate_anthropic_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        tools=parsed_tools,
+                        max_tokens=max_tokens,
+                    )
+                case LLMProvider.OLLAMA:
+                    content = await self._generate_ollama_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        strict=strict,
+                        max_tokens=max_tokens,
+                    )
+                case LLMProvider.CUSTOM:
+                    content = await self._generate_custom_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        strict=strict,
+                        max_tokens=max_tokens,
+                    )
+
+            if content is not None:
+                return content
+
+            if attempt < 2:
+                await asyncio.sleep(0.5 * (attempt + 1))
+
+        raise HTTPException(
+            status_code=400,
+            detail="LLM did not return any content",
+        )
 
     # ? Stream Unstructured Content
     async def _stream_openai(

--- a/servers/fastapi/services/llm_client.py
+++ b/servers/fastapi/services/llm_client.py
@@ -967,7 +967,10 @@ class LLMClient:
             ],
         )
         tool_calls: List[AnthropicToolCall] = []
+        text_parts: List[str] = []
         for content in response.content:
+            if content.type == "text" and isinstance(content.text, str):
+                text_parts.append(content.text)
             if content.type == "tool_use":
                 tool_calls.append(
                     AnthropicToolCall(
@@ -1000,6 +1003,24 @@ class LLMClient:
             return await self._generate_anthropic_structured(
                 model=model,
                 messages=new_messages,
+                max_tokens=max_tokens,
+                response_format=response_format,
+                tools=tools,
+                depth=depth + 1,
+            )
+
+        text_content = "".join(text_parts).strip()
+        if text_content:
+            try:
+                return dict(dirtyjson.loads(text_content))
+            except Exception:
+                pass
+
+        if depth < 2:
+            await asyncio.sleep(0.4 * (depth + 1))
+            return await self._generate_anthropic_structured(
+                model=model,
+                messages=messages,
                 max_tokens=max_tokens,
                 response_format=response_format,
                 tools=tools,
@@ -1057,64 +1078,70 @@ class LLMClient:
     ) -> dict:
         parsed_tools = self.tool_calls_handler.parse_tools(tools)
 
-        content = None
-        match self.llm_provider:
-            case LLMProvider.OPENAI:
-                content = await self._generate_openai_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    strict=strict,
-                    tools=parsed_tools,
-                    max_tokens=max_tokens,
-                )
-            case LLMProvider.CODEX:
-                content = await self._generate_codex_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    strict=strict,
-                    tools=parsed_tools,
-                    max_tokens=max_tokens,
-                )
-            case LLMProvider.GOOGLE:
-                content = await self._generate_google_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    tools=parsed_tools,
-                    max_tokens=max_tokens,
-                )
-            case LLMProvider.ANTHROPIC:
-                content = await self._generate_anthropic_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    tools=parsed_tools,
-                    max_tokens=max_tokens,
-                )
-            case LLMProvider.OLLAMA:
-                content = await self._generate_ollama_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    strict=strict,
-                    max_tokens=max_tokens,
-                )
-            case LLMProvider.CUSTOM:
-                content = await self._generate_custom_structured(
-                    model=model,
-                    messages=messages,
-                    response_format=response_format,
-                    strict=strict,
-                    max_tokens=max_tokens,
-                )
-        if content is None:
-            raise HTTPException(
-                status_code=400,
-                detail="LLM did not return any content",
-            )
-        return content
+        for attempt in range(3):
+            content = None
+            match self.llm_provider:
+                case LLMProvider.OPENAI:
+                    content = await self._generate_openai_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        strict=strict,
+                        tools=parsed_tools,
+                        max_tokens=max_tokens,
+                    )
+                case LLMProvider.CODEX:
+                    content = await self._generate_codex_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        strict=strict,
+                        tools=parsed_tools,
+                        max_tokens=max_tokens,
+                    )
+                case LLMProvider.GOOGLE:
+                    content = await self._generate_google_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        tools=parsed_tools,
+                        max_tokens=max_tokens,
+                    )
+                case LLMProvider.ANTHROPIC:
+                    content = await self._generate_anthropic_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        tools=parsed_tools,
+                        max_tokens=max_tokens,
+                    )
+                case LLMProvider.OLLAMA:
+                    content = await self._generate_ollama_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        strict=strict,
+                        max_tokens=max_tokens,
+                    )
+                case LLMProvider.CUSTOM:
+                    content = await self._generate_custom_structured(
+                        model=model,
+                        messages=messages,
+                        response_format=response_format,
+                        strict=strict,
+                        max_tokens=max_tokens,
+                    )
+
+            if content is not None:
+                return content
+
+            if attempt < 2:
+                await asyncio.sleep(0.5 * (attempt + 1))
+
+        raise HTTPException(
+            status_code=400,
+            detail="LLM did not return any content",
+        )
 
     # ? Stream Unstructured Content
     async def _stream_openai(


### PR DESCRIPTION
This pull request improves the robustness and reliability of the structured LLM response generation logic by adding retry mechanisms and better handling of partial or malformed responses. The changes are applied to both the main and `electron` FastAPI servers.

**Reliability and Retry Logic:**

* Added a retry loop (up to 3 attempts) in the `generate_structured` method to handle transient failures when requesting structured responses from LLM providers. Now, if the response is `None`, the method waits and retries before raising an exception. [[1]](diffhunk://#diff-14d556b888bce5c432cca2d3d7da82d79322e180517d7ab36ba7fb29353a7a34R1081) [[2]](diffhunk://#diff-14d556b888bce5c432cca2d3d7da82d79322e180517d7ab36ba7fb29353a7a34L1112-L1117) [[3]](diffhunk://#diff-34c2fc83abb8c1cf7c13b7e7d25b847f97a3141b761188cb53d129758e2dd0e4R1081) [[4]](diffhunk://#diff-34c2fc83abb8c1cf7c13b7e7d25b847f97a3141b761188cb53d129758e2dd0e4L1112-L1117)

**Response Parsing Improvements:**

* In `_generate_anthropic_structured`, collects all text parts from the response, attempts to parse them as JSON, and returns the result if successful. If parsing fails and the retry depth is less than 2, the method waits and retries recursively. This improves handling of malformed or incomplete responses from Anthropic models. [[1]](diffhunk://#diff-14d556b888bce5c432cca2d3d7da82d79322e180517d7ab36ba7fb29353a7a34R970-R973) [[2]](diffhunk://#diff-14d556b888bce5c432cca2d3d7da82d79322e180517d7ab36ba7fb29353a7a34R1012-R1029) [[3]](diffhunk://#diff-34c2fc83abb8c1cf7c13b7e7d25b847f97a3141b761188cb53d129758e2dd0e4R970-R973) [[4]](diffhunk://#diff-34c2fc83abb8c1cf7c13b7e7d25b847f97a3141b761188cb53d129758e2dd0e4R1012-R1029)… content retrieval