### PR TITLE
Update border_radius parameter type to float

### DIFF
--- a/electron/servers/fastapi/services/pptx_presentation_creator.py
+++ b/electron/servers/fastapi/services/pptx_presentation_creator.py
@@ -444,7 +444,7 @@ class PptxPresentationCreator:
         if text_run_model.font:
             self.apply_font(text_run.font, text_run_model.font)
 
-    def apply_border_radius_to_shape(self, shape: Shape, border_radius: Optional[int]):
+    def apply_border_radius_to_shape(self, shape: Shape, border_radius: Optional[float]):
         if not border_radius:
             return
         try:


### PR DESCRIPTION
Change border_radius type from int to float for better precision. This is part of fixing powerpoint export errors, together with 

`PptxAutoShapeBoxModel` `border_radius: Optional[int] = None` → `Optional[float]`

PptxPictureBoxModel `border_radius: Optional[List[int]] = None` → `Optional[List[float]]`
 https://github.com/presenton/presenton/tree/main/electron/servers/fastapi/services/pptx_presentation_creator.py  `apply_border_radius_to_shape(self, shape, border_radius: Optional[int])` → `Optional[float]`
 https://github.com/presenton/presenton/tree/main/electron/servers/fastapi/utils/image_utils.py  `round_image_corners(image, radii: List[int])` → `List[float]`