### PR TITLE
feat: add data retention service with RETENTION_PERIOD_DAYS env var

### DIFF
--- a/servers/fastapi/api/lifespan.py
+++ b/servers/fastapi/api/lifespan.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 import logging
 import os
@@ -11,6 +12,7 @@ from utils.model_availability import (
     check_llm_and_image_provider_api_or_model_availability,
 )
 from utils.user_config import update_env_with_user_config
+from services.data_retention_service import retention_scheduler
 from utils.simple_auth import (
     clear_stored_credentials,
     force_set_credentials,
@@ -98,6 +100,8 @@ async def app_lifespan(_: FastAPI):
     if get_can_change_keys_env() != "false":
         update_env_with_user_config()
     await check_llm_and_image_provider_api_or_model_availability()
+    retention_task = asyncio.create_task(retention_scheduler())
     yield
+    retention_task.cancel()
     # Shutdown: release all database connections to prevent stale/leaked pools.
     await dispose_engines()

--- a/servers/fastapi/services/data_retention_service.py
+++ b/servers/fastapi/services/data_retention_service.py
@@ -1,0 +1,110 @@
+import asyncio
+import logging
+import os
+import shutil
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import delete, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from models.sql.async_presentation_generation_status import AsyncPresentationGenerationTaskModel
+from models.sql.presentation import PresentationModel
+from models.sql.presentation_layout_code import PresentationLayoutCodeModel
+from models.sql.template import TemplateModel
+from services.database import get_async_session
+
+logger = logging.getLogger(__name__)
+
+_CLEANUP_INTERVAL_SECONDS = 24 * 60 * 60
+
+
+def get_retention_period_days() -> Optional[int]:
+    raw = os.getenv("RETENTION_PERIOD_DAYS", "0").strip()
+    try:
+        days = int(raw)
+        return days if days > 0 else None
+    except ValueError:
+        logger.warning("Invalid RETENTION_PERIOD_DAYS value %r — retention disabled.", raw)
+        return None
+
+
+async def _delete_presentation_files(file_paths: list[str] | None) -> None:
+    if not file_paths:
+        return
+    for path in file_paths:
+        try:
+            if os.path.isfile(path):
+                os.remove(path)
+            elif os.path.isdir(path):
+                shutil.rmtree(path, ignore_errors=True)
+        except Exception:
+            logger.exception("Failed to delete file %s", path)
+
+
+async def run_retention_cleanup(session: AsyncSession, cutoff: datetime) -> dict:
+    template_ids_result = await session.exec(select(TemplateModel.id))
+    protected_ids = set(template_ids_result.all())
+
+    stale_result = await session.exec(
+        select(PresentationModel).where(PresentationModel.created_at < cutoff)
+    )
+    stale_presentations = stale_result.all()
+
+    presentations_deleted = 0
+    files_deleted = 0
+
+    for presentation in stale_presentations:
+        if presentation.id in protected_ids:
+            logger.debug("Skipping protected template presentation %s", presentation.id)
+            continue
+
+        await session.exec(
+            delete(PresentationLayoutCodeModel).where(
+                PresentationLayoutCodeModel.presentation == presentation.id
+            )
+        )
+
+        if presentation.file_paths:
+            await _delete_presentation_files(presentation.file_paths)
+            files_deleted += len(presentation.file_paths)
+
+        await session.delete(presentation)
+        presentations_deleted += 1
+
+    tasks_result = await session.exec(
+        delete(AsyncPresentationGenerationTaskModel).where(
+            AsyncPresentationGenerationTaskModel.created_at < cutoff
+        )
+    )
+    tasks_deleted = getattr(tasks_result, "rowcount", 0)
+
+    await session.commit()
+
+    summary = {
+        "presentations_deleted": presentations_deleted,
+        "files_deleted": files_deleted,
+        "tasks_deleted": tasks_deleted,
+        "cutoff": cutoff.isoformat(),
+    }
+    logger.info("Retention cleanup complete: %s", summary)
+    return summary
+
+
+async def retention_scheduler() -> None:
+    days = get_retention_period_days()
+    if days is None:
+        logger.info("Data retention disabled (RETENTION_PERIOD_DAYS not set or 0).")
+        return
+
+    logger.info("Data retention enabled: deleting presentations older than %d day(s).", days)
+
+    while True:
+        try:
+            cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+            async for session in get_async_session():
+                await run_retention_cleanup(session, cutoff)
+        except Exception:
+            logger.exception("Retention cleanup failed — will retry in 24 h.")
+
+        await asyncio.sleep(_CLEANUP_INTERVAL_SECONDS)

--- a/servers/fastapi/tests/unit/test_data_retention_service.py
+++ b/servers/fastapi/tests/unit/test_data_retention_service.py
@@ -1,0 +1,120 @@
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.data_retention_service import get_retention_period_days, run_retention_cleanup
+
+
+# --- get_retention_period_days ---
+
+def test_returns_none_when_not_set(monkeypatch):
+    monkeypatch.delenv("RETENTION_PERIOD_DAYS", raising=False)
+    assert get_retention_period_days() is None
+
+
+def test_returns_none_when_zero(monkeypatch):
+    monkeypatch.setenv("RETENTION_PERIOD_DAYS", "0")
+    assert get_retention_period_days() is None
+
+
+def test_returns_days_when_positive(monkeypatch):
+    monkeypatch.setenv("RETENTION_PERIOD_DAYS", "7")
+    assert get_retention_period_days() == 7
+
+
+def test_returns_none_on_invalid_value(monkeypatch):
+    monkeypatch.setenv("RETENTION_PERIOD_DAYS", "abc")
+    assert get_retention_period_days() is None
+
+
+# --- run_retention_cleanup ---
+
+def _make_presentation(days_old: int, file_paths=None):
+    p = MagicMock()
+    p.id = uuid.uuid4()
+    p.created_at = datetime.now(timezone.utc) - timedelta(days=days_old)
+    p.file_paths = file_paths
+    return p
+
+
+@pytest.mark.asyncio
+async def test_stale_presentation_is_deleted():
+    session = AsyncMock()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+
+    presentation = _make_presentation(days_old=10)
+
+    # No templates (nothing protected)
+    session.exec.side_effect = [
+        MagicMock(all=MagicMock(return_value=[])),        # template ids
+        MagicMock(all=MagicMock(return_value=[presentation])),  # stale presentations
+        MagicMock(),                                       # delete layout codes
+        MagicMock(),                                       # delete tasks
+    ]
+
+    result = await run_retention_cleanup(session, cutoff)
+
+    session.delete.assert_awaited_once_with(presentation)
+    assert result["presentations_deleted"] == 1
+
+
+@pytest.mark.asyncio
+async def test_protected_presentation_is_skipped():
+    session = AsyncMock()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+
+    presentation = _make_presentation(days_old=10)
+
+    # This presentation is a saved template
+    session.exec.side_effect = [
+        MagicMock(all=MagicMock(return_value=[presentation.id])),  # template ids
+        MagicMock(all=MagicMock(return_value=[presentation])),     # stale presentations
+        MagicMock(),                                                # delete tasks
+    ]
+
+    result = await run_retention_cleanup(session, cutoff)
+
+    session.delete.assert_not_awaited()
+    assert result["presentations_deleted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_files_are_deleted_with_presentation(tmp_path):
+    session = AsyncMock()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+
+    test_file = tmp_path / "slide.pptx"
+    test_file.write_text("data")
+
+    presentation = _make_presentation(days_old=10, file_paths=[str(test_file)])
+
+    session.exec.side_effect = [
+        MagicMock(all=MagicMock(return_value=[])),
+        MagicMock(all=MagicMock(return_value=[presentation])),
+        MagicMock(),
+        MagicMock(),
+    ]
+
+    await run_retention_cleanup(session, cutoff)
+
+    assert not test_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_returns_correct_summary():
+    session = AsyncMock()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+
+    session.exec.side_effect = [
+        MagicMock(all=MagicMock(return_value=[])),
+        MagicMock(all=MagicMock(return_value=[])),
+        MagicMock(rowcount=3),
+    ]
+
+    result = await run_retention_cleanup(session, cutoff)
+
+    assert result["presentations_deleted"] == 0
+    assert "cutoff" in result


### PR DESCRIPTION
Closes #455

## What
Adds a background data retention service that automatically deletes stale presentations on a configurable schedule.

## How
- New `services/data_retention_service.py` with a `retention_scheduler()` asyncio task
- Wired into `api/lifespan.py` — starts on app startup, cancelled on shutdown
- Reads `RETENTION_PERIOD_DAYS` env var (default: 0 = disabled)

## Behaviour
- Runs once every 24 hours
- Deletes presentations older than `RETENTION_PERIOD_DAYS` days
- Skips presentations that have a saved template row
- Cascades: slides delete automatically (FK CASCADE)
- Also deletes: `presentation_layout_codes`, `async_presentation_generation_tasks`, and `file_paths` from disk
- Logs a summary after each run

## Usage
```env
RETENTION_PERIOD_DAYS=7
```