### PR TITLE
Preserve DOCX text during document loading

### DIFF
--- a/servers/fastapi/pyproject.toml
+++ b/servers/fastapi/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "llmai==0.2.5",
     "jsonschema>=4.26.0",
     "python-pptx>=1.0.2",
+    "python-docx>=1.1.2",
     "fonttools>=4.55.0",
 ]
 

--- a/servers/fastapi/services/documents_loader.py
+++ b/servers/fastapi/services/documents_loader.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
 import pdfplumber
+from docx import Document
 from fastapi import HTTPException
 
 from constants.documents import (
@@ -15,6 +16,7 @@ from constants.documents import (
     OFFICE_EXTENSIONS,
     PDF_EXTENSIONS,
     TEXT_EXTENSIONS,
+    WORD_EXTENSIONS,
 )
 from services.document_conversion_service import (
     DocumentConversionError,
@@ -138,6 +140,44 @@ def _clean_extracted_one_pass(t: str) -> str:
     return t
 
 
+def _iter_docx_table_rows(table) -> list[str]:
+    rows: list[str] = []
+    for row in table.rows:
+        cells = [cell.text.strip() for cell in row.cells]
+        cells = [cell for cell in cells if cell]
+        if cells:
+            rows.append(" | ".join(cells))
+    return rows
+
+
+def docx_to_markdown(file_path: str) -> str:
+    """Extract DOCX text directly to preserve CJK text and document structure."""
+    document = Document(file_path)
+    blocks: list[str] = []
+
+    for paragraph in document.paragraphs:
+        text = paragraph.text.strip()
+        if not text:
+            continue
+
+        style_name = (paragraph.style.name if paragraph.style else "").lower()
+        if style_name.startswith("heading"):
+            level = "".join(ch for ch in style_name if ch.isdigit())
+            heading_level = min(max(int(level or "1"), 1), 6)
+            blocks.append(f"{'#' * heading_level} {text}")
+        elif "list" in style_name:
+            blocks.append(f"- {text}")
+        else:
+            blocks.append(text)
+
+    for table in document.tables:
+        rows = _iter_docx_table_rows(table)
+        if rows:
+            blocks.extend(rows)
+
+    return "\n\n".join(blocks)
+
+
 def clean_extracted_document_text(text: str) -> str:
     """
     Return only the document body: strip LiteParse JSON wrappers, then drop any
@@ -217,6 +257,8 @@ class DocumentsLoader:
                 )
             elif extension in TEXT_EXTENSIONS:
                 document = await self.load_text(file_path)
+            elif extension == ".docx":
+                document = await asyncio.to_thread(self.load_docx_document, file_path)
             elif extension in OFFICE_EXTENSIONS:
                 document = await asyncio.to_thread(
                     self.load_office_document,
@@ -265,6 +307,9 @@ class DocumentsLoader:
     async def load_text(self, file_path: str) -> str:
         with open(file_path, "r", encoding="utf-8") as file:
             return await asyncio.to_thread(file.read)
+
+    def load_docx_document(self, file_path: str) -> str:
+        return docx_to_markdown(file_path)
 
     def load_office_document(self, file_path: str, temp_dir: Optional[str] = None) -> str:
         if temp_dir:

--- a/servers/fastapi/tests/unit/test_documents_loader.py
+++ b/servers/fastapi/tests/unit/test_documents_loader.py
@@ -61,3 +61,28 @@ def test_load_pdf_requires_temp_dir_when_images_are_requested():
 
     assert exc.value.status_code == 400
     assert "temp_dir is required" in exc.value.detail
+
+
+def test_docx_to_markdown_preserves_chinese_text_and_structure(tmp_path):
+    from docx import Document
+    from services.documents_loader import docx_to_markdown
+
+    path = tmp_path / "中文方案.docx"
+    document = Document()
+    document.add_heading("人工智能项目方案", level=1)
+    document.add_paragraph("这是第一段中文正文，包含关键背景和目标。")
+    document.add_paragraph("第一项行动", style="List Bullet")
+    table = document.add_table(rows=2, cols=2)
+    table.cell(0, 0).text = "阶段"
+    table.cell(0, 1).text = "说明"
+    table.cell(1, 0).text = "启动"
+    table.cell(1, 1).text = "完成需求确认"
+    document.save(path)
+
+    markdown = docx_to_markdown(str(path))
+
+    assert "# 人工智能项目方案" in markdown
+    assert "这是第一段中文正文，包含关键背景和目标。" in markdown
+    assert "- 第一项行动" in markdown
+    assert "阶段 | 说明" in markdown
+    assert "启动 | 完成需求确认" in markdown

--- a/servers/fastapi/uv.lock
+++ b/servers/fastapi/uv.lock
@@ -1738,6 +1738,7 @@ dependencies = [
     { name = "pathvalidate" },
     { name = "pdfplumber" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "python-docx" },
     { name = "python-pptx" },
     { name = "sqlmodel" },
 ]
@@ -1770,6 +1771,7 @@ requires-dist = [
     { name = "pathvalidate", specifier = ">=3.3.1" },
     { name = "pdfplumber", specifier = ">=0.11.7" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "python-docx", specifier = ">=1.1.2" },
     { name = "python-pptx", specifier = ">=1.0.2" },
     { name = "sqlmodel", specifier = ">=0.0.24" },
 ]
@@ -2143,6 +2145,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987, upload-time = "2025-06-16T20:46:22.506Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Load `.docx` files directly with `python-docx` instead of converting them through PDF first.
- Preserve headings, list-like paragraphs, table rows, and CJK text in a Markdown-like text stream.
- Add a regression test covering Chinese headings, body text, a bullet, and table content.

## Why

The current Office document path converts `.docx` files to PDF with LibreOffice and then parses the PDF with LiteParse. That route can degrade Chinese/CJK documents before the LLM ever sees them: text may be split, table/list structure can be lost, and OCR/font fallback can further reduce fidelity.

Modern `.docx` files already contain structured text. Reading them directly avoids the lossy PDF conversion path while keeping the existing LibreOffice fallback for other Office formats.

## Validation

```bash
cd servers/fastapi
uv run pytest tests/unit/test_documents_loader.py tests/test_documents_loader_unwrap.py
```

Result: `12 passed`.
