### PR TITLE
fix: forward auth cookies to Puppeteer for PPTX export in Docker

### DIFF
--- a/electron/servers/nextjs/app/api/presentation_to_pptx_model/route.ts
+++ b/electron/servers/nextjs/app/api/presentation_to_pptx_model/route.ts
@@ -55,7 +55,8 @@ export async function GET(request: NextRequest) {
 
   try {
     const id = await getPresentationId(request);
-    [browser, page] = await getBrowserAndPage(id);
+    const cookieHeader = request.headers.get("cookie") ?? "";
+    [browser, page] = await getBrowserAndPage(id, cookieHeader);
     const screenshotsDir = getScreenshotsDir();
 
     const { slides, speakerNotes } = await getSlidesAndSpeakerNotes(page);
@@ -95,7 +96,7 @@ async function getPresentationId(request: NextRequest) {
   return id;
 }
 
-async function getBrowserAndPage(id: string): Promise<[Browser, Page]> {
+async function getBrowserAndPage(id: string, cookieHeader: string): Promise<[Browser, Page]> {
   const browser = await puppeteer.launch({
     executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
     headless: true,
@@ -114,6 +115,14 @@ async function getBrowserAndPage(id: string): Promise<[Browser, Page]> {
   });
 
   const page = await browser.newPage();
+
+  if (cookieHeader) {
+    const cookies = cookieHeader.split(";").map((pair) => {
+      const [name, ...rest] = pair.trim().split("=");
+      return { name: name.trim(), value: rest.join("=").trim(), domain: "localhost" };
+    }).filter((c) => c.name);
+    await page.setCookie(...cookies);
+  }
 
   await page.setViewport({ width: 1280, height: 720, deviceScaleFactor: 1 });
   page.setDefaultNavigationTimeout(300000);

--- a/servers/nextjs/app/api/presentation_to_pptx_model/route.ts
+++ b/servers/nextjs/app/api/presentation_to_pptx_model/route.ts
@@ -51,7 +51,8 @@ export async function GET(request: NextRequest) {
 
   try {
     const id = await getPresentationId(request);
-    [browser, page] = await getBrowserAndPage(id);
+    const cookieHeader = request.headers.get("cookie") ?? "";
+    [browser, page] = await getBrowserAndPage(id, cookieHeader);
     const screenshotsDir = getScreenshotsDir();
 
     const { slides, speakerNotes } = await getSlidesAndSpeakerNotes(page);
@@ -91,7 +92,7 @@ async function getPresentationId(request: NextRequest) {
   return id;
 }
 
-async function getBrowserAndPage(id: string): Promise<[Browser, Page]> {
+async function getBrowserAndPage(id: string, cookieHeader: string): Promise<[Browser, Page]> {
   const browser = await puppeteer.launch({
     executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
     headless: true,
@@ -110,6 +111,14 @@ async function getBrowserAndPage(id: string): Promise<[Browser, Page]> {
   });
 
   const page = await browser.newPage();
+
+  if (cookieHeader) {
+    const cookies = cookieHeader.split(";").map((pair) => {
+      const [name, ...rest] = pair.trim().split("=");
+      return { name: name.trim(), value: rest.join("=").trim(), domain: "localhost" };
+    }).filter((c) => c.name);
+    await page.setCookie(...cookies);
+  }
 
   await page.setViewport({ width: 1280, height: 720, deviceScaleFactor: 1 });
   page.setDefaultNavigationTimeout(300000);


### PR DESCRIPTION
## Summary

- When authentication is configured on a Docker deployment, the Puppeteer browser instance opens `pdf-maker` without any session cookie. All API requests inside the page return 401, the slides never render, and the export times out.
- Fix: extract the session cookie from the incoming Next.js request and inject it into the Puppeteer page via `page.setCookie()` before navigation.

## What and why

| File | Change |
|------|--------|
| `presentation_to_pptx_model/route.ts` | Read `cookie` header from request, parse it, and call `page.setCookie()` before `page.goto()` |

## Root cause

`/api/presentation_to_pptx_model` is called with the user's browser cookie, but Puppeteer launches a fresh browser with no cookies. The internal `GET /api/v1/ppt/presentation/:id` call made by the React page returns 401, `contentLoading` stays `true`, and slides never appear in the DOM.

This bug only affects Docker deployments where a username/password has been configured via `/api/v1/auth/setup`. Electron (unauthenticated by default) is unaffected.

## Test plan

- [x] Set up a Docker deployment with authentication enabled
- [x] Trigger PPTX export — export completes successfully with cookies forwarded
- [x] Confirmed Electron export still works (no cookie header present, branch is skipped)

## Notes

This is AI-assisted (Claude Sonnet 4.6). Code reviewed and tested by author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)