### PR TITLE
Add delete slide functionality and update related components

### DIFF
--- a/servers/fastapi/services/chat/memory_layer.py
+++ b/servers/fastapi/services/chat/memory_layer.py
@@ -370,6 +370,45 @@ class PresentationChatMemoryLayer:
             "shifted_slide_count": len(slides_to_shift),
         }
 
+    async def delete_slide(self, *, index: int) -> dict[str, Any]:
+        target_index = max(0, index)
+        slide = await self._sql_session.scalar(
+            select(SlideModel).where(
+                SlideModel.presentation == self._presentation_id,
+                SlideModel.index == target_index,
+            )
+        )
+        if not slide:
+            return {
+                "deleted": False,
+                "message": f"No slide found at index {target_index}.",
+                "index": target_index,
+            }
+
+        await self._sql_session.delete(slide)
+
+        slides_result = await self._sql_session.scalars(
+            select(SlideModel).where(SlideModel.presentation == self._presentation_id)
+        )
+        slides = sorted(list(slides_result), key=lambda each: each.index)
+        shifted_count = 0
+        for each_slide in slides:
+            if each_slide.index <= target_index:
+                continue
+            each_slide.index -= 1
+            self._sql_session.add(each_slide)
+            shifted_count += 1
+
+        await self._sql_session.commit()
+
+        return {
+            "deleted": True,
+            "message": f"Slide at index {target_index} was deleted successfully.",
+            "deleted_slide_id": str(slide.id),
+            "index": target_index,
+            "shifted_slide_count": shifted_count,
+        }
+
     async def retrieve_context(self, query: str) -> str:
         context = await MEM0_PRESENTATION_MEMORY_SERVICE.retrieve_context(
             self._presentation_id,

--- a/servers/fastapi/services/chat/prompts.py
+++ b/servers/fastapi/services/chat/prompts.py
@@ -41,6 +41,7 @@ def build_system_prompt(
         "- Start with compact reads: getPresentationOutline -> searchSlides -> getSlideAtIndex.\n"
         "- Set includeFullContent=true only when full JSON is required (typically right before saveSlide).\n"
         "- Before saveSlide, validate target layout/schema (getAvailableLayouts, getContentSchemaFromLayoutId).\n"
+        "- For removal requests, call deleteSlide with the zero-based target index.\n"
         "- Generate required assets in batch with generateAssets before saving.\n"
         "- saveSlide payload must match the schema exactly; do not invent fields.\n"
         "- If a tool fails, report it briefly and choose the best next step.\n"

--- a/servers/fastapi/services/chat/schemas.py
+++ b/servers/fastapi/services/chat/schemas.py
@@ -79,3 +79,7 @@ class SaveSlideInput(StrictSchemaModel):
             raise ValueError("'content' must be a JSON object.")
 
         return value
+
+
+class DeleteSlideInput(StrictSchemaModel):
+    index: int = Field(ge=0, le=1000)

--- a/servers/fastapi/services/chat/service.py
+++ b/servers/fastapi/services/chat/service.py
@@ -380,6 +380,7 @@ class PresentationChatService:
             "getContentSchemaFromLayoutId": "Checking the layout schema",
             "generateAssets": "Generating slide assets",
             "saveSlide": "Saving the slide",
+            "deleteSlide": "Deleting the slide",
         }
         return labels.get(tool_name, f"Running {tool_name}")
 

--- a/servers/fastapi/services/chat/tools.py
+++ b/servers/fastapi/services/chat/tools.py
@@ -7,6 +7,7 @@ import dirtyjson  # type: ignore[import-untyped]
 from llmai.shared import AssistantToolCall, Tool  # type: ignore[import-not-found]
 
 from services.chat.schemas import (
+    DeleteSlideInput,
     GenerateAssetsInput,
     GenerateIconInput,
     GenerateImageInput,
@@ -36,6 +37,7 @@ class ChatTools:
             "generateImage": self._generate_image,
             "generateIcon": self._generate_icon,
             "saveSlide": self._save_slide,
+            "deleteSlide": self._delete_slide,
         }
 
     def get_tool_definitions(self) -> list[Tool]:
@@ -110,6 +112,15 @@ class ChatTools:
                     "will validate it against layout schema before save."
                 ),
                 schema=SaveSlideInput,
+                strict=True,
+            ),
+            Tool(
+                name="deleteSlide",
+                description=(
+                    "Delete an existing slide by zero-based index and reindex the "
+                    "remaining slides. Use when the user asks to remove a slide."
+                ),
+                schema=DeleteSlideInput,
                 strict=True,
             ),
         ]
@@ -320,6 +331,10 @@ class ChatTools:
             index=payload.index,
             replace_old_slide_at_index=payload.replace_old_slide_at_index,
         )
+
+    async def _delete_slide(self, args: dict[str, Any]) -> dict[str, Any]:
+        payload = DeleteSlideInput(**args)
+        return await self._memory.delete_slide(index=payload.index)
 
     @staticmethod
     def _parse_args(arguments: str | None) -> dict[str, Any]:

--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/dashboard/components/PresentationCard.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/dashboard/components/PresentationCard.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from "react";
 
 import { Card } from "@/components/ui/card";
 import { DashboardApi } from "@/app/(presentation-generator)/services/api/dashboard";
