### PR TITLE
fix: resolve npm spawn issue on Windows by using npm.cmd and enabling…

### DIFF
--- a/electron/app/utils/servers.ts
+++ b/electron/app/utils/servers.ts
@@ -71,13 +71,15 @@ export async function startNextJsServer(
   let nextjsProcess;
 
   if (isDev) {
+    // Windows: npm is npm.cmd; spawn() needs a shell or ENOENT.
     nextjsProcess = spawn(
-      "npm",
+      process.platform === "win32" ? "npm.cmd" : "npm",
       ["run", "dev", "--", "-p", port.toString()],
       {
         cwd: directory,
         stdio: ["ignore", "pipe", "pipe"],
         env: { ...process.env, ...env },
+        shell: process.platform === "win32",
       }
     );
     const nextjsLogPath = path.join(logsDir, "nextjs-server.log");


### PR DESCRIPTION
This pull request updates the way the Next.js server process is spawned on Windows to improve compatibility and prevent errors.

Process spawning improvements for Windows:

* In `electron/app/utils/servers.ts`, the code now uses `npm.cmd` and enables the `shell` option when spawning the Next.js server process on Windows, addressing issues where `spawn()` would fail with ENOENT if not run in a shell.… shell