### PR TITLE
Change border_radius type from int to float

### DIFF
--- a/servers/fastapi/models/pptx_models.py
+++ b/servers/fastapi/models/pptx_models.py
@@ -128,7 +128,7 @@ class PptxAutoShapeBoxModel(PptxShapeModel):
     shadow: Optional[PptxShadowModel] = None
     position: PptxPositionModel
     text_wrap: bool = True
-    border_radius: Optional[int] = None
+    border_radius: Optional[float] = None
     paragraphs: Optional[List[PptxParagraphModel]] = None
 
 
@@ -139,7 +139,7 @@ class PptxPictureBoxModel(PptxShapeModel):
     clip: bool = True
     opacity: Optional[float] = None
     invert: bool = False
-    border_radius: Optional[List[int]] = None
+    border_radius: Optional[List[float]] = None
     shape: Optional[PptxBoxShapeEnum] = None
     object_fit: Optional[PptxObjectFitModel] = None
     picture: PptxPictureModel


### PR DESCRIPTION
This is part of fixing powerpoint export errors, together with 

`PptxAutoShapeBoxModel` `border_radius: Optional[int] = None` → `Optional[float]`

PptxPictureBoxModel `border_radius: Optional[List[int]] = None` → `Optional[List[float]]`
 https://github.com/presenton/presenton/tree/main/electron/servers/fastapi/services/pptx_presentation_creator.py  `apply_border_radius_to_shape(self, shape, border_radius: Optional[int])` → `Optional[float]`
 https://github.com/presenton/presenton/tree/main/electron/servers/fastapi/utils/image_utils.py  `round_image_corners(image, radii: List[int])` → `List[float]`