### PR TITLE
Update radii parameter type in round_image_corners

### DIFF
--- a/electron/servers/fastapi/utils/image_utils.py
+++ b/electron/servers/fastapi/utils/image_utils.py
@@ -46,7 +46,7 @@ def clip_image(
     return clipped_image
 
 
-def round_image_corners(image: Image.Image, radii: List[int]) -> Image.Image:
+def round_image_corners(image: Image.Image, radii: List[float]) -> Image.Image:
     if len(radii) != 4:
         raise ValueError(
             "Image Border Radius - radii must contain exactly 4 values for each corner"


### PR DESCRIPTION
Change the type of 'radii' parameter from List[int] to List[float] in round_image_corners function. This is part of fixing powerpoint export errors, together with 

`PptxAutoShapeBoxModel` `border_radius: Optional[int] = None` → `Optional[float]`

PptxPictureBoxModel `border_radius: Optional[List[int]] = None` → `Optional[List[float]]`
 https://github.com/presenton/presenton/tree/main/electron/servers/fastapi/services/pptx_presentation_creator.py  `apply_border_radius_to_shape(self, shape, border_radius: Optional[int])` → `Optional[float]`
 https://github.com/presenton/presenton/tree/main/electron/servers/fastapi/utils/image_utils.py  `round_image_corners(image, radii: List[int])` → `List[float]`