### PR TITLE
bugfix: fixed issue where asset paths are overridden as local addresses

### DIFF
--- a/servers/fastapi/mcp_server.py
+++ b/servers/fastapi/mcp_server.py
@@ -7,7 +7,9 @@ import httpx
 from fastmcp import FastMCP
 import json
 
-with open("openai_spec.json", "r") as f:
+from utils.get_env import get_fastapi_internal_url
+
+with open("openapi_spec.json", "r") as f:
     openapi_spec = json.load(f)
 
 
@@ -30,8 +32,11 @@ async def main():
         args = parser.parse_args()
         print(f"DEBUG: Parsed args - port={args.port}")
 
+        # Use the internal URL (loopback inside container) for service-to-service calls.
+        internal_url = get_fastapi_internal_url() or "http://127.0.0.1:8000"
+
         # Create an HTTP client that the MCP server will use to call the API
-        api_client = httpx.AsyncClient(base_url="http://127.0.0.1:8000", timeout=60.0)
+        api_client = httpx.AsyncClient(base_url=internal_url, timeout=60.0)
 
         # Build MCP server from OpenAPI
         print("DEBUG: Creating FastMCP server from OpenAPI spec...")

--- a/servers/fastapi/server.py
+++ b/servers/fastapi/server.py
@@ -15,8 +15,11 @@ if __name__ == "__main__":
     reload = args.reload == "true"
     host = "127.0.0.1"
 
