### PR TITLE
Auth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,11 @@ Same variables as compose; use `-e` instead of `.env` when running `docker run` 
 <strong>Content-Type:</strong> <code>application/json</code>
 </p>
 
+<p>
+<strong>Authentication (HTTP Basic):</strong><br>
+All <code>/api/v1/</code> routes except <code>/api/v1/auth/*</code> require authentication. Send your Presenton admin username and password (same as the web UI, or <strong>AUTH_USERNAME</strong> / <strong>AUTH_PASSWORD</strong> when preseeding Docker). With <code>curl</code>, put them right after <code>-u</code> as <code>-u USERNAME:PASSWORD</code> — that is HTTP Basic auth and sets <code>Authorization: Basic …</code> for you. Replace the sample <code>sudipnext:sudipnext</code> below with your real credentials.
+</p>
+
 **Request Body**
 
 <table>
@@ -475,17 +480,19 @@ Options: <code>pptx</code>, <code>pdf</code>
   "edit_path": "string"
 }</code></pre>
 
-**Example Request**
+**Example (curl + HTTP Basic auth with <code>-u</code>)**
 
-<pre><code class="language-bash">curl -X POST http://localhost:5000/api/v1/ppt/presentation/generate \
+<pre><code class="language-bash">curl -u username:password \
+  -X POST http://localhost:5000/api/v1/ppt/presentation/generate \
   -H "Content-Type: application/json" \
   -d '{
-    "content": "Introduction to Machine Learning",
+   "content": "Introduction to Machine Learning",
     "n_slides": 5,
     "language": "English",
     "template": "general",
     "export_as": "pptx"
   }'</code></pre>
+
 
 **Example Response**
 

--- a/servers/fastapi/api/middlewares.py
+++ b/servers/fastapi/api/middlewares.py
@@ -3,7 +3,12 @@ from starlette.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from utils.get_env import get_can_change_keys_env
-from utils.simple_auth import get_auth_status, get_session_token_from_request
+from utils.simple_auth import (
+    get_auth_status,
+    get_basic_auth_credentials_from_request,
+    get_session_token_from_request,
+    verify_credentials,
+)
 from utils.user_config import update_env_with_user_config
 
 
@@ -55,6 +60,13 @@ class SessionAuthMiddleware(BaseHTTPMiddleware):
             )
 
         if not auth_status["authenticated"]:
+            basic_credentials = get_basic_auth_credentials_from_request(request)
+            if basic_credentials and verify_credentials(
+                basic_credentials[0], basic_credentials[1]
+            ):
+                request.state.auth_username = basic_credentials[0].strip()
+                return await call_next(request)
+
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Unauthorized"},

--- a/servers/fastapi/templates/get_layout_by_name.py
+++ b/servers/fastapi/templates/get_layout_by_name.py
@@ -2,12 +2,23 @@ import aiohttp
 from fastapi import HTTPException
 
 from templates.presentation_layout import PresentationLayoutModel
+from utils.simple_auth import (
+    SESSION_COOKIE_NAME,
+    create_session_token,
+    get_configured_auth_username,
+)
 
 
 async def get_layout_by_name(layout_name: str) -> PresentationLayoutModel:
     url = f"http://localhost/api/template?group={layout_name}"
+    headers = {}
+    auth_username = get_configured_auth_username()
+    if auth_username:
+        internal_token = create_session_token(auth_username)
+        headers["Cookie"] = f"{SESSION_COOKIE_NAME}={internal_token}"
+
     async with aiohttp.ClientSession() as session:
-        async with session.get(url) as response:
+        async with session.get(url, headers=headers) as response:
             if response.status != 200:
                 error_text = await response.text()
                 raise HTTPException(

--- a/servers/fastapi/utils/simple_auth.py
+++ b/servers/fastapi/utils/simple_auth.py
@@ -98,6 +98,14 @@ def is_auth_configured() -> bool:
     return bool(config.get("AUTH_USERNAME") and config.get("AUTH_PASSWORD_HASH"))
 
 
+def get_configured_auth_username() -> Optional[str]:
+    config = _load_user_config()
+    username = config.get("AUTH_USERNAME")
+    if isinstance(username, str) and username.strip():
+        return username.strip()
+    return None
+
+
 def setup_initial_credentials(username: str, password: str) -> None:
     cleaned_username = (username or "").strip()
     if len(cleaned_username) < 3:
@@ -242,6 +250,29 @@ def get_session_token_from_request(request: Request) -> Optional[str]:
         return auth_header[7:].strip() or None
 
     return None
+
+
+def get_basic_auth_credentials_from_request(
+    request: Request,
+) -> Optional[tuple[str, str]]:
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.lower().startswith("basic "):
+        return None
+
+    encoded_value = auth_header[6:].strip()
+    if not encoded_value:
+        return None
+
+    try:
+        decoded_value = base64.b64decode(encoded_value).decode("utf-8")
+    except Exception:
+        return None
+
+    if ":" not in decoded_value:
+        return None
+
+    username, password = decoded_value.split(":", 1)
+    return username, password
 
 
 def get_auth_status(session_token: Optional[str] = None) -> dict:


### PR DESCRIPTION
This pull request adds HTTP Basic authentication support to the API, updates the documentation to reflect this new authentication method, and improves internal authentication handling for service-to-service calls. The most important changes are grouped below.

**Authentication Enhancements:**

* Added support for HTTP Basic authentication to all `/api/v1/` routes (except `/api/v1/auth/*`). If session authentication fails, the middleware now checks for Basic Auth credentials and authenticates the user if valid. (`servers/fastapi/api/middlewares.py`, `servers/fastapi/utils/simple_auth.py`) [[1]](diffhunk://#diff-b4a33157686144b3ce453c2904e7cd87f2d57bae21d1ee611426ae8b91122023R63-R69) [[2]](diffhunk://#diff-2efc5eb53488b402e803c4e39c2f9d8115708ecfcedd062e6db0b402ef2af6c4R255-R277)
* Introduced a utility function `get_basic_auth_credentials_from_request` to extract and decode Basic Auth credentials from the request header. (`servers/fastapi/utils/simple_auth.py`)
* Added a helper function `get_configured_auth_username` to retrieve the configured admin username from environment or config. (`servers/fastapi/utils/simple_auth.py`)

**Internal Service Authentication:**

* When making internal requests to fetch presentation layouts, the service now programmatically authenticates using the configured admin username, ensuring secure internal API calls. (`servers/fastapi/templates/get_layout_by_name.py`)

**Documentation Updates:**

* Updated the `README.md` to clearly document HTTP Basic authentication requirements for API usage, and revised the example `curl` command to show how to use the `-u` flag for authentication. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R350-R354) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L478-R486)

These changes improve both the security and usability of the API by supporting standard authentication mechanisms and clarifying usage in the documentation.