### PR TITLE
feat: Implement chat LLM tools integration

### DIFF
--- a/servers/fastapi/services/chat/llm_tools.py
+++ b/servers/fastapi/services/chat/llm_tools.py
@@ -1,0 +1,23 @@
+from llmai.shared import Tool, WebSearchTool  # type: ignore[import-not-found]
+
+from enums.llm_provider import LLMProvider
+from utils.llm_provider import get_llm_provider
+
+# Gemini (Google AI + Vertex) does not allow Search and Function tools in one request.
+_GEMINI_EXCLUSIVE_TOOL_PROVIDERS = frozenset(
+    {
+        LLMProvider.GOOGLE,
+        LLMProvider.VERTEX,
+    }
+)
+
+
+def build_chat_llm_tools(function_tools: list[Tool]) -> list[Tool | WebSearchTool]:
+    """
+    Chat needs slide-edit function tools on every provider. Hosted web search is
+    appended only when the active provider can combine it with function tools.
+    """
+    tools: list[Tool | WebSearchTool] = list(function_tools)
+    if get_llm_provider() not in _GEMINI_EXCLUSIVE_TOOL_PROVIDERS:
+        tools.append(WebSearchTool())
+    return tools

--- a/servers/fastapi/services/chat/service.py
+++ b/servers/fastapi/services/chat/service.py
@@ -16,7 +16,6 @@ from llmai.shared import (  # type: ignore[import-not-found]
     TextContentPart,
     ToolResponseMessage,
     UserMessage,
-    WebSearchTool
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,6 +23,7 @@ from models.sql.presentation import PresentationModel
 from services.chat.conversation_store import ChatConversationStore
 from services.chat.presentation_context_store import PresentationContextStore
 from services.chat.prompts import build_system_prompt
+from services.chat.llm_tools import build_chat_llm_tools
 from services.chat.tools import ChatTools
 from utils.llm_client_error_handler import handle_llm_client_exceptions
 from utils.llm_config import get_llm_config
@@ -82,8 +82,7 @@ class PresentationChatService:
 
         client = get_client(config=get_llm_config())
         model = get_model()
-        tools = self._tools.get_tool_definitions()
-        tools.append(WebSearchTool())
+        tools = build_chat_llm_tools(self._tools.get_tool_definitions())
 
         called_tools: list[str] = []
         last_tool_results: list[dict[str, Any]] = []
@@ -295,7 +294,7 @@ class PresentationChatService:
     async def _run_llm_with_tools(self, messages: list[Message]) -> tuple[str, list[str]]:
         client = get_client(config=get_llm_config())
         model = get_model()
-        tools = self._tools.get_tool_definitions()
+        tools = build_chat_llm_tools(self._tools.get_tool_definitions())
 
         called_tools: list[str] = []
         last_tool_results: list[dict[str, Any]] = []

--- a/servers/fastapi/tests/unit/test_chat_llm_tools.py
+++ b/servers/fastapi/tests/unit/test_chat_llm_tools.py
@@ -1,0 +1,40 @@
+import pytest
+from llmai.shared import Tool, WebSearchTool  # type: ignore[import-not-found]
+
+from enums.llm_provider import LLMProvider
+from services.chat.llm_tools import build_chat_llm_tools
+
+
+def _sample_function_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="getSlideAtIndex",
+            description="Read a slide",
+            input_schema={"type": "object", "properties": {}},
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [LLMProvider.GOOGLE, LLMProvider.VERTEX],
+)
+def test_build_chat_llm_tools_omits_web_search_for_gemini_providers(monkeypatch, provider):
+    monkeypatch.setenv("LLM", provider.value)
+    tools = build_chat_llm_tools(_sample_function_tools())
+
+    assert len(tools) == 1
+    assert isinstance(tools[0], Tool)
+    assert not any(isinstance(tool, WebSearchTool) for tool in tools)
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [LLMProvider.OPENAI, LLMProvider.ANTHROPIC, LLMProvider.CUSTOM],
+)
+def test_build_chat_llm_tools_includes_web_search_for_other_providers(monkeypatch, provider):
+    monkeypatch.setenv("LLM", provider.value)
+    tools = build_chat_llm_tools(_sample_function_tools())
+
+    assert len(tools) == 2
+    assert isinstance(tools[-1], WebSearchTool)


### PR DESCRIPTION
- Added a new module `llm_tools.py` to manage the integration of function tools and web search tools based on the active LLM provider.
- Updated `PresentationChatService` to utilize the new `build_chat_llm_tools` function for tool definitions.
- Introduced unit tests for `build_chat_llm_tools` to ensure correct behavior for different LLM providers.