### PR TITLE
feat: add MarkdownInlineText component and integrate into TiptapTextR…

### DIFF
--- a/servers/nextjs/app/(presentation-generator)/components/MarkdownInlineText.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/MarkdownInlineText.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { marked } from "marked";
+
+interface MarkdownInlineTextProps {
+  content: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Renders inline markdown (e.g. **bold**) without block wrappers like <p>.
+ * Used for export/preview where Tiptap edit mode is off.
+ */
+const MarkdownInlineText: React.FC<MarkdownInlineTextProps> = ({
+  content,
+  className = "",
+  style,
+}) => {
+  const [html, setHtml] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    const parse = async () => {
+      try {
+        const parsed = await marked.parseInline(content || "");
+        if (!cancelled) setHtml(parsed);
+      } catch {
+        if (!cancelled) setHtml(content || "");
+      }
+    };
+    void parse();
+    return () => {
+      cancelled = true;
+    };
+  }, [content]);
+
+  if (!html) {
+    return (
+      <span className={className} style={style}>
+        {content}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={className}
+      style={style}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+};
+
+export default MarkdownInlineText;

--- a/servers/nextjs/app/(presentation-generator)/components/TiptapText.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/TiptapText.tsx
@@ -57,7 +57,7 @@ const TiptapText: React.FC<TiptapTextProps> = ({
     // Compare against current plain text to avoid unnecessary updates
     const currentText = editor?.storage.markdown.getMarkdown();
     if ((content || "") !== currentText) {
-      editor.commands.setContent(content || "");
+      editor.commands.setContent(content || "", false);
     }
   }, [content, editor]);
 

--- a/servers/nextjs/app/(presentation-generator)/components/TiptapTextReplacer.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/TiptapTextReplacer.tsx
@@ -3,6 +3,7 @@
 import React, { useRef, useEffect, useState, ReactNode } from "react";
 import ReactDOM from "react-dom/client";
 import TiptapText from "./TiptapText";
+import MarkdownInlineText from "./MarkdownInlineText";
 import { useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { Markdown } from "tiptap-markdown";
@@ -14,6 +15,7 @@ interface TiptapTextReplacerProps {
   children: ReactNode;
   slideData?: any;
   slideIndex?: number;
+  readOnly?: boolean;
   onContentChange?: (
     content: string,
     path: string,
@@ -25,6 +27,7 @@ const TiptapTextReplacer: React.FC<TiptapTextReplacerProps> = ({
   children,
   slideData,
   slideIndex,
+  readOnly = false,
   onContentChange = () => {},
 }) => {
 
@@ -107,28 +110,35 @@ const TiptapTextReplacer: React.FC<TiptapTextReplacerProps> = ({
           fallbackText: trimmedText,
         });
         root.render(
-          <TiptapText
-            content={initialContent}
-           
-            onContentChange={(content: string) => {
-              if (dataPath && onContentChange) {
-                onContentChange(content, dataPath.path, slideIndex);
-              }
-            }}
-            placeholder="Enter text..."
-          />
+          readOnly ? (
+            <MarkdownInlineText content={initialContent} />
+          ) : (
+            <TiptapText
+              content={initialContent}
+              onContentChange={(content: string) => {
+                if (dataPath && onContentChange) {
+                  onContentChange(content, dataPath.path, slideIndex);
+                }
+              }}
+              placeholder="Enter text..."
+            />
+          )
         );
       });
+
+      if (readOnly && container) {
+        container.setAttribute("data-markdown-rendered", "true");
+      }
     };
 
   
     // Replace text elements after a short delay to ensure DOM is ready
-    const timer = setTimeout(replaceTextElements, 1000);
+    const timer = setTimeout(replaceTextElements, readOnly ? 250 : 1000);
 
     return () => {
       clearTimeout(timer);
     };
-  }, [slideData, slideIndex]);
+  }, [slideData, slideIndex, readOnly]);
   
   // When slideData changes, update existing editors' content using the stored dataPath
   useEffect(() => {
@@ -136,18 +146,22 @@ const TiptapTextReplacer: React.FC<TiptapTextReplacerProps> = ({
     rootsRef.current.forEach(({ root, dataPath,  fallbackText }) => {
       const newContent = dataPath ? getValueByPath(slideData, dataPath) ?? fallbackText : fallbackText;
       root.render(
-        <TiptapText
-          content={newContent}
-          onContentChange={(content: string) => {
-            if (dataPath && onContentChange) {
-              onContentChange(content, dataPath, slideIndex);
-            }
-          }}
-          placeholder="Enter text..."
-        />
+        readOnly ? (
+          <MarkdownInlineText content={newContent} />
+        ) : (
+          <TiptapText
+            content={newContent}
+            onContentChange={(content: string) => {
+              if (dataPath && onContentChange) {
+                onContentChange(content, dataPath, slideIndex);
+              }
+            }}
+            placeholder="Enter text..."
+          />
+        )
       );
     });
-  }, [slideData, slideIndex]);
+  }, [slideData, slideIndex, readOnly]);
   // helper functions
     // Function to check if element is inside an ignored element tree
     const isInIgnoredElementTree = (element: HTMLElement): boolean => {

--- a/servers/nextjs/app/(presentation-generator)/components/V1ContentRender.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/V1ContentRender.tsx
@@ -127,11 +127,22 @@ export const V1ContentRender = ({ slide, isEditMode, theme }: { slide: any, isEd
         );
     }
     return (
-        <LayoutComp data={{
-            ...slide.content,
-            _logo_url__: theme ? theme.logo_url : null,
-            __companyName__: (theme && theme.company_name) ? theme.company_name : null,
-        }} />
-    )
+        <SlideErrorBoundary label={`Slide ${slide.index + 1}`}>
+            <div ref={containerRef}>
+                <TiptapTextReplacer
+                    key={slide.id}
+                    slideData={slide.content}
+                    slideIndex={slide.index}
+                    readOnly
+                >
+                    <LayoutComp data={{
+                        ...slide.content,
+                        _logo_url__: theme ? theme.logo_url : null,
+                        __companyName__: (theme && theme.company_name) ? theme.company_name : null,
+                    }} />
+                </TiptapTextReplacer>
+            </div>
+        </SlideErrorBoundary>
+    );
 };
 


### PR DESCRIPTION
…eplacer for read-only mode

- Introduced a new MarkdownInlineText component to render inline markdown without block wrappers.
- Updated TiptapTextReplacer to conditionally render MarkdownInlineText when in read-only mode.
- Adjusted TiptapText to set content without triggering unnecessary updates.
- Enhanced V1ContentRender to utilize TiptapTextReplacer with read-only functionality for slide rendering.