### PR TITLE
refactor: Move Codex model definitions to CodexConfig component

### DIFF
--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/SettingCodex.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/SettingCodex.tsx
@@ -23,6 +23,10 @@ import { cn } from "@/lib/utils";
 import { notify } from "@/components/ui/sonner";
 import { getApiUrl } from "@/utils/api";
 import { Button } from "@/components/ui/button";
+import {
+    CHATGPT_MODELS,
+    DEFAULT_CODEX_MODEL,
+} from "@/components/CodexConfig";
 
 interface CodexConfigProps {
     codexModel: string;
@@ -39,22 +43,6 @@ interface StatusResponse {
     is_pro?: boolean;
     detail?: string;
 }
-
-interface CodexModel {
-    id: string;
-    name: string;
-}
-
-const CHATGPT_MODELS: CodexModel[] = [
-    { id: "gpt-5.4", name: "GPT-5.4" },
-    { id: "gpt-5.2-codex", name: "GPT-5.2-Codex" },
-    { id: "gpt-5.1-codex-max", name: "GPT-5.1-Codex-Max" },
-    { id: "gpt-5.4-mini", name: "GPT-5.4-Mini" },
-    { id: "gpt-5.3-codex", name: "GPT-5.3-Codex" },
-    { id: "gpt-5.2", name: "GPT-5.2" },
-];
-
-const DEFAULT_CODEX_MODEL = "gpt-5.2";
 
 export default function CodexConfig({
     codexModel,

--- a/servers/nextjs/components/CodexConfig.tsx
+++ b/servers/nextjs/components/CodexConfig.tsx
@@ -33,12 +33,12 @@ interface CodexModel {
 }
 
 export const CHATGPT_MODELS: CodexModel[] = [
-  { id: "gpt-5.4", name: "GPT-5.4" },
-  { id: "gpt-5.2-codex", name: "GPT-5.2-Codex" },
-  { id: "gpt-5.1-codex-max", name: "GPT-5.1-Codex-Max" },
-  { id: "gpt-5.4-mini", name: "GPT-5.4-Mini" },
-  { id: "gpt-5.3-codex", name: "GPT-5.3-Codex" },
   { id: "gpt-5.2", name: "GPT-5.2" },
+  { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+  { id: "gpt-5.3-codex-spark", name: "GPT-5.3 Codex Spark" },
+  { id: "gpt-5.4", name: "GPT-5.4" },
+  { id: "gpt-5.4-mini", name: "GPT-5.4 mini" },
+  { id: "gpt-5.5", name: "GPT-5.5" },
 ];
 
 export const DEFAULT_CODEX_MODEL = "gpt-5.2";


### PR DESCRIPTION
- Extracted CHATGPT_MODELS and DEFAULT_CODEX_MODEL from SettingCodex.tsx to CodexConfig.tsx for better organization.
- Updated CHATGPT_MODELS to include new model entries and removed duplicates.