### PR TITLE
fix(fastapi): serve locally-generated images as /app_data URLs in slide DOM

### DIFF
--- a/servers/fastapi/tests/unit/test_small_surfaces_coverage.py
+++ b/servers/fastapi/tests/unit/test_small_surfaces_coverage.py
@@ -29,6 +29,7 @@ from services.export_task_service import EXPORT_TASK_SERVICE
 from templates import get_layout_by_name as tpl_layout_fetcher
 from templates.presentation_layout import PresentationLayoutModel, SlideLayoutModel
 from utils import ocr_language
+from utils.asset_directory_utils import app_data_path_to_url
 from utils.datetime_utils import get_current_utc_datetime
 from utils.export_utils import export_presentation
 from utils.file_utils import (
@@ -276,6 +277,46 @@ def test_get_writable_path_app_data_fallback(monkeypatch, tmp_path):
     monkeypatch.delenv("APP_DATA_DIRECTORY", raising=False)
     cwd_path = get_writable_path("other/dir")
     assert cwd_path.startswith(os.path.abspath(str(tmp_path)))
+
+
+def test_app_data_path_to_url_converts_absolute_path(monkeypatch, tmp_path):
+    """Locally-generated images live under app_data and must be served via the
+    /app_data StaticFiles mount; an absolute filesystem path in <img src>
+    cannot be loaded by the browser."""
+    base = tmp_path / "appdata"
+    base.mkdir()
+    monkeypatch.setenv("APP_DATA_DIRECTORY", str(base))
+
+    abs_path = str(base / "presentations" / "abc" / "image.png")
+    assert app_data_path_to_url(abs_path) == "/app_data/presentations/abc/image.png"
+
+
+def test_app_data_path_to_url_passes_through_urls_and_web_paths(monkeypatch, tmp_path):
+    monkeypatch.setenv("APP_DATA_DIRECTORY", str(tmp_path))
+
+    # Stock providers (Pexels, Pixabay) and Open WebUI return http(s) URLs.
+    assert app_data_path_to_url("https://example.com/x.jpg") == "https://example.com/x.jpg"
+    # Already-served web paths must remain untouched.
+    assert app_data_path_to_url("/app_data/foo.png") == "/app_data/foo.png"
+    assert app_data_path_to_url("/static/icons/placeholder.svg") == "/static/icons/placeholder.svg"
+
+
+def test_app_data_path_to_url_returns_input_when_outside_app_data(monkeypatch, tmp_path):
+    base = tmp_path / "appdata"
+    base.mkdir()
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    monkeypatch.setenv("APP_DATA_DIRECTORY", str(base))
+
+    outside = str(other / "image.png")
+    # Paths outside app_data are passed through unchanged so callers can
+    # decide how to handle them (current behaviour: keep as-is).
+    assert app_data_path_to_url(outside) == outside
+
+
+def test_app_data_path_to_url_handles_empty_input():
+    assert app_data_path_to_url("") is None
+    assert app_data_path_to_url(None) is None  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(

--- a/servers/fastapi/utils/asset_directory_utils.py
+++ b/servers/fastapi/utils/asset_directory_utils.py
@@ -70,6 +70,45 @@ def resolve_image_path_to_filesystem(path_or_url: str) -> Optional[str]:
     return resolve_app_path_to_filesystem(path_or_url)
 
 
+def app_data_path_to_url(path: str) -> Optional[str]:
+    """
+    Convert an absolute filesystem path that lies under the app_data directory
+    into a browser-loadable URL served by the ``/app_data`` StaticFiles mount
+    (see ``api/main.py``).
+
+    Inputs that are already URLs (``http://``/``https://``) or already web
+    paths (``/app_data/...``, ``/static/...``) are passed through unchanged so
+    this helper is safe to apply to any image/asset URL the pipeline produces.
+
+    Returns ``None`` only for empty inputs.
+
+    The reverse direction is :func:`resolve_app_path_to_filesystem`.
+    """
+    if not path:
+        return None
+    # Already a URL or web path — pass through unchanged.
+    if path.startswith(("http://", "https://", "/app_data/", "/static/")):
+        return path
+
+    app_data = get_app_data_directory_env()
+    if not app_data:
+        return path
+
+    try:
+        norm_path = os.path.normpath(path)
+        norm_app_data = os.path.normpath(app_data)
+        common = os.path.commonpath([norm_path, norm_app_data])
+    except ValueError:
+        # commonpath raises on Windows when paths are on different drives.
+        return path
+
+    if common != norm_app_data:
+        return path
+
+    relative = os.path.relpath(norm_path, norm_app_data).replace(os.sep, "/")
+    return f"/app_data/{relative}"
+
+
 def get_images_directory():
     images_directory = os.path.join(get_app_data_directory_env(), "images")
     os.makedirs(images_directory, exist_ok=True)

--- a/servers/fastapi/utils/process_slides.py
+++ b/servers/fastapi/utils/process_slides.py
@@ -5,6 +5,7 @@ from models.sql.image_asset import ImageAsset
 from models.sql.slide import SlideModel
 from services.icon_finder_service import ICON_FINDER_SERVICE
 from services.image_generation_service import ImageGenerationService
+from utils.asset_directory_utils import app_data_path_to_url
 from utils.dict_utils import get_dict_at_path, get_dict_paths_with_key, set_dict_at_path
 
 
@@ -56,7 +57,15 @@ async def process_slide_and_fetch_assets(
             image_dict = get_dict_at_path(slide.content, asset_path)
             if isinstance(result, ImageAsset):
                 return_assets.append(result)
-                image_dict["__image_url__"] = result.path
+                # Locally-generated images (DALL-E, GPT-Image, Gemini Flash,
+                # ComfyUI, ...) come back as absolute filesystem paths. Convert
+                # them to web URLs served by the /app_data StaticFiles mount so
+                # the browser (editor preview + Puppeteer PDF/PPTX export) can
+                # actually load them. Stock providers (Pexels/Pixabay) already
+                # return http URLs and are handled by the else branch.
+                image_dict["__image_url__"] = (
+                    app_data_path_to_url(result.path) or result.path
+                )
             else:
                 image_dict["__image_url__"] = result
             set_dict_at_path(slide.content, asset_path, image_dict)
@@ -169,7 +178,12 @@ async def process_old_and_new_slides_and_fetch_assets(
             fetched_image = new_images[i]
             if isinstance(fetched_image, ImageAsset):
                 new_assets.append(fetched_image)
-                image_url = fetched_image.path
+                # See note in process_slide_and_fetch_assets: convert the
+                # absolute filesystem path returned by local image providers
+                # to a /app_data/... URL so the browser can render it.
+                image_url = (
+                    app_data_path_to_url(fetched_image.path) or fetched_image.path
+                )
             else:
                 image_url = fetched_image
             new_image_dicts[i]["__image_url__"] = image_url


### PR DESCRIPTION
## Summary

Closes #564.

Locally-generated images (DALL·E, GPT-Image-1.5, Gemini Flash, NanoBanana, ComfyUI) used to be stored as absolute filesystem paths in `__image_url__`. The browser cannot load those over HTTP, so images rendered as broken `<img>` tags in the editor preview and disappeared entirely from PDF/PPTX exports — the prompt text became visible via the `alt` attribute instead of the picture.

This PR converts the absolute path to a `/app_data/<relative>` URL in `process_slides.py` so the existing StaticFiles mount in `api/main.py` can serve it. Stock providers (Pexels, Pixabay) and Open WebUI URLs already came through as `https://…` and remain untouched.

## Changes
- `utils/asset_directory_utils.py` — new helper `app_data_path_to_url`, the inverse of the existing `resolve_app_path_to_filesystem`.
- `utils/process_slides.py` — apply the helper at the two `result.path → __image_url__` sites (`process_slide_and_fetch_assets`, `process_old_and_new_slides_and_fetch_assets`).
- `tests/unit/test_small_surfaces_coverage.py` — 4 unit tests covering: absolute path conversion, URL pass-through, out-of-tree paths, empty input.

## Test plan
- [x] `uv run pytest tests/unit/test_small_surfaces_coverage.py -k "app_data_path_to_url"` — 4 passed.
- [x] Manual: re-ran a presentation generation with `gpt-image-1.5` and exported as PDF — images now render correctly where they previously showed `alt` text.

## Notes
- Pre-existing failures in `test_get_layout_by_name_*` on `main` are unrelated to this change.