### PR TITLE
feat: server-side web grounding via DuckDuckGo search context injection

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/outlines.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/outlines.py
@@ -30,6 +30,7 @@ from utils.llm_calls.generate_presentation_outlines import (
     generate_ppt_outline,
     get_messages as get_outline_messages,
 )
+from utils.web_search import build_search_context
 
 OUTLINES_ROUTER = APIRouter(prefix="/outlines", tags=["Outlines"])
 
@@ -49,6 +50,10 @@ async def stream_outlines(
         yield SSEStatusResponse(
             status="Generating presentation outlines..."
         ).to_string()
+
+        search_context = await build_search_context(
+            presentation.content, presentation.web_search
+        )
 
         additional_context = ""
         if presentation.file_paths:
@@ -111,6 +116,7 @@ async def stream_outlines(
             presentation.include_title_slide,
             presentation.web_search,
             presentation.include_table_of_contents,
+            search_context=search_context,
         ):
             # Give control to the event loop
             await asyncio.sleep(0)

--- a/servers/fastapi/api/v1/ppt/endpoints/presentation.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/presentation.py
@@ -58,6 +58,7 @@ from utils.llm_calls.generate_presentation_structure import (
 from utils.llm_calls.generate_slide_content import (
     get_slide_content_from_type_and_outline,
 )
+from utils.web_search import build_search_context
 from utils.ppt_utils import (
     select_toc_or_list_slide_layout_index,
 )
@@ -382,6 +383,10 @@ async def stream_presentation(
 
     image_generation_service = ImageGenerationService(get_images_directory())
 
+    search_context = await build_search_context(
+        presentation.content, presentation.web_search
+    )
+
     async def inner():
         structure = presentation.get_structure()
         layout = presentation.get_layout()
@@ -414,6 +419,7 @@ async def stream_presentation(
                     presentation.tone,
                     presentation.verbosity,
                     presentation.instructions,
+                    search_context=search_context,
                 )
             except HTTPException as e:
                 yield SSEErrorResponse(detail=e.detail).to_string()
@@ -636,6 +642,7 @@ async def generate_presentation_handler(
         using_slides_markdown = False
         language_to_use = (request.language or "").strip() or None
         additional_context = ""
+        search_context = await build_search_context(request.content, request.web_search)
 
         if request.slides_markdown:
             using_slides_markdown = True
@@ -710,6 +717,7 @@ async def generate_presentation_handler(
                 request.include_title_slide,
                 request.web_search,
                 request.include_table_of_contents,
+                search_context=search_context,
             ):
 
                 if isinstance(chunk, HTTPException):
@@ -892,6 +900,7 @@ async def generate_presentation_handler(
                     request.tone.value,
                     request.verbosity.value,
                     request.instructions,
+                    search_context=search_context,
                 )
                 for i in range(start, end)
             ]

--- a/servers/fastapi/pyproject.toml
+++ b/servers/fastapi/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "aiosqlite>=0.21.0",
     "asyncpg>=0.30.0",
     "dirtyjson>=1.0.8",
+    "duckduckgo-search>=6.0.0",
     "fastapi[standard]>=0.116.1",
     "fastembed-vectorstore>=0.5.2",
     "fastmcp>=2.11.0",

--- a/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
+++ b/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
@@ -28,6 +28,7 @@ def get_system_prompt(
     verbosity: Optional[str] = None,
     include_title_slide: bool = True,
     include_table_of_contents: bool = False,
+    search_context: Optional[str] = None,
 ):
     verbosity_instruction = (
         "Slide content should be around 20 words but detailed enough to generate a good slide."
@@ -89,7 +90,8 @@ def get_system_prompt(
         "If the answer may be outdated or uncertain, prefer using the web search tool.\n"
     )
 
-    return system
+    search_context_block = (search_context + "\n\n") if search_context else ""
+    return search_context_block + system
 
 
 def _resolve_prompt_language(language: Optional[str]) -> str:
@@ -145,6 +147,7 @@ def get_messages(
     instructions: Optional[str] = None,
     include_title_slide: bool = True,
     include_table_of_contents: bool = False,
+    search_context: Optional[str] = None,
 ) -> list[Message]:
     return [
         SystemMessage(
@@ -152,6 +155,7 @@ def get_messages(
                 verbosity,
                 include_title_slide,
                 include_table_of_contents,
+                search_context,
             ),
         ),
         UserMessage(
@@ -180,6 +184,7 @@ async def generate_ppt_outline(
     include_title_slide: bool = True,
     web_search: bool = False,
     include_table_of_contents: bool = False,
+    search_context: Optional[str] = None,
 ):
     model = get_model()
     response_model = (
@@ -216,6 +221,7 @@ async def generate_ppt_outline(
                     instructions,
                     include_title_slide,
                     include_table_of_contents,
+                    search_context,
                 ),
                 response_format=response_format,
                 tools=([WebSearchTool()] if use_search_tool else None),

--- a/servers/fastapi/utils/llm_calls/generate_slide_content.py
+++ b/servers/fastapi/utils/llm_calls/generate_slide_content.py
@@ -92,6 +92,7 @@ def get_system_prompt(
     verbosity: Optional[str] = None,
     instructions: Optional[str] = None,
     response_schema: Optional[dict] = None,
+    search_context: Optional[str] = None,
 ):
     markdown_emphasis_rules = (
         "- Strictly use markdown to emphasize important points, by bolding or "
@@ -117,7 +118,8 @@ def get_system_prompt(
         response_schema
     )
 
-    return SLIDE_CONTENT_SYSTEM_PROMPT.format(
+    search_context_prefix = (search_context + "\n\n") if search_context else ""
+    return search_context_prefix + SLIDE_CONTENT_SYSTEM_PROMPT.format(
         markdown_emphasis_rules=markdown_emphasis_rules,
         user_instructions=user_instructions,
         tone_instructions=tone_instructions,
@@ -141,6 +143,7 @@ def get_messages(
     verbosity: Optional[str] = None,
     instructions: Optional[str] = None,
     response_schema: Optional[dict] = None,
+    search_context: Optional[str] = None,
 ) -> list[Message]:
 
     return [
@@ -150,6 +153,7 @@ def get_messages(
                 verbosity,
                 instructions,
                 response_schema,
+                search_context,
             ),
         ),
         UserMessage(
@@ -165,6 +169,7 @@ async def get_slide_content_from_type_and_outline(
     tone: Optional[str] = None,
     verbosity: Optional[str] = None,
     instructions: Optional[str] = None,
+    search_context: Optional[str] = None,
 ):
     client = get_client(config=get_llm_config())
     model = get_model()
@@ -199,6 +204,7 @@ async def get_slide_content_from_type_and_outline(
             verbosity,
             instructions,
             response_schema,
+            search_context,
         )
 
         return await generate_structured_with_schema_retries(

--- a/servers/fastapi/utils/web_search.py
+++ b/servers/fastapi/utils/web_search.py
@@ -1,0 +1,208 @@
+"""
+Server-side web grounding for local LLM pipelines.
+
+Flow:
+  1. extract_search_queries()  — low-temp LLM call → 2-3 search strings
+  2. execute_web_search()       — Tavily (if TAVILY_API_KEY set) else DuckDuckGo
+  3. build_search_context()     — orchestrates 1+2, returns a Markdown block
+                                   ready to inject into any system prompt
+
+All failures are non-fatal: a warning is logged and None is returned so
+callers can fall back to standard generation without a crash.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal: single-query search backends
+# ---------------------------------------------------------------------------
+
+async def _ddg_search(query: str, max_results: int) -> list[dict]:
+    """DuckDuckGo search wrapped in a thread (sync client, avoids blocking)."""
+    def _sync() -> list[dict]:
+        try:
+            from duckduckgo_search import DDGS
+            with DDGS() as ddgs:
+                return list(ddgs.text(query, max_results=max_results))
+        except Exception as exc:
+            logger.warning("[web_search] DuckDuckGo failed for %r: %s", query, exc)
+            return []
+    return await asyncio.to_thread(_sync)
+
+
+async def _tavily_search(query: str, max_results: int, api_key: str) -> list[dict]:
+    """Tavily search wrapped in a thread."""
+    def _sync() -> list[dict]:
+        try:
+            from tavily import TavilyClient
+            client = TavilyClient(api_key=api_key)
+            response = client.search(query, max_results=max_results)
+            return [
+                {
+                    "title": r.get("title", ""),
+                    "body": r.get("content", ""),
+                    "href": r.get("url", ""),
+                }
+                for r in response.get("results", [])
+            ]
+        except Exception as exc:
+            logger.warning("[web_search] Tavily failed for %r: %s", query, exc)
+            return []
+    return await asyncio.to_thread(_sync)
+
+
+async def _search_one(query: str, max_results: int) -> list[dict]:
+    """Try Tavily first; fall back to DuckDuckGo."""
+    tavily_key = os.getenv("TAVILY_API_KEY", "").strip()
+    if tavily_key:
+        results = await _tavily_search(query, max_results, tavily_key)
+        if results:
+            return results
+    return await _ddg_search(query, max_results)
+
+
+def _format_results(query: str, results: list[dict]) -> str:
+    if not results:
+        return ""
+    lines = [f"### Search: {query}"]
+    for r in results:
+        title = r.get("title") or ""
+        body = r.get("body") or r.get("snippet") or r.get("content") or ""
+        url = r.get("href") or r.get("url") or ""
+        if title:
+            lines.append(f"**{title}**")
+        if body:
+            lines.append(body.strip())
+        if url:
+            lines.append(f"Source: {url}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+# ---------------------------------------------------------------------------
+# Public: single-query entry point
+# ---------------------------------------------------------------------------
+
+async def execute_web_search(query: str, max_results: int = 5) -> str:
+    """Run a single search and return formatted Markdown. Returns '' on failure."""
+    try:
+        results = await _search_one(query, max_results)
+        return _format_results(query, results)
+    except Exception as exc:
+        logger.warning("[web_search] execute_web_search failed: %s", exc)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Query extraction: lightweight LLM call
+# ---------------------------------------------------------------------------
+
+async def extract_search_queries(content: str) -> list[str]:
+    """
+    Ask the configured LLM to derive 2-3 search queries from the presentation topic.
+    Uses temperature=0.0 and re-uses the existing LLM config — no new model added.
+    Returns [] on any failure.
+    """
+    try:
+        import asyncio as _asyncio
+        from llmai import get_client
+        from llmai.shared import SystemMessage, UserMessage
+        from utils.llm_config import get_llm_config
+        from utils.llm_provider import get_model
+        from utils.llm_utils import get_generate_kwargs
+
+        client = get_client(config=get_llm_config())
+        model = get_model()
+        messages = [
+            SystemMessage(content=(
+                "You are a search query generator. "
+                "Output ONLY a JSON array of 2-3 short search engine queries. "
+                "No explanation, no markdown fences — just the raw JSON array. "
+                'Example: ["query one", "query two", "query three"]'
+            )),
+            UserMessage(content=(
+                f"Presentation topic:\n{content[:800]}\n\n"
+                "Generate 2-3 search queries to find current facts, statistics, "
+                "and recent developments relevant to this topic."
+            )),
+        ]
+        kwargs = get_generate_kwargs(model=model, messages=messages, temperature=0.0)
+        raw = await _asyncio.to_thread(client.generate, **kwargs)
+
+        text: str = raw if isinstance(raw, str) else (
+            raw.content if hasattr(raw, "content") else str(raw)
+        )
+        start = text.find("[")
+        end = text.rfind("]") + 1
+        if start != -1 and end > start:
+            queries = json.loads(text[start:end])
+            if isinstance(queries, list):
+                cleaned = [str(q).strip() for q in queries if str(q).strip()]
+                logger.info("[web_search] Extracted queries: %s", cleaned)
+                return cleaned[:3]
+    except Exception as exc:
+        logger.warning("[web_search] Query extraction failed: %s", exc)
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Main entry point: build full grounding context
+# ---------------------------------------------------------------------------
+
+async def build_search_context(content: str, web_search: bool) -> Optional[str]:
+    """
+    Orchestrates query extraction + search and returns a Markdown block
+    ready to prepend to any LLM system prompt.
+
+    Returns None if:
+    - web_search is False
+    - query extraction yields nothing
+    - all search calls fail
+
+    Never raises — callers always get None on failure.
+    """
+    if not web_search:
+        return None
+
+    try:
+        queries = await extract_search_queries(content)
+        if not queries:
+            logger.warning("[web_search] No queries extracted — skipping grounding")
+            return None
+
+        sections: list[str] = []
+        for query in queries:
+            section = await execute_web_search(query, max_results=5)
+            if section:
+                sections.append(section)
+
+        if not sections:
+            logger.warning("[web_search] All searches returned empty results — skipping grounding")
+            return None
+
+        body = "\n\n".join(sections)
+        header = (
+            "# Web Search Grounding\n"
+            "The following results were retrieved from live web searches. "
+            "Use them to ground the presentation with current facts, figures, "
+            "and sources. Prefer these over training-data knowledge where they conflict.\n\n"
+        )
+        logger.info(
+            "[web_search] Grounding context built (%d chars, %d sections)",
+            len(body),
+            len(sections),
+        )
+        return header + body
+
+    except Exception as exc:
+        logger.warning(
+            "[web_search] build_search_context failed: %s — continuing without grounding", exc
+        )
+        return None


### PR DESCRIPTION
## Summary

- Adds a `build_search_context()` utility that runs DuckDuckGo searches against the presentation topic and formats the results as a context block
- Injects the search context into the LLM system prompt for both outline generation (`generate_ppt_outline`) and slide content generation (`get_slide_content_from_type_and_outline`)
- Hooks into both the streaming outline endpoint (`/outlines/stream/{id}`) and the batch presentation generation handler
- Search is only performed when `web_search=True` on the presentation; zero overhead otherwise
- Adds `duckduckgo-search>=6.0.0` to `pyproject.toml`

## Files changed

| File | Change |
|------|--------|
| `servers/fastapi/pyproject.toml` | Add `duckduckgo-search>=6.0.0` dependency |
| `servers/fastapi/utils/web_search.py` | New: `build_search_context()` helper |
| `servers/fastapi/utils/llm_calls/generate_presentation_outlines.py` | Accept + pass `search_context` |
| `servers/fastapi/utils/llm_calls/generate_slide_content.py` | Accept + pass `search_context` |
| `servers/fastapi/api/v1/ppt/endpoints/outlines.py` | Fetch and pass `search_context` |
| `servers/fastapi/api/v1/ppt/endpoints/presentation.py` | Fetch and pass `search_context` |

## Test plan

- [ ] Create a presentation with `web_search=true` — verify outlines reference current factual data
- [ ] Create a presentation with `web_search=false` — verify no search is performed and output is unchanged
- [ ] Confirm no regressions on standard outline/slide generation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)