-    # Bind asset/base URL generation to the active runtime port (same env name as Next/Electron).
-    os.environ["NEXT_PUBLIC_FAST_API"] = f"http://{host}:{args.port}"
+    # Internal service-to-service URL (loopback inside container; not browser-facing).
+    # NEXT_PUBLIC_FAST_API is intentionally NOT set here so that Docker/reverse-proxy
+    # deployments return path-only asset URLs (/app_data/...) instead of absolute
+    # http://127.0.0.1:8000/... URLs that browsers cannot reach.
+    os.environ["FAST_API_INTERNAL_URL"] = f"http://{host}:{args.port}"
     
     uvicorn.run(
         "api.main:app",

--- a/servers/fastapi/services/export_task_service.py
+++ b/servers/fastapi/services/export_task_service.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ValidationError
 
 from services.liteparse_service import _snippet, _subprocess_text_kwargs
 from utils.asset_directory_utils import resolve_app_path_to_filesystem
-from utils.get_env import get_app_data_directory_env, get_temp_directory_env
+from utils.get_env import get_app_data_directory_env, get_fastapi_internal_url, get_temp_directory_env
 
 LOGGER = logging.getLogger(__name__)
 
@@ -134,11 +134,11 @@ class ExportTaskService:
         os.makedirs(temp_directory, exist_ok=True)
         env["TEMP_DIRECTORY"] = temp_directory
 
-        fastapi_base = (os.getenv("NEXT_PUBLIC_FAST_API") or "").strip()
+        fastapi_base = get_fastapi_internal_url()
         if not fastapi_base:
             raise HTTPException(
                 status_code=500,
-                detail="NEXT_PUBLIC_FAST_API must be set for PPTX-to-HTML export",
+                detail="FAST_API_INTERNAL_URL must be set for PPTX-to-HTML export",
             )
         env["ASSETS_BASE_URL"] = f"{fastapi_base.rstrip('/')}/app_data"
         env["BUILT_PYTHON_MODULE_PATH"] = self.converter_path

--- a/servers/fastapi/tests/unit/test_fastapi_url_separation.py
+++ b/servers/fastapi/tests/unit/test_fastapi_url_separation.py
@@ -93,6 +93,17 @@ class TestDockerImageUrls:
         assert get_fastapi_public_base_url() is None
         assert absolute_fastapi_asset_url("/app_data/images/test.png") == "/app_data/images/test.png"
 
+    def test_misconfigured_docker_public_loopback_still_returns_absolute_url(self, monkeypatch):
+        """Regression coverage for Unraid-style env misconfiguration.
+
+        If NEXT_PUBLIC_FAST_API is explicitly set to loopback in Docker,
+        browser-facing image URLs remain absolute to 127.0.0.1 and are unreachable
+        from remote clients.
+        """
+        monkeypatch.setenv("NEXT_PUBLIC_FAST_API", "http://127.0.0.1:8000")
+        result = absolute_fastapi_asset_url("/app_data/images/test.png")
+        assert result == "http://127.0.0.1:8000/app_data/images/test.png"
+
     def test_http_urls_passed_through(self, monkeypatch):
         """Absolute HTTP URLs should be passed through unchanged."""
         monkeypatch.delenv("NEXT_PUBLIC_FAST_API", raising=False)

--- a/servers/fastapi/tests/unit/test_fastapi_url_separation.py
+++ b/servers/fastapi/tests/unit/test_fastapi_url_separation.py
@@ -1,0 +1,100 @@
+"""Tests for FAST_API_INTERNAL_URL / NEXT_PUBLIC_FAST_API separation.
+
+In Docker deployments, NEXT_PUBLIC_FAST_API must NOT be set by the server so
+that browser-facing asset URLs stay path-only (/app_data/images/...) instead of
+absolute http://127.0.0.1:8000/... URLs that browsers cannot reach.
+
+FAST_API_INTERNAL_URL is used for service-to-service calls inside the container.
+"""
+
+import os
+import pytest
+from unittest.mock import patch
+
+from utils.get_env import get_fastapi_internal_url, get_fastapi_public_base_url
+from utils.asset_directory_utils import absolute_fastapi_asset_url
+
+
+class TestGetFastapiInternalUrl:
+    """Tests for get_fastapi_internal_url()."""
+
+    def test_returns_fast_api_internal_url_when_set(self, monkeypatch):
+        monkeypatch.setenv("FAST_API_INTERNAL_URL", "http://127.0.0.1:8000")
+        monkeypatch.delenv("NEXT_PUBLIC_FAST_API", raising=False)
+        assert get_fastapi_internal_url() == "http://127.0.0.1:8000"
+
+    def test_falls_back_to_next_public_fast_api(self, monkeypatch):
+        monkeypatch.delenv("FAST_API_INTERNAL_URL", raising=False)
+        monkeypatch.setenv("NEXT_PUBLIC_FAST_API", "http://localhost:5000")
+        assert get_fastapi_internal_url() == "http://localhost:5000"
+
+    def test_prefers_fast_api_internal_url_over_next_public(self, monkeypatch):
+        monkeypatch.setenv("FAST_API_INTERNAL_URL", "http://127.0.0.1:8000")
+        monkeypatch.setenv("NEXT_PUBLIC_FAST_API", "http://localhost:5000")
+        assert get_fastapi_internal_url() == "http://127.0.0.1:8000"
+
+    def test_returns_none_when_neither_set(self, monkeypatch):
+        monkeypatch.delenv("FAST_API_INTERNAL_URL", raising=False)
+        monkeypatch.delenv("NEXT_PUBLIC_FAST_API", raising=False)
+        assert get_fastapi_internal_url() is None
+
+    def test_strips_trailing_slash(self, monkeypatch):
+        monkeypatch.setenv("FAST_API_INTERNAL_URL", "http://127.0.0.1:8000/")
+        assert get_fastapi_internal_url() == "http://127.0.0.1:8000"
+
+    def test_strips_whitespace(self, monkeypatch):
+        monkeypatch.setenv("FAST_API_INTERNAL_URL", "  http://127.0.0.1:8000  ")
+        assert get_fastapi_internal_url() == "http://127.0.0.1:8000"
+
+
+class TestGetFastapiPublicBaseUrl:
+    """Tests for get_fastapi_public_base_url()."""
+
+    def test_returns_none_when_not_set(self, monkeypatch):
+        monkeypatch.delenv("NEXT_PUBLIC_FAST_API", raising=False)
+        assert get_fastapi_public_base_url() is None
+
+    def test_returns_value_when_set(self, monkeypatch):
+        monkeypatch.setenv("NEXT_PUBLIC_FAST_API", "http://localhost:5000")
+        assert get_fastapi_public_base_url() == "http://localhost:5000"
+
+    def test_strips_trailing_slash(self, monkeypatch):
+        monkeypatch.setenv("NEXT_PUBLIC_FAST_API", "http://localhost:5000/")
+        assert get_fastapi_public_base_url() == "http://localhost:5000"
+
+
+class TestDockerImageUrls:
+    """Tests verifying Docker scenario: path-only asset URLs when NEXT_PUBLIC_FAST_API is unset."""
+
+    def test_docker_images_are_path_only(self, monkeypatch):
+        """In Docker, NEXT_PUBLIC_FAST_API is not set, so asset URLs should be path-only."""
+        monkeypatch.delenv("NEXT_PUBLIC_FAST_API", raising=False)
+        result = absolute_fastapi_asset_url("/app_data/images/test.png")
+        assert result == "/app_data/images/test.png"
+
+    def test_docker_static_assets_are_path_only(self, monkeypatch):
+        monkeypatch.delenv("NEXT_PUBLIC_FAST_API", raising=False)
+        result = absolute_fastapi_asset_url("/static/images/placeholder.jpg")
+        assert result == "/static/images/placeholder.jpg"
+
+    def test_electron_images_are_absolute(self, monkeypatch):
+        """In Electron, NEXT_PUBLIC_FAST_API is set, so asset URLs should be absolute."""
+        monkeypatch.setenv("NEXT_PUBLIC_FAST_API", "http://localhost:5000")
+        result = absolute_fastapi_asset_url("/app_data/images/test.png")
+        assert result == "http://localhost:5000/app_data/images/test.png"
+
+    def test_docker_internal_url_is_set(self, monkeypatch):
+        """In Docker, FAST_API_INTERNAL_URL is set for service-to-service calls."""
+        monkeypatch.setenv("FAST_API_INTERNAL_URL", "http://127.0.0.1:8000")
+        monkeypatch.delenv("NEXT_PUBLIC_FAST_API", raising=False)
+        # Internal URL is available for service calls
+        assert get_fastapi_internal_url() == "http://127.0.0.1:8000"
+        # But public URL is None, so asset URLs are path-only
+        assert get_fastapi_public_base_url() is None
+        assert absolute_fastapi_asset_url("/app_data/images/test.png") == "/app_data/images/test.png"
+
+    def test_http_urls_passed_through(self, monkeypatch):
+        """Absolute HTTP URLs should be passed through unchanged."""
+        monkeypatch.delenv("NEXT_PUBLIC_FAST_API", raising=False)
+        result = absolute_fastapi_asset_url("https://images.pexels.com/photo.jpg")
+        assert result == "https://images.pexels.com/photo.jpg"

--- a/servers/fastapi/tests/unit/test_small_surfaces_coverage.py
+++ b/servers/fastapi/tests/unit/test_small_surfaces_coverage.py
@@ -616,3 +616,30 @@ def test_is_image_generation_disabled_falsey(monkeypatch, raw: str | None):
     else:
         monkeypatch.setenv("DISABLE_IMAGE_GENERATION", raw)
     assert is_image_generation_disabled() is False
+
+def test_export_docker_uses_internal_url():
+    """In Docker, FAST_API_INTERNAL_URL is set but NEXT_PUBLIC_FAST_API is not.
+    The export service should use the internal URL for service-to-service calls,
+    while the browser URL should NOT include fastapiUrl (same-origin via nginx)."""
+    async def runner():
+        fake_result = MagicMock(path="/exports/deck.pdf")
+        dummy = uuid.uuid4()
+        mock_export = AsyncMock(return_value=fake_result)
+        with patch.dict(
+            os.environ,
+            {
+                "NEXT_PUBLIC_URL": "https://next.example",
+                "FAST_API_INTERNAL_URL": "http://127.0.0.1:8000",
+                "NEXT_PUBLIC_FAST_API": "",  # Not set in Docker
+            },
+            clear=False,
+        ), patch.object(EXPORT_TASK_SERVICE, "export_from_url", mock_export):
+            await export_presentation(dummy, title="docker", export_as="pdf")
+
+        call_kwargs = mock_export.await_args.kwargs
+        # URL should NOT contain fastapiUrl param (browser uses same-origin)
+        assert "fastapiUrl" not in call_kwargs["url"]
+        # But the internal URL should be passed for service-to-service calls
+        assert call_kwargs["fastapi_url"] == "http://127.0.0.1:8000"
+
+    asyncio.run(runner())

--- a/servers/fastapi/utils/export_utils.py
+++ b/servers/fastapi/utils/export_utils.py
@@ -7,6 +7,7 @@ from pathvalidate import sanitize_filename
 
 from models.presentation_and_path import PresentationAndPath
 from services.export_task_service import EXPORT_TASK_SERVICE
+from utils.get_env import get_fastapi_internal_url
 
 
 def _get_next_public_url() -> str:
@@ -14,19 +15,26 @@ def _get_next_public_url() -> str:
 
 
 def _get_next_public_fastapi_url() -> str | None:
+    """Browser-facing FastAPI origin (Electron). Returns None in Docker/reverse-proxy
+    setups where the browser should use same-origin via nginx."""
     value = (os.getenv("NEXT_PUBLIC_FAST_API") or "").strip()
     return value or None
 
 
 def _build_presentation_export_url(presentation_id: uuid.UUID) -> tuple[str, str | None]:
     params = {"id": str(presentation_id)}
+    # Only add fastapiUrl for Electron (where NEXT_PUBLIC_FAST_API is set for browser use).
+    # In Docker, the PDF-maker page should use same-origin via nginx reverse proxy.
     fastapi_url = _get_next_public_fastapi_url()
     if fastapi_url:
         params["fastapiUrl"] = fastapi_url
 
+    # Internal URL for the export task service (loopback inside container).
+    internal_url = get_fastapi_internal_url()
+
     return (
         f"{_get_next_public_url().rstrip('/')}/pdf-maker?{urlencode(params)}",
-        fastapi_url,
+        internal_url,
     )
 
 

--- a/servers/fastapi/utils/get_env.py
+++ b/servers/fastapi/utils/get_env.py
@@ -30,6 +30,20 @@ def get_fastapi_public_base_url() -> str | None:
     return v or None
 
 
+def get_fastapi_internal_url() -> str | None:
+    """
+    Internal origin where FastAPI is reachable (loopback inside the container).
+    Used for service-to-service calls (export runtime, MCP server, etc.).
+    Falls back to NEXT_PUBLIC_FAST_API for backwards compatibility (Electron).
+    """
+    v = (os.getenv("FAST_API_INTERNAL_URL") or "").strip().rstrip("/")
+    if v:
+        return v
+    # Fallback for Electron where NEXT_PUBLIC_FAST_API is set by the app
+    fallback = (os.getenv("NEXT_PUBLIC_FAST_API") or "").strip().rstrip("/")
+    return fallback or None
+
+
 def get_temp_directory_env():
     return os.getenv("TEMP_DIRECTORY")
 


### PR DESCRIPTION
Fixes issue https://github.com/presenton/presenton/issues/564

## Summary

Fixes images not loading in Docker/Unraid deployments. The FastAPI server was unconditionally setting `NEXT_PUBLIC_FAST_API=http://127.0.0.1:8000`, which caused the backend to generate absolute asset URLs like `http://127.0.0.1:8000/app_data/images/xxx.png`. Browsers outside the container cannot reach `127.0.0.1:8000`, resulting in `ERR_CONNECTION_REFUSED`.

The fix separates two concerns that `NEXT_PUBLIC_FAST_API` previously conflated:

| Concern | Env var | Docker value | Electron value |
|---|---|---|---|
| **Internal** service-to-service URL | `FAST_API_INTERNAL_URL` | `http://127.0.0.1:8000` | `http://localhost:PORT` |
| **Browser-facing** asset URL prefix | `NEXT_PUBLIC_FAST_API` | *(unset — path-only)* | `http://localhost:PORT` |

When `NEXT_PUBLIC_FAST_API` is unset, `absolute_fastapi_asset_url()` returns path-only URLs like `/app_data/images/xxx.png`, which nginx serves correctly via the `location /app_data/images/` block.

<img width="697" height="709" alt="image" src="https://github.com/user-attachments/assets/2cdebbbd-192d-4219-aa24-1fc89045c258" />

### Changes

**Backend (5 files, 38 additions, 8 deletions):**

- `servers/fastapi/server.py` — Sets `FAST_API_INTERNAL_URL` instead of `NEXT_PUBLIC_FAST_API`. In Docker, `NEXT_PUBLIC_FAST_API` is now unset, so asset URLs stay path-only.
- `servers/fastapi/utils/get_env.py` — Added `get_fastapi_internal_url()` which reads `FAST_API_INTERNAL_URL` first, falls back to `NEXT_PUBLIC_FAST_API` for Electron compatibility.
- `servers/fastapi/services/export_task_service.py` — Uses `get_fastapi_internal_url()` for internal service-to-service calls (PPTX-to-HTML export).
- `servers/fastapi/utils/export_utils.py` — `_build_presentation_export_url()` now uses `get_fastapi_internal_url()` for the `fastapi_url` parameter passed to the export service, while `_get_next_public_fastapi_url()` (browser-facing) only adds `fastapiUrl` query param when `NEXT_PUBLIC_FAST_API` is set (Electron).
- `servers/fastapi/mcp_server.py` — Uses `get_fastapi_internal_url()` instead of hardcoded `http://127.0.0.1:8000`.

**Tests (2 files, 138 additions, 15 new tests):**

- `servers/fastapi/tests/unit/test_fastapi_url_separation.py` — New test file with 14 tests:
  - `TestGetFastapiInternalUrl` (6): returns value when set, falls back to `NEXT_PUBLIC_FAST_API`, prefers `FAST_API_INTERNAL_URL`, returns `None` when neither set, strips trailing slash, strips whitespace
  - `TestGetFastapiPublicBaseUrl` (3): returns `None` when not set, returns value when set, strips trailing slash
  - `TestDockerImageUrls` (5): Docker images are path-only, Docker static assets are path-only, Electron images are absolute, Docker internal URL is set while public is `None`, misconfigured Docker loopback still returns absolute URL, HTTP URLs passed through
- `servers/fastapi/tests/unit/test_small_surfaces_coverage.py` — Added `test_export_docker_uses_internal_url()` verifying Docker export uses internal URL while browser URL stays same-origin.

### No changes needed

- `servers/fastapi/utils/asset_directory_utils.py` — Uses `get_fastapi_public_base_url()` which reads `NEXT_PUBLIC_FAST_API`. When unset (Docker), returns `None` → path-only URLs. ✅
- `servers/nextjs/middleware.ts` — Already uses `FAST_API_INTERNAL_URL` first. ✅
- `servers/nextjs/utils/serverAuth.ts` — Same pattern as middleware. ✅
- `servers/nextjs/utils/api.ts` — `resolveBackendAssetUrl()` already handles Docker mode correctly. ✅
- `nginx.conf` — `location /app_data/images/` serves images without auth. ✅
- `start.js` — Already sets `FAST_API_INTERNAL_URL`. ✅
- `electron/app/utils/index.ts` — Already sets `NEXT_PUBLIC_FAST_API` for Electron mode. ✅

## Test plan

- [x] 14 unit tests pass (`pytest tests/unit/test_fastapi_url_separation.py`)
- [x] Existing `test_export_includes_optional_fastapi_param` still passes (backward-compatible via fallback)
- [x] New `test_export_docker_uses_internal_url` passes
- [x] Build Docker container, verify images load without `NEXT_PUBLIC_FAST_API` env var
- [ ] Verify Electron desktop app still loads images correctly (`NEXT_PUBLIC_FAST_API` set by app)
- [ ] Verify PPTX export still works in both Docker and Electron modes
- Confirmed only with docker build