### PR TITLE
fix: truncate long filenames to prevent OSError on Japanese themes

### DIFF
--- a/servers/fastapi/tests/unit/test_filename_utils.py
+++ b/servers/fastapi/tests/unit/test_filename_utils.py
@@ -1,0 +1,32 @@
+from pathvalidate import sanitize_filename
+
+from utils.filename_utils import safe_export_basename, MAX_EXPORT_BASENAME_BYTES
+
+
+def test_safe_export_basename_short_name_unchanged():
+    assert safe_export_basename("Hello World") == "Hello World"
+
+
+def test_safe_export_basename_empty_falls_back_to_presentation():
+    assert safe_export_basename("") == "presentation"
+    assert safe_export_basename("   ") == "presentation"
+
+
+def test_safe_export_basename_long_ascii_truncated_with_hash():
+    long_name = "a" * 300
+    result = safe_export_basename(long_name)
+    assert len(result.encode("utf-8")) <= MAX_EXPORT_BASENAME_BYTES
+    assert "_" in result
+
+
+def test_safe_filename_japanese_under_os_limit():
+    title = "2026下半期営業戦略 " + "あ" * 80
+    safe = safe_export_basename(sanitize_filename(title))
+    assert len(safe.encode("utf-8")) + len(".pptx") <= 255
+
+
+def test_safe_export_basename_exactly_at_limit_unchanged():
+    name = "x" * MAX_EXPORT_BASENAME_BYTES
+    result = safe_export_basename(name)
+    assert result == name
+    assert len(result.encode("utf-8")) == MAX_EXPORT_BASENAME_BYTES

--- a/servers/fastapi/utils/export_utils.py
+++ b/servers/fastapi/utils/export_utils.py
@@ -1,13 +1,16 @@
-import hashlib
 import os
 import logging
 from typing import Literal
 from urllib.parse import urlencode
 import uuid
+
 from pathvalidate import sanitize_filename
+
 from models.presentation_and_path import PresentationAndPath
+from utils.filename_utils import safe_export_basename
 from services.export_task_service import EXPORT_TASK_SERVICE
 from utils.runtime_limits import log_memory
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,21 +35,6 @@ def _build_presentation_export_url(presentation_id: uuid.UUID) -> tuple[str, str
     )
 
 
-def _safe_filename(name: str, max_bytes: int = 200) -> str:
-    """Truncate filename to avoid OSError on long names (e.g. Japanese characters).
-    
-    On most Linux/macOS systems, the filename limit is 255 bytes.
-    Japanese characters take 3 bytes each in UTF-8, so a short-looking
-    title can easily exceed this limit and raise an OSError.
-    """
-    encoded = name.encode('utf-8')
-    if len(encoded) <= max_bytes:
-        return name
-    hash_suffix = hashlib.md5(encoded).hexdigest()[:8]
-    truncated = encoded[:max_bytes - 9].decode('utf-8', errors='ignore')
-    return f"{truncated}_{hash_suffix}"
-
-
 async def export_presentation(
     presentation_id: uuid.UUID,
     title: str,
@@ -60,9 +48,10 @@ async def export_presentation(
         export_as=export_as,
     )
     export_url, fastapi_url = _build_presentation_export_url(presentation_id)
+    name = (title or "").strip() or str(uuid.uuid4())
     export_result = await EXPORT_TASK_SERVICE.export_from_url(
         url=export_url,
-        title=_safe_filename(sanitize_filename(title or str(uuid.uuid4()))),
+        title=safe_export_basename(sanitize_filename(name)),
         export_as=export_as,
         fastapi_url=fastapi_url,
         cookie_header=cookie_header,

--- a/servers/fastapi/utils/export_utils.py
+++ b/servers/fastapi/utils/export_utils.py
@@ -1,15 +1,13 @@
+import hashlib
 import os
 import logging
 from typing import Literal
 from urllib.parse import urlencode
 import uuid
-
 from pathvalidate import sanitize_filename
-
 from models.presentation_and_path import PresentationAndPath
 from services.export_task_service import EXPORT_TASK_SERVICE
 from utils.runtime_limits import log_memory
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -28,11 +26,25 @@ def _build_presentation_export_url(presentation_id: uuid.UUID) -> tuple[str, str
     fastapi_url = _get_next_public_fastapi_url()
     if fastapi_url:
         params["fastapiUrl"] = fastapi_url
-
     return (
         f"{_get_next_public_url().rstrip('/')}/pdf-maker?{urlencode(params)}",
         fastapi_url,
     )
+
+
+def _safe_filename(name: str, max_bytes: int = 200) -> str:
+    """Truncate filename to avoid OSError on long names (e.g. Japanese characters).
+    
+    On most Linux/macOS systems, the filename limit is 255 bytes.
+    Japanese characters take 3 bytes each in UTF-8, so a short-looking
+    title can easily exceed this limit and raise an OSError.
+    """
+    encoded = name.encode('utf-8')
+    if len(encoded) <= max_bytes:
+        return name
+    hash_suffix = hashlib.md5(encoded).hexdigest()[:8]
+    truncated = encoded[:max_bytes - 9].decode('utf-8', errors='ignore')
+    return f"{truncated}_{hash_suffix}"
 
 
 async def export_presentation(
@@ -50,7 +62,7 @@ async def export_presentation(
     export_url, fastapi_url = _build_presentation_export_url(presentation_id)
     export_result = await EXPORT_TASK_SERVICE.export_from_url(
         url=export_url,
-        title=sanitize_filename(title or str(uuid.uuid4())),
+        title=_safe_filename(sanitize_filename(title or str(uuid.uuid4()))),
         export_as=export_as,
         fastapi_url=fastapi_url,
         cookie_header=cookie_header,
@@ -61,7 +73,6 @@ async def export_presentation(
         presentation_id=str(presentation_id),
         export_as=export_as,
     )
-
     return PresentationAndPath(
         presentation_id=presentation_id,
         path=export_result.path,

--- a/servers/fastapi/utils/filename_utils.py
+++ b/servers/fastapi/utils/filename_utils.py
@@ -1,0 +1,18 @@
+import hashlib
+
+MAX_EXPORT_BASENAME_BYTES = 200
+
+
+def safe_export_basename(name: str, max_bytes: int = MAX_EXPORT_BASENAME_BYTES) -> str:
+    name = (name or "").strip() or "presentation"
+
+    encoded = name.encode("utf-8")
+
+    if len(encoded) <= max_bytes:
+        return name
+
+    suffix = hashlib.md5(encoded).hexdigest()[:8]
+    budget = max_bytes - len(suffix) - 1
+    truncated = encoded[:budget].decode("utf-8", errors="ignore").rstrip()
+
+    return f"{truncated}_{suffix}" if truncated else suffix


### PR DESCRIPTION
What does this PR do?
Refactors filename truncation into a shared helper to prevent 
OSError on systems with 255-byte filename limits.

Changes:
- Created utils/filename_utils.py with safe_export_basename() helper
- Updated export_utils.py to use the shared helper
- Added unit tests including Japanese filename edge case

Why?
Japanese characters take 3 bytes each in UTF-8. A presentation
title can easily exceed the OS filename limit and raise an OSError.

Fixes #500