### PR TITLE
chore: update presentation export version to v0.2.8 in package.json f…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,8 @@ RUN mkdir -p /app/document-extraction-liteparse \
 COPY electron/resources/document-extraction/liteparse_runner.mjs /app/document-extraction-liteparse/liteparse_runner.mjs
 COPY scripts/sync-presentation-export.cjs /app/scripts/sync-presentation-export.cjs
 # Bundled export still loads @img/sharp-* native addons from node_modules (not inlined).
-RUN node /app/scripts/sync-presentation-export.cjs --force \
+RUN rm -rf /app/presentation-export \
+    && node /app/scripts/sync-presentation-export.cjs --force \
     && chmod +x /app/presentation-export/py/convert-linux-x64 \
     && cd /app/presentation-export \
     && npm init -y \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -39,7 +39,8 @@ COPY electron/resources/document-extraction/liteparse_runner.mjs /app/document-e
 
 COPY scripts/sync-presentation-export.cjs /app/scripts/sync-presentation-export.cjs
 COPY scripts/presenton-terminal-banner.mjs /app/scripts/presenton-terminal-banner.mjs
-RUN node /app/scripts/sync-presentation-export.cjs --force \
+RUN rm -rf /app/presentation-export \
+    && node /app/scripts/sync-presentation-export.cjs --force \
     && chmod +x /app/presentation-export/py/convert-linux-x64
 
 # Bind mount `.:/app` hides any .venv under servers/fastapi at runtime — install deps into

--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,7 @@
   "name": "presenton",
   "productName": "Presenton Open Source",
   "version": "0.8.3-beta",
-  "exportVersion": "v0.2.6",
+  "exportVersion": "v0.2.8",
   "main": "app_dist/main.js",
   "description": "Open-Source AI Presentation Generator",
   "homepage": "https://presenton.ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "presenton",
   "version": "1.0.0",
-  "presentationExportVersion": "v0.2.6",
+  "presentationExportVersion": "v0.2.8",
   "type": "module",
   "description": "Open-source AI presentation generator",
   "scripts": {

--- a/scripts/sync-presentation-export.cjs
+++ b/scripts/sync-presentation-export.cjs
@@ -8,6 +8,9 @@
  *
  * CLI: --force  re-download even if valid runtime already exists
  *       --check-only  verify index.cjs + converter exist and exit 0/1
+ *
+ * On every run (including --check-only), index.cjs is overwritten from index.js
+ * so the CommonJS entrypoint never drifts from the bundled ESM build.
  */
 const fs = require("fs");
 const path = require("path");
@@ -173,10 +176,6 @@ function normalizeRuntimeLayout() {
 function ensureCommonJsEntrypoint() {
   if (!fs.existsSync(targetIndexJs)) {
     return { ok: false, reason: `Missing runtime bundle: ${targetIndexJs}` };
-  }
-
-  if (fs.existsSync(targetIndexCjs)) {
-    return { ok: true, entrypointPath: targetIndexCjs };
   }
 
   try {


### PR DESCRIPTION
This pull request updates the presentation export integration and improves the reliability of the export runtime setup. The main changes include bumping the export version, ensuring the CommonJS entrypoint is always up-to-date, and making the Docker build process more robust by cleaning up old export directories before syncing.

**Presentation Export Version Update:**
- Bumped `presentationExportVersion` in `package.json` and `exportVersion` in `electron/package.json` from `v0.2.6` to `v0.2.8` to use the latest export runtime. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-bc5aaa68eeacd1d94418e4382ca249b7ace55b052311c93c9c9d49add44eec22L5-R5)

**Export Runtime Synchronization Improvements:**
- Updated `scripts/sync-presentation-export.cjs` to always overwrite `index.cjs` from `index.js` on every run, ensuring the CommonJS entrypoint is always in sync with the bundled ESM build.
- Simplified the logic in `ensureCommonJsEntrypoint()` to always copy the file, removing the check that skipped copying if `index.cjs` already existed.

**Docker Build Process Improvements:**
- Modified both `Dockerfile` and `Dockerfile.dev` to delete any existing `/app/presentation-export` directory before running the export sync script, preventing stale files from interfering with the build. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L64-R65) [[2]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL42-R43)