### PR TITLE
fix(nginx): drop auth_request on /app_data/images/ to match FastAPI m…

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -108,7 +108,6 @@ http {
     }
 
     location /app_data/images/ {
-      auth_request /_auth_check;
       alias /app_data/images/;
       expires 1y;
       add_header Cache-Control "private, max-age=31536000";


### PR DESCRIPTION
## Problem

API-triggered PPTX exports lose **all images**. The web UI is fine —
images appear there because the browser carries the session cookie.

## Root cause

Commit ba7623e5 ("Enhance authentication and session handling for export
functionality") exempted `/app_data/images/` from auth in the FastAPI
middleware:

```python
# servers/fastapi/api/middlewares.py
# PPTX export may re-fetch slide images without session/basic headers.
if path.startswith("/app_data/images/"):
    return False