### PR TITLE
fix(security): close nginx `/static` alias path traversal

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -100,8 +100,15 @@ http {
     }
 
     # Bundled UI static assets (logos, fonts packaged with the app) are safe to
-    # serve unauthenticated; they contain no user data.
-    location /static {
+    # serve unauthenticated; they contain no user data. The trailing slash on
+    # the location pattern is required: with a bare `/static`, a request like
+    # `/static../server.py` matches this block and `alias` rewrites it to
+    # `/app/servers/fastapi/static/../server.py`, which nginx resolves to
+    # `/app/servers/fastapi/server.py` — unauthenticated arbitrary read of any
+    # file under /app the worker can stat. `/static/` constrains the match so
+    # the only path that lands here is one that actually started with the
+    # separator.
+    location /static/ {
       alias /app/servers/fastapi/static/;
       expires 1y;
       add_header Cache-Control "public, immutable";


### PR DESCRIPTION
## Summary

`nginx.conf` exposes the `/static` location block to unauthenticated arbitrary file read because the `location` prefix lacks a trailing slash while its `alias` has one. A request like `GET /static../server.py` matches `location /static`, nginx strips the matched prefix (`/static`), prepends the alias (`/app/servers/fastapi/static/`), and the resolved path collapses to `/app/servers/fastapi/server.py`. The result is read access to any file under `/app/` that the nginx worker (`www-data`) can stat — no auth, no preconditions.

## Impact

Pre-auth, default-config information disclosure against any Presenton install reachable on its bound port:

- Source code under `/app/servers/fastapi/` (e.g. `server.py`, `utils/get_env.py`, `utils/llm_provider.py`, `api/v1/...` routes, the auth implementation under `utils/simple_auth.py`).
- The Next.js standalone build under `/app/servers/nextjs/`.
- Any sibling file under `/app/` (`start.js`, the LICENSE/NOTICE, the bundled `package.json`, the presentation-export runtime).
- Files outside `/app/` reachable by enough `..` traversal — `/app/servers/fastapi/static/../../../etc/passwd` resolves to `/etc/passwd` inside the container.

All of the above is reachable without a session because `/static` is intentionally exempted from `auth_request /_auth_check` (it's meant to serve bundled UI assets like logos and fonts).

The other `location` blocks in this file already use trailing slashes (`/app_data/images/`, `/app_data/exports/`, etc.), so this is the only block exposed.

## Location

[`nginx.conf:104`](https://github.com/presenton/presenton/blob/main/nginx.conf#L104) — the `location /static` block.

## Fix

Add the trailing slash to the `location` prefix so the only URI that matches the block is one that genuinely started with `/static/`:

```diff
-    location /static {
+    location /static/ {
       alias /app/servers/fastapi/static/;
       expires 1y;
       add_header Cache-Control "public, immutable";
     }
```

After the change, `GET /static../server.py` no longer matches the block (the URI doesn't begin with `/static/`), falls through to `location /`, and gets proxied to Next.js (which 404s it). `GET /static/icons/foo.svg` and every other legitimate use still matches.

This is the canonical fix for the alias-misuse pattern that nginx itself warns about — see the alias directive docs (last paragraph): <https://nginx.org/en/docs/http/ngx_http_core_module.html#alias>.

## Verification

- `nginx -t -c nginx.conf` — syntax is ok.
- Client-side and server-side usage of `/static` was grepped across the repo before the fix: every reference in `servers/nextjs/` (`/static/icons/...`, `/static/images/...`, `path.join("/static", ...)`) and `servers/fastapi/api/main.py` (`app.mount("/static", ...)`) uses the `/static/<path>` form, so none of them rely on the bare-prefix match. The FastAPI `app.mount("/static", ...)` is a separate Starlette routing layer — unaffected by nginx config.
- Manual reproduction with the original config would be `curl -sI 'http://<host>/static../server.py'` returning a 200 with Python source; after the fix, the same request 404s through the Next.js proxy.

## Detected by

Aeon + semgrep
- Rule: `generic.nginx.security.alias-path-traversal.alias-path-traversal`
- Severity: high
- CWE-22 (Path Traversal) + CWE-200 (Exposure of Sensitive Information to an Unauthorized Actor)

## Related observations (not changed here)

While reading the config and the FastAPI app, two further items surfaced that are out of scope for this PR but worth noting:

1. `servers/fastapi/api/main.py:76-83` configures the CORS middleware with `allow_origins=["*"]` and `allow_credentials=True`. Starlette's CORS middleware, in this combination, echoes the request `Origin` back into `Access-Control-Allow-Origin`, effectively allowing any origin to read credentialed responses. In practice this is largely contained because session cookies are `SameSite=Lax` (`utils/simple_auth.py:332`), but the wildcard is still a footgun if anything ever flips the cookie to `SameSite=None` or if any state-changing endpoint becomes reachable via GET.
2. `servers/fastapi/api/v1/ppt/endpoints/pptx_slides.py:12,161`, `servers/fastapi/templates/font_utils.py:3,92`, `servers/fastapi/templates/pptx_font_utils.py:11,271,434,1120` parse user-uploaded PPTX XML with `xml.etree.ElementTree.fromstring`. On Python 3.11 (your runtime image) external-entity processing is disabled by default, but internal-entity expansion ("billion laughs" / quadratic blowup) is not — an upload can DoS the worker with a small file. Drop-in fix is `from defusedxml.ElementTree import fromstring`.

Happy to file these separately if you'd prefer.

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
