### PR TITLE
fix: support with_schema in PresentationLayoutModel.to_string()

### DIFF
--- a/servers/fastapi/templates/presentation_layout.py
+++ b/servers/fastapi/templates/presentation_layout.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional
 
 from fastapi import HTTPException
@@ -42,10 +43,17 @@ class PresentationLayoutModel(BaseModel):
             slides=[index for index in range(len(self.slides))]
         )
 
-    def to_string(self) -> str:
+    def to_string(self, with_schema: bool = False) -> str:
         message = "## Presentation Layout\n\n"
         for index, slide in enumerate(self.slides):
             message += f"### Slide Layout: {index}\n"
             message += f"- Name: {slide.name or slide.json_schema.get('title')}\n"
-            message += f"- Description: {slide.description}\n\n"
+            message += f"- Description: {slide.description}\n"
+            if with_schema:
+                try:
+                    schema_text = json.dumps(slide.json_schema, ensure_ascii=False)
+                except (TypeError, ValueError):
+                    schema_text = str(slide.json_schema)
+                message += f"- Schema: {schema_text}\n"
+            message += "\n"
         return message

--- a/servers/fastapi/tests/unit/test_small_surfaces_coverage.py
+++ b/servers/fastapi/tests/unit/test_small_surfaces_coverage.py
@@ -491,6 +491,8 @@ def test_presentation_layout_model_surface():
         ],
     )
     assert "From schema" in layout.to_string()
+    with_schema = layout.to_string(with_schema=True)
+    assert '"title": "From schema"' in with_schema
     assert layout.to_presentation_structure().slides == [0]
     assert layout.get_slide_layout_index("sid") == 0
     with pytest.raises(HTTPException):


### PR DESCRIPTION
slides_markdown generation called to_string(with_schema=True) but the method did not accept that argument, causing a 500 on every request. Include JSON schema in the layout prompt when with_schema is set.

Fixes presenton/presenton#637