### PR TITLE
Fix/warmup huggingface download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --python /opt/venv/bin/python \
     "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
-RUN --mount=type=cache,target=/root/.cache \
-    /opt/venv/bin/python scripts/warm_fastembed_cache.py
+ENV HF_HOME=/root/.cache/huggingface \
+    PRESENTON_FASTEMBED_ICON_CACHE_DIR=/root/.cache/presenton/fastembed-icons
+# Warm FastEmbed caches into the image (not a BuildKit cache mount, or HF weights would be missing).
+RUN /opt/venv/bin/python scripts/warm_fastembed_cache.py
 
 
 FROM node:20-bookworm-slim AS nextjs-builder
@@ -81,6 +83,8 @@ ENV APP_DATA_DIRECTORY=/app_data \
     EXPORT_RUNTIME_DIR=/app/presentation-export \
     BUILT_PYTHON_MODULE_PATH=/app/presentation-export/py/convert-linux-x64 \
     PRESENTON_APP_ROOT=/app \
+    HF_HOME=/root/.cache/huggingface \
+    PRESENTON_FASTEMBED_ICON_CACHE_DIR=/root/.cache/presenton/fastembed-icons \
     PATH="/opt/venv/bin:${PATH}" \
     NODE_ENV=production \
     START_OLLAMA=false
@@ -99,6 +103,8 @@ RUN mkdir -p /app/scripts /app/servers/fastapi /app/servers/nextjs
 
 COPY --from=fastapi-builder /opt/venv /opt/venv
 COPY --from=fastapi-builder /app/servers/fastapi /app/servers/fastapi
+COPY --from=fastapi-builder /root/.cache/huggingface /root/.cache/huggingface
+COPY --from=fastapi-builder /root/.cache/presenton/fastembed-icons /root/.cache/presenton/fastembed-icons
 
 COPY --from=assets-builder /app/package.json /app/package.json
 COPY --from=assets-builder /app/document-extraction-liteparse /app/document-extraction-liteparse

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,7 +14,9 @@ ENV APP_DATA_DIRECTORY=/app_data \
     EXPORT_PACKAGE_ROOT=/app/presentation-export \
     EXPORT_RUNTIME_DIR=/app/presentation-export \
     BUILT_PYTHON_MODULE_PATH=/app/presentation-export/py/convert-linux-x64 \
-    PRESENTON_APP_ROOT=/app
+    PRESENTON_APP_ROOT=/app \
+    HF_HOME=/root/.cache/huggingface \
+    PRESENTON_FASTEMBED_ICON_CACHE_DIR=/root/.cache/presenton/fastembed-icons
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl unzip \
@@ -53,6 +55,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system \
     "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
+
+# FastEmbed + Hugging Face Hub weights for icon search and Mem0 (no cache-only mount here:
+# those files must remain in the image layer).
+WORKDIR /app/servers/fastapi
+RUN python scripts/warm_fastembed_cache.py
 
 WORKDIR /app
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/electron/app/main.ts
+++ b/electron/app/main.ts
@@ -160,22 +160,8 @@ const createWindow = () => {
     win.show();
     win.focus();
   });
-};
 
