### PR TITLE
fix: hide console window for export task on Windows

### DIFF
--- a/electron/app/ipc/export_handlers.ts
+++ b/electron/app/ipc/export_handlers.ts
@@ -63,6 +63,7 @@ export function setupExportHandlers() {
       const exportTaskProcess = spawn(process.execPath, [exportScriptPath, exportTaskPath], {
         stdio: ["ignore", "pipe", "pipe"],
         cwd: baseDir,
+        windowsHide: process.platform === "win32",
         env: {
           ...process.env,
           ELECTRON_RUN_AS_NODE: "1",


### PR DESCRIPTION
This pull request makes a minor update to the `setupExportHandlers` function to improve process handling on Windows systems.

* Process handling improvement:
  * [`electron/app/ipc/export_handlers.ts`](diffhunk://#diff-1b22ede4454239f832b5a167a578c70014e37323135b0a5e95b656297f30498eR66): Added the `windowsHide` option to the `spawn` call to ensure child windows are hidden when running on Windows (`process.platform === "win32"`).