-import { EllipsisVertical, Star, Trash } from "lucide-react";
+import { AlertTriangle, EllipsisVertical, Loader2, Trash } from "lucide-react";
 import {
   Popover,
   PopoverTrigger,
@@ -30,6 +30,8 @@ export const PresentationCard = ({
 }) => {
   const router = useRouter();
   const pathname = usePathname();
+  const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
+  const [isDeleting, setIsDeleting] = React.useState(false);
 
   const handlePreview = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -83,14 +85,12 @@ export const PresentationCard = ({
 
   }
 
-  const handleDelete = async (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-
+  const handleDelete = async () => {
+    if (isDeleting) return;
+    setIsDeleting(true);
     const response = await DashboardApi.deletePresentation(id);
 
-    if (response) {
+    if (response?.success) {
       trackEvent(MixpanelEvent.Dashboard_Presentation_Deleted, {
         pathname,
         presentation_id: id,
@@ -99,12 +99,14 @@ export const PresentationCard = ({
       toast.success("Presentation deleted", {
         description: "The presentation has been deleted successfully",
       });
+      setShowDeleteDialog(false);
       if (onDeleted) {
         onDeleted(id);
       }
     } else {
-      toast.error("Error deleting presentation");
+      toast.error(response?.message || "Error deleting presentation");
     }
+    setIsDeleting(false);
   };
   const firstSlide = presentation?.slides?.[0];
   return (
@@ -145,7 +147,11 @@ export const PresentationCard = ({
               <PopoverContent align="end" className="bg-white w-[200px]">
                 <button
                   className="flex items-center justify-between w-full px-2 py-1 hover:bg-gray-100"
-                  onClick={handleDelete}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setShowDeleteDialog(true);
+                  }}
                 >
                   <p>Delete</p>
                   <Trash className="w- h-4 text-red-500" />
@@ -156,6 +162,63 @@ export const PresentationCard = ({
 
         </div>
       </div>
+      {showDeleteDialog && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center animate-[fadeIn_150ms_ease-out]"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (isDeleting) return;
+            setShowDeleteDialog(false);
+          }}
+        >
+          <div className="absolute inset-0 bg-black/40 backdrop-blur-[2px]" />
+          <div
+            className="relative w-[360px] rounded-2xl bg-white shadow-2xl animate-[scaleIn_200ms_ease-out]"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+          >
+            <div className="flex flex-col items-center p-6 pb-4 text-center">
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-50">
+                <AlertTriangle className="h-6 w-6 text-red-500" />
+              </div>
+              <h3 className="mb-2 text-lg font-semibold text-[#191919]">
+                Delete Presentation?
+              </h3>
+              <p className="text-sm leading-relaxed text-gray-500">
+                You are about to delete{" "}
+                <span className="font-medium text-gray-700">&quot;{title}&quot;</span>.
+                This action cannot be undone.
+              </p>
+            </div>
+            <div className="flex border-t border-gray-100">
+              <button
+                onClick={() => setShowDeleteDialog(false)}
+                disabled={isDeleting}
+                className="flex-1 px-4 py-3.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => void handleDelete()}
+                disabled={isDeleting}
+                className="flex flex-1 items-center justify-center gap-2 border-l border-gray-100 px-4 py-3.5 text-sm font-medium text-red-500 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isDeleting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Deleting...
+                  </>
+                ) : (
+                  "Delete"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </Card>
   );
 };

--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/SettingPage.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/SettingPage.tsx
@@ -180,7 +180,7 @@ const SettingsPage = () => {
           }
         }
       }
-      notify.info(
+      notify.success(
         "Settings saved",
         "Your configuration was saved successfully."
       );

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/Chat.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/Chat.tsx
@@ -270,6 +270,7 @@ const TOOL_LABELS: Record<string, string> = {
   getContentSchemaFromLayoutId: "Schema checker",
   generateAssets: "Asset generator",
   saveSlide: "Slide saver",
+  deleteSlide: "Slide remover",
 };
 
 const getToolLabel = (tool?: string) => {
@@ -309,6 +310,9 @@ const humanizeTraceMessage = (message: string, tool?: string) => {
   }
   if (lower === "saving the slide") {
     return "Saving slide updates.";
+  }
+  if (lower === "deleting the slide") {
+    return "Deleting the slide.";
   }
   if (lower.startsWith("using tools:")) {
     const toolNames = trimmed
@@ -554,7 +558,9 @@ const Chat = ({
   };
 
   const refreshPresentationIfNeeded = async (toolCalls: string[]) => {
-    if (!toolCalls.includes("saveSlide") || !onPresentationChanged) {
+    const hasSlideMutation =
+      toolCalls.includes("saveSlide") || toolCalls.includes("deleteSlide");
+    if (!hasSlideMutation || !onPresentationChanged) {
       return;
     }
 


### PR DESCRIPTION
- Implemented `delete_slide` method in `PresentationChatMemoryLayer` to handle slide deletion and reindexing.
- Added `DeleteSlideInput` schema for input validation.
- Updated `ChatTools` to include the new `deleteSlide` tool with appropriate schema.
- Enhanced system prompts to include instructions for slide deletion.
- Modified `PresentationCard` component to support a delete confirmation dialog.
- Updated tool labels and messages in the chat component to reflect the new delete functionality.