-function registerDevToolsShortcuts(): void {
-  const accelerators = ["CommandOrControl+Shift+I", "F12"];
-  for (const accelerator of accelerators) {
-    const registered = globalShortcut.register(accelerator, () => {
-      if (!win || win.isDestroyed()) {
-        return;
-      }
-      win.webContents.toggleDevTools();
-    });
-    if (!registered) {
-      console.warn(`[Presenton] Failed to register ${accelerator} for DevTools`);
-    }
-  }
-}
+};
 
 async function startServers(fastApiPort: number, nextjsPort: number) {
   try {
@@ -216,7 +202,6 @@ async function startServers(fastApiPort: number, nextjsPort: number) {
         DALL_E_3_QUALITY: process.env.DALL_E_3_QUALITY,
         GPT_IMAGE_1_5_QUALITY: process.env.GPT_IMAGE_1_5_QUALITY,
         APP_DATA_DIRECTORY: appDataDir,
-        FASTAPI_PUBLIC_URL: process.env.NEXT_PUBLIC_FAST_API,
         TEMP_DIRECTORY: tempDir,
         USER_CONFIG_PATH: userConfigPath,
         MIGRATE_DATABASE_ON_STARTUP: "True",
@@ -249,7 +234,6 @@ async function startServers(fastApiPort: number, nextjsPort: number) {
       nextjsPort,
       {
         NEXT_PUBLIC_FAST_API: process.env.NEXT_PUBLIC_FAST_API,
-        FAST_API_INTERNAL_URL: process.env.NEXT_PUBLIC_FAST_API,
         TEMP_DIRECTORY: process.env.TEMP_DIRECTORY,
         NEXT_PUBLIC_URL: process.env.NEXT_PUBLIC_URL,
         NEXT_PUBLIC_USER_CONFIG_PATH: process.env.NEXT_PUBLIC_USER_CONFIG_PATH,
@@ -322,7 +306,6 @@ app.whenReady().then(async () => {
 
   // Create main window before setup so that when user skips, the main window stays open
   createWindow();
-  registerDevToolsShortcuts();
   win?.loadFile(path.join(baseDir, "resources/ui/homepage/index.html"));
 
   // Single installer: checks LibreOffice, Chrome, and ImageMagick; if any are missing, shows one

--- a/electron/app/types/index.d.ts
+++ b/electron/app/types/index.d.ts
@@ -28,7 +28,8 @@ interface FastApiEnv {
   DALL_E_3_QUALITY?: string,
   GPT_IMAGE_1_5_QUALITY?: string,
   APP_DATA_DIRECTORY?: string,
-  FASTAPI_PUBLIC_URL?: string,
+  /** Same origin the Next.js app uses for FastAPI (assets + API). Passed through to Python. */
+  NEXT_PUBLIC_FAST_API?: string,
   TEMP_DIRECTORY?: string,
   USER_CONFIG_PATH?: string,
   MIGRATE_DATABASE_ON_STARTUP?: string,
@@ -53,6 +54,7 @@ interface FastApiEnv {
 
 interface NextJsEnv {
   NEXT_PUBLIC_FAST_API?: string,
+  /** Optional Docker-only: SSR/middleware reach FastAPI on a different base than the browser. */
   FAST_API_INTERNAL_URL?: string,
   TEMP_DIRECTORY?: string,
   NEXT_PUBLIC_URL?: string,

--- a/electron/app/utils/index.ts
+++ b/electron/app/utils/index.ts
@@ -36,7 +36,6 @@ export function setupEnv(fastApiPort: number, nextjsPort: number) {
   process.env.SENTRY_RELEASE = process.env.SENTRY_RELEASE || `presenton-electron@${process.env.APP_VERSION}`;
   process.env.SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT || (app.isPackaged ? 'production' : 'development');
   process.env.NEXT_PUBLIC_FAST_API = `${localhost}:${fastApiPort}`;
-  process.env.FASTAPI_PUBLIC_URL = process.env.NEXT_PUBLIC_FAST_API;
   process.env.TEMP_DIRECTORY = tempDir;
   process.env.NEXT_PUBLIC_USER_CONFIG_PATH = userConfigPath;
   process.env.NEXT_PUBLIC_URL = `${localhost}:${nextjsPort}`;

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presenton",
-  "version": "0.8.0-beta",
+  "version": "0.8.3-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presenton",
-      "version": "0.8.0-beta",
+      "version": "0.8.3-beta",
       "hasInstallScript": true,
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.2",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "presenton",
   "productName": "Presenton Open Source",
-  "version": "0.8.0-beta",
+  "version": "0.8.3-beta",
   "exportVersion": "v0.2.6",
   "main": "app_dist/main.js",
   "description": "Open-Source AI Presentation Generator",

--- a/electron/version.json
+++ b/electron/version.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.8.0-beta",
+  "version": "0.8.3-beta",
   "message": "Presenton Desktop electron-v0.7.3-beta\n\nSmarter content generation, reliable web search, no more shady Windows popups, and a round of minor fixes under the hood. Clean update. 🙌\n\nWhat's New\n\n🧠 Smarter Slide Content Generation\n• Overflow mitigation loop added — slides no longer clip or overflow when content runs long\n• Improved system prompt for slide content generation — cleaner, better-fitting output every time\n\n🔍 Web Search Fixed\n• Web search is back to working reliably during presentation generation\n\n🪟 Windows Fix\n• Export tasks no longer flash a console window on Windows — cleaner, more polished experience\n\n🔧 Minor Fixes\n• Various small fixes and stability improvements across the app\n\n---\nView full diff: electron-v0.7.2-beta → electron-v0.7.3-beta\nhttps://github.com/presenton/presenton/compare/electron-v0.7.2-beta...electron-v0.7.3-beta\n\nInstallation\nDownload Link: https://presenton.ai/download\nLove the app? Star us on GitHub → github.com/presenton/presenton",
   "downloads": {
-    "linux": "https://github.com/presenton/presenton/releases/download/electron-v0.8.0-beta/Presenton-0.8.0-beta.deb",
-    "mac": "https://github.com/presenton/presenton/releases/download/electron-v0.8.0-beta/Presenton-0.8.0-beta.dmg",
-    "windows": "https://github.com/presenton/presenton/releases/download/electron-v0.8.0-beta/Presenton-0.8.0-beta.exe"
+    "linux": "https://github.com/presenton/presenton/releases/download/electron-v0.8.3-beta/Presenton-0.8.3-beta.deb",
+    "mac": "https://github.com/presenton/presenton/releases/download/electron-v0.8.3-beta/Presenton-0.8.3-beta.dmg",
+    "windows": "https://github.com/presenton/presenton/releases/download/electron-v0.8.3-beta/Presenton-0.8.3-beta.exe"
   }
 }

--- a/servers/fastapi/api/v1/mock/router.py
+++ b/servers/fastapi/api/v1/mock/router.py
@@ -4,6 +4,8 @@ from models.api_error_model import APIErrorModel
 from models.presentation_and_path import PresentationPathAndEditPath
 from typing import List
 
+from utils.asset_directory_utils import absolute_fastapi_asset_url
+
 API_V1_MOCK_ROUTER = APIRouter(prefix="/api/v1/mock", tags=["Mock"])
 
 
@@ -15,7 +17,7 @@ async def mock_presentation_generation_completed():
     return [
         PresentationPathAndEditPath(
             presentation_id=uuid.uuid4(),
-            path="/app_data/exports/test.pdf",
+            path=absolute_fastapi_asset_url("/app_data/exports/test.pdf"),
             edit_path="/presentation?id=123",
         )
     ]

--- a/servers/fastapi/api/v1/ppt/endpoints/fonts.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/fonts.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any, Optional
 from fastapi import APIRouter, HTTPException, File, UploadFile
 from pydantic import BaseModel
 from templates.preview import FontCheckResponse, check_fonts_in_pptx_handler
-from utils.asset_directory_utils import get_app_data_directory_env
+from utils.asset_directory_utils import absolute_fastapi_asset_url, get_app_data_directory_env
 
 try:
     from fontTools.ttLib import TTFont
@@ -171,7 +171,7 @@ async def upload_font(
             shutil.copyfileobj(font_file.file, buffer)
         
         # Generate accessible URL
-        font_url = f"/app_data/fonts/{unique_filename}"
+        font_url = absolute_fastapi_asset_url(f"/app_data/fonts/{unique_filename}")
         
         return FontUploadResponse(
             success=True,
@@ -228,7 +228,7 @@ async def list_fonts():
                             "filename": filename,
                             "font_name": font_name,  # Real font family name from metadata
                             "original_name": base_name,
-                            "font_url": f"/app_data/fonts/{filename}",
+                            "font_url": absolute_fastapi_asset_url(f"/app_data/fonts/{filename}"),
                             "font_type": SUPPORTED_FONT_EXTENSIONS.get(file_ext, 'unknown'),
                             "file_size": os.path.getsize(file_path)
                         })
@@ -272,7 +272,7 @@ async def get_uploaded_fonts():
                     {
                         "id": filename,
                         "name": font_name,
-                        "url": f"/app_data/fonts/{filename}",
+                        "url": absolute_fastapi_asset_url(f"/app_data/fonts/{filename}"),
                     }
                 )
 

--- a/servers/fastapi/api/v1/ppt/endpoints/images.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/images.py
@@ -7,7 +7,11 @@ from models.image_prompt import ImagePrompt
 from models.sql.image_asset import ImageAsset
 from services.database import get_async_session
 from services.image_generation_service import ImageGenerationService
-from utils.asset_directory_utils import get_images_directory
+from utils.asset_directory_utils import (
+    filesystem_image_path_to_app_data_url,
+    get_images_directory,
+    normalize_slide_asset_url,
+)
 from utils.get_env import get_pexels_api_key_env, get_pixabay_api_key_env
 from utils.image_provider import get_selected_image_provider
 from enums.image_provider import ImageProvider
@@ -97,15 +101,26 @@ async def generate_image(
 
     image = await image_generation_service.generate_image(image_prompt)
     if not isinstance(image, ImageAsset):
-        return image
+        return normalize_slide_asset_url(image) if isinstance(image, str) else image
 
     sql_session.add(image)
     await sql_session.commit()
 
-    return image.path
+    return filesystem_image_path_to_app_data_url(image.path)
 
 
-@IMAGES_ROUTER.get("/generated", response_model=List[ImageAsset])
+def _image_asset_api_dict(asset: ImageAsset) -> dict:
+    return {
+        "id": asset.id,
+        "created_at": asset.created_at,
+        "is_uploaded": asset.is_uploaded,
+        "path": asset.path,
+        "extras": asset.extras,
+        "file_url": filesystem_image_path_to_app_data_url(asset.path),
+    }
+
+
+@IMAGES_ROUTER.get("/generated")
 async def get_generated_images(sql_session: AsyncSession = Depends(get_async_session)):
     try:
         images_result = await sql_session.scalars(
@@ -113,7 +128,7 @@ async def get_generated_images(sql_session: AsyncSession = Depends(get_async_ses
             .where(ImageAsset.is_uploaded == False)
             .order_by(ImageAsset.created_at.desc())
         )
-        return list(images_result)
+        return [_image_asset_api_dict(a) for a in images_result]
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"Failed to retrieve generated images: {str(e)}"
@@ -140,12 +155,12 @@ async def upload_image(
         # Refresh to ensure all defaults are loaded
         await sql_session.refresh(image_asset)
 
-        return image_asset
+        return _image_asset_api_dict(image_asset)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to upload image: {str(e)}")
 
 
-@IMAGES_ROUTER.get("/uploaded", response_model=List[ImageAsset])
+@IMAGES_ROUTER.get("/uploaded")
 async def get_uploaded_images(sql_session: AsyncSession = Depends(get_async_session)):
     try:
         images_result = await sql_session.scalars(
@@ -153,7 +168,7 @@ async def get_uploaded_images(sql_session: AsyncSession = Depends(get_async_sess
             .where(ImageAsset.is_uploaded == True)
             .order_by(ImageAsset.created_at.desc())
         )
-        return list(images_result)
+        return [_image_asset_api_dict(a) for a in images_result]
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"Failed to retrieve uploaded images: {str(e)}"

--- a/servers/fastapi/api/v1/ppt/endpoints/pdf_slides.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/pdf_slides.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, UploadFile, File, HTTPException
 from pydantic import BaseModel
 
 from services.documents_loader import DocumentsLoader
-from utils.asset_directory_utils import get_images_directory
+from utils.asset_directory_utils import absolute_fastapi_asset_url, get_images_directory
 import uuid
 from constants.documents import PDF_MIME_TYPES
 
@@ -94,12 +94,14 @@ async def process_pdf_slides(
                 ):
                     # Use shutil.copy2 instead of os.rename to handle cross-device moves
                     shutil.copy2(screenshot_path, permanent_screenshot_path)
-                    screenshot_url = (
+                    screenshot_url = absolute_fastapi_asset_url(
                         f"/app_data/images/{presentation_id}/{screenshot_filename}"
                     )
                 else:
                     # Fallback if screenshot generation failed or file is empty placeholder
-                    screenshot_url = "/static/images/replaceable_template_image.png"
+                    screenshot_url = absolute_fastapi_asset_url(
+                        "/static/images/replaceable_template_image.png"
+                    )
 
                 slides_data.append(
                     PdfSlideData(slide_number=i, screenshot_url=screenshot_url)

--- a/servers/fastapi/api/v1/ppt/endpoints/pptx_slides.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/pptx_slides.py
@@ -13,7 +13,7 @@ import xml.etree.ElementTree as ET
 import re
 
 from services.documents_loader import DocumentsLoader
-from utils.asset_directory_utils import get_images_directory
+from utils.asset_directory_utils import absolute_fastapi_asset_url, get_images_directory
 import uuid
 from constants.documents import POWERPOINT_TYPES
 
@@ -373,12 +373,14 @@ async def process_pptx_slides(
                 ):
                     # Use shutil.copy2 instead of os.rename to handle cross-device moves
                     shutil.copy2(screenshot_path, permanent_screenshot_path)
-                    screenshot_url = (
+                    screenshot_url = absolute_fastapi_asset_url(
                         f"/app_data/images/{presentation_id}/{screenshot_filename}"
                     )
                 else:
                     # Fallback if screenshot generation failed or file is empty placeholder
-                    screenshot_url = "/static/images/replaceable_template_image.png"
+                    screenshot_url = absolute_fastapi_asset_url(
+                        "/static/images/replaceable_template_image.png"
+                    )
 
                 # Compute normalized fonts for this slide
                 raw_slide_fonts = extract_fonts_from_oxml(xml_content)

--- a/servers/fastapi/api/v1/ppt/endpoints/theme.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/theme.py
@@ -10,6 +10,7 @@ from sqlmodel import select
 from models.sql.image_asset import ImageAsset
 from models.sql.key_value import KeyValueSqlModel
 from services.database import get_async_session
+from utils.asset_directory_utils import normalize_slide_asset_url
 
 THEMES_ROUTER = APIRouter(prefix="/themes", tags=["Themes"])
 THEMES_STORAGE_KEY = "presentation_custom_themes"
@@ -45,13 +46,21 @@ class ThemeResponse(BaseModel):
 
 
 def _normalize_theme(theme: dict[str, Any]) -> ThemeResponse:
+    raw_logo_url = theme.get("logo_url")
+    if raw_logo_url is None:
+        logo_url = None
+    elif isinstance(raw_logo_url, str):
+        s = raw_logo_url.strip()
+        logo_url = normalize_slide_asset_url(s) if s else None
+    else:
+        logo_url = raw_logo_url
     return ThemeResponse(
         id=str(theme["id"]),
         name=theme["name"],
         description=theme["description"],
         user=theme.get("user", "local"),
         logo=theme.get("logo"),
-        logo_url=theme.get("logo_url"),
+        logo_url=logo_url,
         company_name=theme.get("company_name"),
         data=theme.get("data", {}),
     )
@@ -86,7 +95,7 @@ async def _resolve_logo_url(
     image_asset = await sql_session.get(ImageAsset, logo_uuid)
     if not image_asset:
         raise HTTPException(status_code=404, detail="Logo not found")
-    return image_asset.path
+    return normalize_slide_asset_url(image_asset.path)
 
 
 @THEMES_ROUTER.get("/default", response_model=List[dict[str, Any]])

--- a/servers/fastapi/scripts/warm_fastembed_cache.py
+++ b/servers/fastapi/scripts/warm_fastembed_cache.py
@@ -1,4 +1,12 @@
+"""Pre-download FastEmbed / Hugging Face weights at Docker image build time.
+
+Icon search uses AllMiniLML6V2 into ``fastembed_cache`` under the package tree.
+Mem0 OSS defaults to ``BAAI/bge-small-en-v1.5`` via Hugging Face Hub under
+``HF_HOME`` (default ``~/.cache/huggingface``).
+"""
+
 from pathlib import Path
+import os
 import sys
 
 
@@ -10,6 +18,23 @@ if str(FASTAPI_ROOT) not in sys.path:
 from services.icon_finder_service import ICON_FINDER_SERVICE
 
 
+def _warm_mem0_default_fastembed() -> None:
+    provider = (os.getenv("MEM0_EMBEDDER_PROVIDER") or "fastembed").strip() or "fastembed"
+    if provider != "fastembed":
+        print(
+            f"Skipping Mem0 embedder warmup (MEM0_EMBEDDER_PROVIDER={provider!r}, not fastembed)"
+        )
+        return
+    model = (os.getenv("MEM0_EMBEDDER_MODEL") or "BAAI/bge-small-en-v1.5").strip() or (
+        "BAAI/bge-small-en-v1.5"
+    )
+    from fastembed import TextEmbedding
+
+    embedder = TextEmbedding(model_name=model)
+    next(embedder.embed(["warmup"]))
+    print(f"Mem0 default fastembed model warmed: {model}")
+
+
 def main() -> None:
     if not ICON_FINDER_SERVICE.ensure_initialized():
         raise RuntimeError("Failed to prepare fastembed cache for icon search")
@@ -17,6 +42,7 @@ def main() -> None:
     print(
         f"Fastembed cache prepared at {ICON_FINDER_SERVICE.cache_directory}"
     )
+    _warm_mem0_default_fastembed()
 
 
 if __name__ == "__main__":

--- a/servers/fastapi/server.py
+++ b/servers/fastapi/server.py
@@ -15,8 +15,8 @@ if __name__ == "__main__":
     reload = args.reload == "true"
     host = "127.0.0.1"
 
-    # Always bind absolute asset generation to the active runtime port.
-    os.environ["FASTAPI_PUBLIC_URL"] = f"http://{host}:{args.port}"
+    # Bind asset/base URL generation to the active runtime port (same env name as Next/Electron).
+    os.environ["NEXT_PUBLIC_FAST_API"] = f"http://{host}:{args.port}"
     
     uvicorn.run(
         "api.main:app",

--- a/servers/fastapi/services/chat/memory_layer.py
+++ b/servers/fastapi/services/chat/memory_layer.py
@@ -17,7 +17,11 @@ from services.icon_finder_service import ICON_FINDER_SERVICE
 from services.image_generation_service import ImageGenerationService
 from services.mem0_presentation_memory_service import MEM0_PRESENTATION_MEMORY_SERVICE
 from templates.presentation_layout import SlideLayoutModel
-from utils.asset_directory_utils import get_images_directory
+from utils.asset_directory_utils import (
+    filesystem_image_path_to_app_data_url,
+    get_images_directory,
+    normalize_slide_asset_url,
+)
 from utils.process_slides import (
     process_old_and_new_slides_and_fetch_assets,
     process_slide_and_fetch_assets,
@@ -220,15 +224,15 @@ class PresentationChatMemoryLayer:
         if isinstance(image, ImageAsset):
             self._sql_session.add(image)
             await self._sql_session.commit()
-            return image.path
+            return filesystem_image_path_to_app_data_url(image.path)
 
-        return str(image)
+        return normalize_slide_asset_url(str(image))
 
     async def generate_icon(self, query: str) -> str:
         icons = await ICON_FINDER_SERVICE.search_icons(query, k=1)
         if icons:
-            return icons[0]
-        return "/static/icons/placeholder.svg"
+            return normalize_slide_asset_url(icons[0])
+        return normalize_slide_asset_url("/static/icons/placeholder.svg")
 
     async def save_slide(
         self,

--- a/servers/fastapi/services/export_task_service.py
+++ b/servers/fastapi/services/export_task_service.py
@@ -131,13 +131,13 @@ class ExportTaskService:
         os.makedirs(temp_directory, exist_ok=True)
         env["TEMP_DIRECTORY"] = temp_directory
 
-        fastapi_public_url = (os.getenv("FASTAPI_PUBLIC_URL") or "").strip()
-        if not fastapi_public_url:
+        fastapi_base = (os.getenv("NEXT_PUBLIC_FAST_API") or "").strip()
+        if not fastapi_base:
             raise HTTPException(
                 status_code=500,
-                detail="FASTAPI_PUBLIC_URL must be set for PPTX-to-HTML export",
+                detail="NEXT_PUBLIC_FAST_API must be set for PPTX-to-HTML export",
             )
-        env["ASSETS_BASE_URL"] = f"{fastapi_public_url.rstrip('/')}/app_data"
+        env["ASSETS_BASE_URL"] = f"{fastapi_base.rstrip('/')}/app_data"
         env["BUILT_PYTHON_MODULE_PATH"] = self.converter_path
 
         return env

--- a/servers/fastapi/services/icon_finder_service.py
+++ b/servers/fastapi/services/icon_finder_service.py
@@ -6,11 +6,22 @@ from utils.asset_directory_utils import absolute_fastapi_asset_url
 from utils.path_helpers import get_resource_path, get_writable_path
 
 
+def _icon_fastembed_cache_directory() -> str:
+    """ONNX weights for icon search (MiniLM). Prefer a path outside ``APP_DATA_DIRECTORY``
+    in Docker: ``./app_data`` is often bind-mounted and would hide weights baked at image build.
+    """
+    override = (os.getenv("PRESENTON_FASTEMBED_ICON_CACHE_DIR") or "").strip()
+    if override:
+        path = os.path.abspath(override)
+        os.makedirs(path, exist_ok=True)
+        return path
+    return get_writable_path("fastembed_cache")
+
+
 class IconFinderService:
     def __init__(self):
         self.model = FastembedEmbeddingModel.AllMiniLML6V2
-        # Use writable path for cache since it needs to be modified
-        self.cache_directory = get_writable_path("fastembed_cache")
+        self.cache_directory = _icon_fastembed_cache_directory()
         self.vectorstore = None
         self._initialized = False
         self._initialization_failed = False

--- a/servers/fastapi/services/icon_finder_service.py
+++ b/servers/fastapi/services/icon_finder_service.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 from fastembed_vectorstore import FastembedEmbeddingModel, FastembedVectorstore
+from utils.asset_directory_utils import absolute_fastapi_asset_url
 from utils.path_helpers import get_resource_path, get_writable_path
 
 
@@ -125,7 +126,9 @@ class IconFinderService:
         try:
             result = await asyncio.to_thread(self.vectorstore.search, query, k)
             return [
-                f"/static/icons/bold/{each[0].split('||')[0]}.svg"
+                absolute_fastapi_asset_url(
+                    f"/static/icons/bold/{each[0].split('||')[0]}.svg"
+                )
                 for each in result
             ]
         except Exception as e:

--- a/servers/fastapi/services/image_generation_service.py
+++ b/servers/fastapi/services/image_generation_service.py
@@ -30,6 +30,7 @@ from utils.image_provider import (
     is_comfyui_selected,
     is_open_webui_selected,
 )
+from utils.asset_directory_utils import absolute_fastapi_asset_url
 import uuid
 
 
@@ -74,11 +75,11 @@ class ImageGenerationService:
         """
         if self.is_image_generation_disabled:
             print("Image generation is disabled. Using placeholder image.")
-            return "/static/images/placeholder.jpg"
+            return absolute_fastapi_asset_url("/static/images/placeholder.jpg")
 
         if not self.image_gen_func:
             print("No image generation function found. Using placeholder image.")
-            return "/static/images/placeholder.jpg"
+            return absolute_fastapi_asset_url("/static/images/placeholder.jpg")
 
         image_prompt = prompt.get_image_prompt(
             with_theme=not self.is_stock_provider_selected()
@@ -107,12 +108,12 @@ class ImageGenerationService:
                 elif image_path.startswith("/app_data/") or image_path.startswith(
                     "/static/"
                 ):
-                    return image_path
+                    return absolute_fastapi_asset_url(image_path)
             raise Exception(f"Image not found at {image_path}")
 
         except Exception as e:
             print(f"Error generating image: {e}")
-            return "/static/images/placeholder.jpg"
+            return absolute_fastapi_asset_url("/static/images/placeholder.jpg")
 
     async def generate_image_openai(
         self, prompt: str, output_directory: str, model: str, quality: str

--- a/servers/fastapi/templates/example.py
+++ b/servers/fastapi/templates/example.py
@@ -1,9 +1,15 @@
 from typing import Any
 
 from templates.presentation_layout import PresentationLayoutModel
+from utils.asset_directory_utils import absolute_fastapi_asset_url
 
-PLACEHOLDER_IMAGE_URL = "/static/images/replaceable_template_image.png"
-PLACEHOLDER_ICON_URL = "/static/icons/placeholder.svg"
+
+def placeholder_image_url() -> str:
+    return absolute_fastapi_asset_url("/static/images/replaceable_template_image.png")
+
+
+def placeholder_icon_url() -> str:
+    return absolute_fastapi_asset_url("/static/icons/placeholder.svg")
 
 
 def build_schema_example(schema: dict) -> Any:
@@ -43,9 +49,9 @@ def build_schema_example(schema: dict) -> Any:
     if schema_type == "string":
         schema_description = (schema.get("description") or "").lower()
         if "icon" in schema_description:
-            return PLACEHOLDER_ICON_URL
+            return placeholder_icon_url()
         if "image" in schema_description or "url" in schema_description:
-            return PLACEHOLDER_IMAGE_URL
+            return placeholder_image_url()
         return "Sample text"
 
     if schema_type == "integer":
@@ -65,9 +71,9 @@ def replace_special_placeholders(value: Any) -> Any:
         result = {}
         for key, child in value.items():
             if key == "__image_url__":
-                result[key] = PLACEHOLDER_IMAGE_URL
+                result[key] = placeholder_image_url()
             elif key == "__icon_url__":
-                result[key] = PLACEHOLDER_ICON_URL
+                result[key] = placeholder_icon_url()
             else:
                 result[key] = replace_special_placeholders(child)
         return result
@@ -76,9 +82,9 @@ def replace_special_placeholders(value: Any) -> Any:
         return [replace_special_placeholders(item) for item in value]
 
     if value == "__image_url__":
-        return PLACEHOLDER_IMAGE_URL
+        return placeholder_image_url()
     if value == "__icon_url__":
-        return PLACEHOLDER_ICON_URL
+        return placeholder_icon_url()
     return value
 
 

--- a/servers/fastapi/templates/preview.py
+++ b/servers/fastapi/templates/preview.py
@@ -20,6 +20,7 @@ from templates.font_utils import (
     get_available_and_unavailable_fonts,
 )
 from utils.get_env import get_app_data_directory_env
+from utils.asset_directory_utils import absolute_fastapi_asset_url
 
 try:
     from fontTools.ttLib import TTFont
@@ -206,7 +207,7 @@ async def _persist_custom_fonts(
         stored_fonts.append(
             StoredFont(
                 display_name=display_name,
-                url=f"/app_data/fonts/{unique_name}",
+                url=absolute_fastapi_asset_url(f"/app_data/fonts/{unique_name}"),
                 temp_path=temp_font_path,
             )
         )
@@ -365,9 +366,15 @@ async def store_slide_images(
 
         if os.path.exists(screenshot_path) and os.path.getsize(screenshot_path) > 0:
             await asyncio.to_thread(_copy_file, screenshot_path, destination_path)
-            slide_image_urls.append(f"/app_data/images/{session_id}/{file_name}")
+            slide_image_urls.append(
+                absolute_fastapi_asset_url(f"/app_data/images/{session_id}/{file_name}")
+            )
         else:
-            slide_image_urls.append("/static/images/replaceable_template_image.png")
+            slide_image_urls.append(
+                absolute_fastapi_asset_url(
+                    "/static/images/replaceable_template_image.png"
+                )
+            )
 
     return slide_image_urls
 
@@ -382,7 +389,9 @@ async def store_uploaded_pptx(
 
     destination_path = os.path.join(target_dir, "presentation.pptx")
     await asyncio.to_thread(_copy_file, pptx_path, destination_path)
-    return f"/app_data/uploads/template-previews/{session_id}/presentation.pptx"
+    return absolute_fastapi_asset_url(
+        f"/app_data/uploads/template-previews/{session_id}/presentation.pptx"
+    )
 
 
 async def get_available_and_unavailable_fonts_for_pptx(

--- a/servers/fastapi/utils/asset_directory_utils.py
+++ b/servers/fastapi/utils/asset_directory_utils.py
@@ -2,7 +2,76 @@ import os
 from typing import Optional
 from urllib.parse import urlparse, unquote
 
-from utils.get_env import get_app_data_directory_env
+from utils.get_env import get_app_data_directory_env, get_fastapi_public_base_url
+
+
+def absolute_fastapi_asset_url(path: str) -> str:
+    """
+    Turn a FastAPI-served path (/app_data/..., /static/...) into a full URL when the public
+    base is configured (split Next + FastAPI, e.g. Electron); otherwise return the path.
+    """
+    p = (path or "").strip()
+    if not p:
+        return p
+    if p.startswith(("http://", "https://")):
+        return p
+    if not p.startswith("/"):
+        p = f"/{p}"
+    base = get_fastapi_public_base_url()
+    if base:
+        return f"{base}{p}"
+    return p
+
+
+def normalize_slide_asset_url(path_or_url: str) -> str:
+    """Slide JSON media URLs: keep https/data/blob; make /app_data and /static absolute when FastAPI base is set."""
+    if not path_or_url or not isinstance(path_or_url, str):
+        return path_or_url
+    s = path_or_url.strip()
+    if s.startswith(("http://", "https://", "data:", "blob:")):
+        return s
+    if s.startswith(("/app_data/", "/static/")):
+        return absolute_fastapi_asset_url(s)
+    return filesystem_image_path_to_app_data_url(s)
+
+
+def filesystem_image_path_to_app_data_url(path_or_url: str) -> str:
+    """
+    Browser-facing URL for files saved under APP_DATA_DIRECTORY/images.
+
+    Raw absolute paths (Linux/macOS/Windows) are interpreted by the browser as paths on the
+    web origin (e.g. Next.js), so AI-generated images break while https stock URLs work.
+    Map known app-data image files to FastAPI's /app_data/images/... mount, as an absolute
+    URL when NEXT_PUBLIC_FAST_API is set (Electron).
+    """
+    if not path_or_url or not isinstance(path_or_url, str):
+        return path_or_url
+    stripped = path_or_url.strip()
+    if stripped.startswith(("http://", "https://", "data:", "blob:")):
+        return stripped
+    if stripped.startswith(("/app_data/", "/static/")):
+        return absolute_fastapi_asset_url(stripped)
+    app_data = get_app_data_directory_env()
+    if not app_data:
+        return stripped
+    images_root = os.path.normpath(os.path.join(app_data, "images"))
+    try:
+        abs_image = os.path.normpath(os.path.abspath(stripped))
+        abs_root = os.path.normpath(os.path.abspath(images_root))
+    except (OSError, ValueError):
+        return stripped
+    abs_image_key = os.path.normcase(abs_image)
+    abs_root_key = os.path.normcase(abs_root)
+    try:
+        common = os.path.commonpath([abs_root, abs_image])
+    except ValueError:
+        return stripped
+    if os.path.normcase(common) != abs_root_key:
+        return stripped
+    rel = os.path.relpath(abs_image, abs_root)
+    if rel.startswith(".."):
+        return stripped
+    return absolute_fastapi_asset_url("/app_data/images/" + rel.replace(os.sep, "/"))
 
 
 def resolve_app_path_to_filesystem(path_or_url: str) -> Optional[str]:

--- a/servers/fastapi/utils/get_env.py
+++ b/servers/fastapi/utils/get_env.py
@@ -19,6 +19,17 @@ def get_app_data_directory_env():
     return os.getenv("APP_DATA_DIRECTORY")
 
 
+def get_fastapi_public_base_url() -> str | None:
+    """
+    Public origin where FastAPI serves /app_data and /static (no trailing slash).
+
+    Uses NEXT_PUBLIC_FAST_API (same value Electron and the export runtime inject for the UI).
+    When unset, callers keep path-only URLs for same-origin / reverse-proxy setups (e.g. Docker).
+    """
+    v = (os.getenv("NEXT_PUBLIC_FAST_API") or "").strip().rstrip("/")
+    return v or None
+
+
 def get_temp_directory_env():
     return os.getenv("TEMP_DIRECTORY")
 

--- a/servers/fastapi/utils/process_slides.py
+++ b/servers/fastapi/utils/process_slides.py
@@ -5,6 +5,10 @@ from models.sql.image_asset import ImageAsset
 from models.sql.slide import SlideModel
 from services.icon_finder_service import ICON_FINDER_SERVICE
 from services.image_generation_service import ImageGenerationService
+from utils.asset_directory_utils import (
+    filesystem_image_path_to_app_data_url,
+    normalize_slide_asset_url,
+)
 from utils.dict_utils import get_dict_at_path, get_dict_paths_with_key, set_dict_at_path
 
 
@@ -28,7 +32,9 @@ async def process_slide_and_fetch_assets(
             and image_index < len(outline_image_urls)
             and outline_image_urls[image_index]
         ):
-            __image_prompt__parent["__image_url__"] = outline_image_urls[image_index]
+            __image_prompt__parent["__image_url__"] = normalize_slide_asset_url(
+                outline_image_urls[image_index]
+            )
             set_dict_at_path(slide.content, image_path, __image_prompt__parent)
             continue
 
@@ -56,19 +62,23 @@ async def process_slide_and_fetch_assets(
             image_dict = get_dict_at_path(slide.content, asset_path)
             if isinstance(result, ImageAsset):
                 return_assets.append(result)
-                image_dict["__image_url__"] = result.path
+                image_dict["__image_url__"] = filesystem_image_path_to_app_data_url(
+                    result.path
+                )
             else:
-                image_dict["__image_url__"] = result
+                image_dict["__image_url__"] = normalize_slide_asset_url(result)
             set_dict_at_path(slide.content, asset_path, image_dict)
             continue
 
         icon_dict = get_dict_at_path(slide.content, asset_path)
         # ICON_FINDER_SERVICE.search_icons returns a list of URLs
         if isinstance(result, list) and result:
-            icon_dict["__icon_url__"] = result[0]
+            icon_dict["__icon_url__"] = normalize_slide_asset_url(result[0])
         else:
             # Fallback to FastAPI static placeholder if no icon found
-            icon_dict["__icon_url__"] = "/static/icons/placeholder.svg"
+            icon_dict["__icon_url__"] = normalize_slide_asset_url(
+                "/static/icons/placeholder.svg"
+            )
         set_dict_at_path(slide.content, asset_path, icon_dict)
 
     return return_assets
@@ -169,19 +179,23 @@ async def process_old_and_new_slides_and_fetch_assets(
             fetched_image = new_images[i]
             if isinstance(fetched_image, ImageAsset):
                 new_assets.append(fetched_image)
-                image_url = fetched_image.path
+                image_url = filesystem_image_path_to_app_data_url(fetched_image.path)
             else:
-                image_url = fetched_image
+                image_url = normalize_slide_asset_url(fetched_image)
             new_image_dicts[i]["__image_url__"] = image_url
 
     for i, _ in enumerate(new_icons):
         if new_icons_fetch_status[i]:
             icon_result = new_icons[i]
             if icon_result and len(icon_result) > 0:
-                new_icon_dicts[i]["__icon_url__"] = icon_result[0]
+                new_icon_dicts[i]["__icon_url__"] = normalize_slide_asset_url(
+                    icon_result[0]
+                )
             else:
                 # Fallback to placeholder if no icon found
-                new_icon_dicts[i]["__icon_url__"] = "/static/icons/placeholder.svg"
+                new_icon_dicts[i]["__icon_url__"] = normalize_slide_asset_url(
+                    "/static/icons/placeholder.svg"
+                )
 
     for i, new_image_dict in enumerate(new_image_dicts):
         set_dict_at_path(new_slide_content, new_image_dict_paths[i], new_image_dict)
@@ -200,11 +214,15 @@ def process_slide_add_placeholder_assets(slide: SlideModel):
     for image_path in image_paths:
         image_dict = get_dict_at_path(slide.content, image_path)
         # Use FastAPI static path for placeholder image
-        image_dict["__image_url__"] = "/static/images/placeholder.jpg"
+        image_dict["__image_url__"] = normalize_slide_asset_url(
+            "/static/images/placeholder.jpg"
+        )
         set_dict_at_path(slide.content, image_path, image_dict)
 
     for icon_path in icon_paths:
         icon_dict = get_dict_at_path(slide.content, icon_path)
         # Use FastAPI static path for placeholder icon
-        icon_dict["__icon_url__"] = "/static/icons/placeholder.svg"
+        icon_dict["__icon_url__"] = normalize_slide_asset_url(
+            "/static/icons/placeholder.svg"
+        )
         set_dict_at_path(slide.content, icon_path, icon_dict)


### PR DESCRIPTION
This pull request introduces several improvements across the Docker build, environment variable management, and FastAPI backend, with a focus on asset URL normalization, image asset API consistency, and cache handling for model weights and icons. It also bumps the application version to 0.8.3-beta and updates related metadata.

**Key changes:**

### Asset URL Normalization and API Consistency

* All asset URLs returned by the FastAPI backend (fonts, images, presentations, slide screenshots) are now normalized using the `absolute_fastapi_asset_url` utility, ensuring consistent, absolute URLs are provided to the frontend. This affects endpoints for fonts, images (generated and uploaded), presentations, and PDF/PPTX slides. [[1]](diffhunk://#diff-109813ace01fc788e58bbba412b1946d1c0d66f01b9ca6fde4f582a4657b6b02L174-R174) [[2]](diffhunk://#diff-109813ace01fc788e58bbba412b1946d1c0d66f01b9ca6fde4f582a4657b6b02L231-R231) [[3]](diffhunk://#diff-109813ace01fc788e58bbba412b1946d1c0d66f01b9ca6fde4f582a4657b6b02L275-R275) [[4]](diffhunk://#diff-4da960df0f103cc52304b45f487d7591d2c22e5fbfced6d9f295ea87692c630fL18-R20) [[5]](diffhunk://#diff-cbe9517ea46c013bce8ba070088debab8ec56d903cedebbbb8828fc4d0e03cf8L97-R104) [[6]](diffhunk://#diff-c6a5b0eae90cf70f2f4a467fdafc627db9e78faeb1cf8ecc89b9e9d078def612L376-R383)
* Image asset API responses are now unified: endpoints for generated and uploaded images return dictionaries with normalized file URLs, rather than raw ORM objects or inconsistent paths. [[1]](diffhunk://#diff-0633f903c6f728b1b6b8c40603ca16113b4c711a548f2996d5238da1cd8d1f0eL100-R131) [[2]](diffhunk://#diff-0633f903c6f728b1b6b8c40603ca16113b4c711a548f2996d5238da1cd8d1f0eL143-R171)

### Docker and Environment Variable Improvements

* Dockerfiles now set and propagate `HF_HOME` and `PRESENTON_FASTEMBED_ICON_CACHE_DIR` environment variables to ensure Hugging Face model weights and FastEmbed icon caches are available at runtime, both in production and development. The relevant cache directories are explicitly copied into the final image. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L26-R29) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R86-R87) [[3]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R106-R107) [[4]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL17-R19) [[5]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacR59-R63)
* The FastEmbed cache warming step is improved to ensure model weights are present in the image layer, not just in the build cache. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L26-R29) [[2]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacR59-R63)

### Electron App and Versioning

* Application version is bumped to `0.8.3-beta` across `package.json`, `package-lock.json`, and `version.json`, with updated download URLs for all platforms. [[1]](diffhunk://#diff-db6684a7c142d2735ebb6047a25d18be8288eca9f98751b3b7b9f6a9b53f45c4L3-R9) [[2]](diffhunk://#diff-bc5aaa68eeacd1d94418e4382ca249b7ace55b052311c93c9c9d49add44eec22L4-R4) [[3]](diffhunk://#diff-a3de47f9bf3cc946ff986e65851d8214b119df5cb74dd1c62327fd19be66ac7eL2-R7)
* Removal of unused or redundant environment variables (`FASTAPI_PUBLIC_URL`, `FAST_API_INTERNAL_URL`) and related code cleanup in the Electron app. [[1]](diffhunk://#diff-e2dc87de03d61b56091b5b272926fd660749d19bb2f61d37bbd9140efa1adcefL219) [[2]](diffhunk://#diff-e2dc87de03d61b56091b5b272926fd660749d19bb2f61d37bbd9140efa1adcefL252) [[3]](diffhunk://#diff-84f49266d3b171e3ae71d50fc8fc8249c537927d8cb8124767e4d08ccc943448L39)
* The DevTools shortcut registration function is removed from the Electron main process as part of code cleanup. [[1]](diffhunk://#diff-e2dc87de03d61b56091b5b272926fd660749d19bb2f61d37bbd9140efa1adcefL163-R164) [[2]](diffhunk://#diff-e2dc87de03d61b56091b5b272926fd660749d19bb2f61d37bbd9140efa1adcefL325)

### Minor Backend Refactoring

* Imports are updated to use the new asset utility functions where needed. [[1]](diffhunk://#diff-4da960df0f103cc52304b45f487d7591d2c22e5fbfced6d9f295ea87692c630fR7-R8) [[2]](diffhunk://#diff-109813ace01fc788e58bbba412b1946d1c0d66f01b9ca6fde4f582a4657b6b02L8-R8) [[3]](diffhunk://#diff-0633f903c6f728b1b6b8c40603ca16113b4c711a548f2996d5238da1cd8d1f0eL10-R14) [[4]](diffhunk://#diff-cbe9517ea46c013bce8ba070088debab8ec56d903cedebbbb8828fc4d0e03cf8L10-R10) [[5]](diffhunk://#diff-c6a5b0eae90cf70f2f4a467fdafc627db9e78faeb1cf8ecc89b9e9d078def612L16-R16) [[6]](diffhunk://#diff-1fdc6275ec4896bdbdadc8e020bed815a3367e04a1608e1d85677af9ba66ea5fR13)

---

**References:**  
[[1]](diffhunk://#diff-109813ace01fc788e58bbba412b1946d1c0d66f01b9ca6fde4f582a4657b6b02L174-R174) [[2]](diffhunk://#diff-109813ace01fc788e58bbba412b1946d1c0d66f01b9ca6fde4f582a4657b6b02L231-R231) [[3]](diffhunk://#diff-109813ace01fc788e58bbba412b1946d1c0d66f01b9ca6fde4f582a4657b6b02L275-R275) [[4]](diffhunk://#diff-4da960df0f103cc52304b45f487d7591d2c22e5fbfced6d9f295ea87692c630fL18-R20) [[5]](diffhunk://#diff-cbe9517ea46c013bce8ba070088debab8ec56d903cedebbbb8828fc4d0e03cf8L97-R104) [[6]](diffhunk://#diff-c6a5b0eae90cf70f2f4a467fdafc627db9e78faeb1cf8ecc89b9e9d078def612L376-R383) [[7]](diffhunk://#diff-0633f903c6f728b1b6b8c40603ca16113b4c711a548f2996d5238da1cd8d1f0eL100-R131) [[8]](diffhunk://#diff-0633f903c6f728b1b6b8c40603ca16113b4c711a548f2996d5238da1cd8d1f0eL143-R171) [[9]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L26-R29) [[10]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R86-R87) [[11]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R106-R107) [[12]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL17-R19) [[13]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacR59-R63) [[14]](diffhunk://#diff-db6684a7c142d2735ebb6047a25d18be8288eca9f98751b3b7b9f6a9b53f45c4L3-R9) [[15]](diffhunk://#diff-bc5aaa68eeacd1d94418e4382ca249b7ace55b052311c93c9c9d49add44eec22L4-R4) [[16]](diffhunk://#diff-a3de47f9bf3cc946ff986e65851d8214b119df5cb74dd1c62327fd19be66ac7eL2-R7) [[17]](diffhunk://#diff-e2dc87de03d61b56091b5b272926fd660749d19bb2f61d37bbd9140efa1adcefL219) [[18]](diffhunk://#diff-e2dc87de03d61b56091b5b272926fd660749d19bb2f61d37bbd9140efa1adcefL252) [[19]](diffhunk://#diff-84f49266d3b171e3ae71d50fc8fc8249c537927d8cb8124767e4d08ccc943448L39) [[20]](diffhunk://#diff-e2dc87de03d61b56091b5b272926fd660749d19bb2f61d37bbd9140efa1adcefL163-R164) [[21]](diffhunk://#diff-e2dc87de03d61b56091b5b272926fd660749d19bb2f61d37bbd9140efa1adcefL325) [[22]](diffhunk://#diff-4da960df0f103cc52304b45f487d7591d2c22e5fbfced6d9f295ea87692c630fR7-R8) [[23]](diffhunk://#diff-109813ace01fc788e58bbba412b1946d1c0d66f01b9ca6fde4f582a4657b6b02L8-R8) [[24]](diffhunk://#diff-0633f903c6f728b1b6b8c40603ca16113b4c711a548f2996d5238da1cd8d1f0eL10-R14) [[25]](diffhunk://#diff-cbe9517ea46c013bce8ba070088debab8ec56d903cedebbbb8828fc4d0e03cf8L10-R10) [[26]](diffhunk://#diff-c6a5b0eae90cf70f2f4a467fdafc627db9e78faeb1cf8ecc89b9e9d078def612L16-R16) [[27]](diffhunk://#diff-1fdc6275ec4896bdbdadc8e020bed815a3367e04a1608e1d85677af9ba66ea5fR13)