### PR TITLE
bugfix: auth issue while api export

### DIFF
--- a/servers/fastapi/services/export_task_service.py
+++ b/servers/fastapi/services/export_task_service.py
@@ -357,9 +357,10 @@ class ExportTaskService:
         fastapi_url: str | None = None,
         cookie_header: str | None = None,
     ) -> PresentationExportTaskResult:
+        log_url = url.split("#", 1)[0] if "#" in url else url
         LOGGER.info(
             "[export_runtime] export_from_url url=%s format=%s cookie_header=%s",
-            url,
+            log_url,
             export_as,
             "set" if cookie_header else "empty",
         )

--- a/servers/fastapi/tests/unit/test_small_surfaces_coverage.py
+++ b/servers/fastapi/tests/unit/test_small_surfaces_coverage.py
@@ -412,11 +412,21 @@ def test_export_includes_optional_fastapi_param():
             },
             clear=False,
         ), patch.object(EXPORT_TASK_SERVICE, "export_from_url", mock_pdf):
-            await export_presentation(dummy, title="safe", export_as="pdf")
+            await export_presentation(
+                dummy,
+                title="safe",
+                export_as="pdf",
+                cookie_header="presenton_session=abc; theme=dark",
+            )
 
         pdf_call = mock_pdf.await_args.kwargs
         assert "pdf-maker" in pdf_call["url"]
+        assert (
+            "#exportCookie=presenton_session%3Dabc%3B+theme%3Ddark"
+            in pdf_call["url"]
+        )
         assert pdf_call["fastapi_url"] == "https://fast.example"
+        assert pdf_call["cookie_header"] == "presenton_session=abc; theme=dark"
 
         mock_pptx = AsyncMock(return_value=fake_result)
         with patch.dict(
@@ -424,6 +434,7 @@ def test_export_includes_optional_fastapi_param():
         ), patch.object(EXPORT_TASK_SERVICE, "export_from_url", mock_pptx):
             await export_presentation(dummy, title="two", export_as="pptx")
         pptx_call = mock_pptx.await_args.kwargs
+        assert "#" not in pptx_call["url"]
         assert pptx_call["fastapi_url"] is None
 
     asyncio.run(runner())

--- a/servers/fastapi/utils/export_utils.py
+++ b/servers/fastapi/utils/export_utils.py
@@ -24,13 +24,18 @@ def _get_next_public_fastapi_url() -> str | None:
     return value or None
 
 
-def _build_presentation_export_url(presentation_id: uuid.UUID) -> tuple[str, str | None]:
+def _build_presentation_export_url(
+    presentation_id: uuid.UUID, cookie_header: str | None = None
+) -> tuple[str, str | None]:
     params = {"id": str(presentation_id)}
     fastapi_url = _get_next_public_fastapi_url()
     if fastapi_url:
         params["fastapiUrl"] = fastapi_url
+    export_url = f"{_get_next_public_url().rstrip('/')}/pdf-maker?{urlencode(params)}"
+    if cookie_header:
+        export_url = f"{export_url}#{urlencode({'exportCookie': cookie_header})}"
     return (
-        f"{_get_next_public_url().rstrip('/')}/pdf-maker?{urlencode(params)}",
+        export_url,
         fastapi_url,
     )
 
@@ -47,7 +52,9 @@ async def export_presentation(
         presentation_id=str(presentation_id),
         export_as=export_as,
     )
-    export_url, fastapi_url = _build_presentation_export_url(presentation_id)
+    export_url, fastapi_url = _build_presentation_export_url(
+        presentation_id, cookie_header
+    )
     name = (title or "").strip() or str(uuid.uuid4())
     export_result = await EXPORT_TASK_SERVICE.export_from_url(
         url=export_url,

--- a/servers/nextjs/next-env.d.ts
+++ b/servers/nextjs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next-build/types/routes.d.ts";
+import "./.next-build/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Occasional Error: 

{"detail":"Export task failed. stderr=[index] Presentation slides not found stdout=[openUrlAndGetStablePage] Cookie header mode: enabled\n[waitForTailwindCdn] Waiting for Tailwind CDN to be ready\n[waitForTailwindCdn] Tailwind CDN ready\n[waitForAllImagesLoaded] Waiting for all images to be loaded\n[waitForAllImagesLoaded] All images loaded\n[waitForFontsReady] Waiting for fonts to be ready\n[waitForFontsReady] Fonts ready\n[waitForDomIdle] Waiting for DOM to be idle\n[waitForDomIdle] DOM idle\n[waitForAllContentLoaded] Waiting for all content to be loaded\n[waitForAllContentLoaded] All content loaded"}

Fixed by adding export cookie in the url path and reading from it:

/pdf-maker?id=...#exportCookie=<encoded cookie>