### PR TITLE
fix: update download URL and version message in version.json

### DIFF
--- a/electron/app/utils/update-checker.ts
+++ b/electron/app/utils/update-checker.ts
@@ -11,6 +11,7 @@ const VERSION_JSON_URL =
   "https://raw.githubusercontent.com/presenton/presenton/refs/heads/main/electron/version.json";
 
 const CURRENT_VERSION = app.getVersion();
+const WEBSITE_DOWNLOAD_URL = "https://presenton.ai/download";
 
 /** Maximum number of fetch attempts (polls). */
 const MAX_ATTEMPTS = 3;
@@ -33,18 +34,11 @@ function log(msg: string): void {
 interface VersionResponse {
   version: string;
   message?: string;
-  downloads: {
+  downloads?: {
     linux: string;
     mac: string;
     windows: string;
   };
-}
-
-function getDownloadUrlForPlatform(downloads: VersionResponse["downloads"]): string {
-  const platform = process.platform;
-  if (platform === "darwin") return downloads.mac;
-  if (platform === "win32") return downloads.windows;
-  return downloads.linux;
 }
 
 /**
@@ -235,7 +229,7 @@ async function checkForUpdatesWithRetry(win: BrowserWindow): Promise<void> {
       const newer = isNewerVersion(CURRENT_VERSION, data.version);
       log(`Remote ${data.version} vs current ${CURRENT_VERSION} -> newer? ${newer}`);
       if (newer) {
-        const downloadUrl = getDownloadUrlForPlatform(data.downloads);
+        const downloadUrl = WEBSITE_DOWNLOAD_URL;
         log(`Injecting banner for ${data.version} (after ${INJECT_DELAY_MS}ms delay)`);
         scheduleBannerInjection(win, data.version, downloadUrl, data.message);
       } else {

--- a/electron/version.json
+++ b/electron/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.7.1-beta",
-  "message": "Air-gapped privacy, revamped UI, improved stability, model fixes & OCR support. Please check the changelog for more details.",
+  "message": "What's Changed\n\n- feat: add telemetry in electron app & UI improvements by @ShivaRajBadu in #488\n- feat: Providers logs and UI display by @ShivaRajBadu in #489\n- feat: enhance Codex user profile management with username, email, and profile fields by @sudipnext in #490\n- refactor: update UI components in settings & templates by @ShivaRajBadu in #494\n- feat: prompt engineering improvements by @sudipnext in #495\n- feat: enhanced presentation generation and asset handling by @sudipnext in #498\n- refactor: content updates and issue fixes by @ShivaRajBadu in #499\n- feat: better template generation across OpenAI, Google, Anthropic, and Codex by @sauravniraula in #501\n- fix: various issues by @sudipnext in #502\n- refactor: custom template improvements by @ShivaRajBadu in #503\n- refactor: launch screen switched to light theme by @sauravniraula in #504\n- feat: new templates by @ShivaRajBadu in #505",
   "downloads": {
     "linux": "https://github.com/presenton/presenton/releases/download/electron-v0.7.1-beta/Presenton-0.7.1-beta.deb",
     "mac": "https://github.com/presenton/presenton/releases/download/electron-v0.7.1-beta/Presenton-0.7.1-beta.dmg",


### PR DESCRIPTION
This pull request updates the update-checking mechanism in the Electron app to simplify how download URLs are handled and updates the release message in `version.json`. The most important changes are:

**Update URL Handling:**

* The platform-specific download URL logic in `update-checker.ts` was replaced with a single static `WEBSITE_DOWNLOAD_URL` (`https://presenton.ai/download`), so users will now always be directed to the main download page instead of platform-specific links. [[1]](diffhunk://#diff-46daaadb2d32cd7ccbafaffb9be34df6f049e0b1524238cfb4db327a74ae467cR14) [[2]](diffhunk://#diff-46daaadb2d32cd7ccbafaffb9be34df6f049e0b1524238cfb4db327a74ae467cL36-L49) [[3]](diffhunk://#diff-46daaadb2d32cd7ccbafaffb9be34df6f049e0b1524238cfb4db327a74ae467cL238-R232)

**Release Message Update:**

* The `message` field in `electron/version.json` was updated to provide a detailed changelog for version 0.7.1-beta, listing new features, improvements, and fixes included in this release.