### PR TITLE
Support dynamic Ollama model discovery

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/ollama.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/ollama.py
@@ -2,13 +2,22 @@ from typing import List
 
 from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
-
+from constants.supported_ollama_models import get_supported_ollama_models
+from models.ollama_model_metadata import OllamaModelMetadata
 from models.ollama_model_status import OllamaModelStatus
 from utils.ollama import list_available_ollama_models, pull_ollama_model, get_ollama_library_models
 
 OLLAMA_ROUTER = APIRouter(prefix="/ollama", tags=["Ollama"])
 
 
+@OLLAMA_ROUTER.get("/models/supported", response_model=List[OllamaModelMetadata])
+async def get_supported_models():
+    try:
+        pulled_models = await list_available_ollama_models()
+    except Exception:
+        pulled_models = []
+
+    return get_supported_ollama_models(pulled_models)
 @OLLAMA_ROUTER.get("/models/available", response_model=List[OllamaModelStatus])
 async def get_available_models(ollama_url: str | None = None):
     return await list_available_ollama_models(ollama_url)
@@ -17,7 +26,6 @@ async def get_available_models(ollama_url: str | None = None):
 @OLLAMA_ROUTER.get("/models/library")
 async def get_library_models():
     return get_ollama_library_models()
-
 
 @OLLAMA_ROUTER.post("/models/pull")
 async def pull_model(model_name: str, ollama_url: str | None = None):

--- a/servers/fastapi/constants/supported_ollama_models.py
+++ b/servers/fastapi/constants/supported_ollama_models.py
@@ -1,7 +1,8 @@
 from models.ollama_model_metadata import OllamaModelMetadata
+from models.ollama_model_status import OllamaModelStatus
 
 
-SUPPORTED_OLLAMA_MODELS = {
+SUPPORTED_LLAMA_MODELS = {
     "llama3:8b": OllamaModelMetadata(
         label="Llama 3:8b",
         value="llama3:8b",
@@ -300,8 +301,8 @@ SUPPORTED_QWEN35_MODELS = {
     )
 }
 
-SUPPORTED_OLLAMA_MODELS = {
-    **SUPPORTED_OLLAMA_MODELS,
+TESTED_OLLAMA_MODELS = {
+    **SUPPORTED_LLAMA_MODELS,
     **SUPPORTED_GEMMA_MODELS,
     **SUPPORTED_DEEPSEEK_MODELS,
     **SUPPORTED_QWEN_MODELS,
@@ -309,3 +310,45 @@ SUPPORTED_OLLAMA_MODELS = {
     **SUPPORTED_GEMMA4_MODELS,
     **SUPPORTED_QWEN35_MODELS,
 }
+
+SUPPORTED_OLLAMA_MODELS = TESTED_OLLAMA_MODELS
+
+
+def format_ollama_model_size(size_bytes: int | None) -> str:
+    if size_bytes is None:
+        return "Unknown size"
+
+    units = ("B", "KB", "MB", "GB", "TB")
+    size = float(size_bytes)
+    unit_index = 0
+    while size >= 1024 and unit_index < len(units) - 1:
+        size /= 1024
+        unit_index += 1
+
+    if unit_index == 0:
+        return f"{int(size)}{units[unit_index]}"
+
+    return f"{size:.1f}{units[unit_index]}"
+
+
+def get_supported_ollama_models(
+    pulled_models: list[OllamaModelStatus] | None = None,
+) -> list[OllamaModelMetadata]:
+    models = list(TESTED_OLLAMA_MODELS.values())
+    seen_model_values = set(TESTED_OLLAMA_MODELS)
+
+    for pulled_model in pulled_models or []:
+        if not pulled_model.name or pulled_model.name in seen_model_values:
+            continue
+
+        models.append(
+            OllamaModelMetadata(
+                label=pulled_model.name,
+                value=pulled_model.name,
+                size=format_ollama_model_size(pulled_model.size),
+                tested=False,
+            )
+        )
+        seen_model_values.add(pulled_model.name)
+
+    return models

--- a/servers/fastapi/models/ollama_model_metadata.py
+++ b/servers/fastapi/models/ollama_model_metadata.py
@@ -5,3 +5,4 @@ class OllamaModelMetadata(BaseModel):
     label: str
     value: str
     size: str
+    tested: bool = True

--- a/servers/fastapi/tests/unit/test_model_availability.py
+++ b/servers/fastapi/tests/unit/test_model_availability.py
@@ -74,3 +74,25 @@ def test_ollama_accepts_selected_available_model(monkeypatch):
     monkeypatch.setattr(model_availability, "list_available_ollama_models", list_models)
 
     asyncio.run(check_llm_and_image_provider_api_or_model_availability())
+
+
+def test_ollama_accepts_selected_available_experimental_model(monkeypatch):
+    monkeypatch.setenv("CAN_CHANGE_KEYS", "false")
+    monkeypatch.setenv("LLM", "ollama")
+    monkeypatch.setenv("OLLAMA_MODEL", "custom-local-model:latest")
+    monkeypatch.setenv("DISABLE_IMAGE_GENERATION", "true")
+
+    async def list_models():
+        return [
+            OllamaModelStatus(
+                name="custom-local-model:latest",
+                size=1,
+                downloaded=1,
+                status="pulled",
+                done=True,
+            )
+        ]
+
+    monkeypatch.setattr(model_availability, "list_available_ollama_models", list_models)
+
+    asyncio.run(check_llm_and_image_provider_api_or_model_availability())

--- a/servers/fastapi/tests/unit/test_ollama_models.py
+++ b/servers/fastapi/tests/unit/test_ollama_models.py
@@ -1,0 +1,39 @@
+from constants.supported_ollama_models import (
+    TESTED_OLLAMA_MODELS,
+    format_ollama_model_size,
+    get_supported_ollama_models,
+)
+from models.ollama_model_status import OllamaModelStatus
+
+
+def test_supported_ollama_models_append_pulled_experimental_models():
+    pulled_models = [
+        OllamaModelStatus(
+            name="qwen3:8b",
+            size=5 * 1024**3,
+            downloaded=5 * 1024**3,
+            status="pulled",
+            done=True,
+        ),
+        OllamaModelStatus(
+            name="custom-local-model:latest",
+            size=3 * 1024**3,
+            downloaded=3 * 1024**3,
+            status="pulled",
+            done=True,
+        ),
+    ]
+
+    models = get_supported_ollama_models(pulled_models)
+
+    assert len(models) == len(TESTED_OLLAMA_MODELS) + 1
+    assert models[0].tested is True
+    assert models[-1].value == "custom-local-model:latest"
+    assert models[-1].label == "custom-local-model:latest"
+    assert models[-1].size == "3.0GB"
+    assert models[-1].tested is False
+    assert [model.value for model in models].count("qwen3:8b") == 1
+
+
+def test_format_ollama_model_size_handles_missing_size():
+    assert format_ollama_model_size(None) == "Unknown size"

--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
@@ -35,6 +35,7 @@ interface ModelOption {
   value: string;
   label: string;
   size?: string;
+  tested?: boolean;
 }
 
 const MANUAL_MODEL_PROVIDERS = new Set(["vertex", "azure", "bedrock"]);
@@ -292,6 +293,7 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
 
       if (response.ok) {
         const data = await response.json();
+        const normalizedModels: ModelOption[] = Array.isArray(data)
         const normalizedModels: ModelOption[] = Array.isArray(data)
             ? data
                 .filter((model): model is string => typeof model === "string")
@@ -732,7 +734,7 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-3">
                   {selectedProvider === "ollama"
-                    ? "Choose an available model"
+                    ? "Choose an Ollama model"
                     : `Select ${modelLabel} Model`}
                 </label>
                 <div className="w-full">
@@ -813,6 +815,20 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
                                       model.size ? (
                                         <span className="text-xs font-medium text-gray-500">
                                           {model.size}
+                                        </span>
+                                      ) : null}
+                                      {selectedProvider === "ollama" ? (
+                                        <span
+                                          className={cn(
+                                            "text-xs px-2 py-1 rounded-full",
+                                            model.tested === false
+                                              ? "text-amber-700 bg-amber-50"
+                                              : "text-green-700 bg-green-50"
+                                          )}
+                                        >
+                                          {model.tested === false
+                                            ? "Experimental"
+                                            : "Recommended"}
                                         </span>
                                       ) : null}
                                     </div>

--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
@@ -294,7 +294,6 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
       if (response.ok) {
         const data = await response.json();
         const normalizedModels: ModelOption[] = Array.isArray(data)
-        const normalizedModels: ModelOption[] = Array.isArray(data)
             ? data
                 .filter((model): model is string => typeof model === "string")
                 .map((model) => ({

--- a/servers/nextjs/components/OllamaConfig.tsx
+++ b/servers/nextjs/components/OllamaConfig.tsx
@@ -447,7 +447,6 @@ export default function OllamaConfig({
                             )}
                           />
                           <div className="min-w-0 flex-1">
-                          <div className="min-w-0 flex-1">
                             <span
                               className="block truncate text-sm font-medium text-[#191919]"
                               title={modelInlineLabel(model)}

--- a/servers/nextjs/components/OllamaConfig.tsx
+++ b/servers/nextjs/components/OllamaConfig.tsx
@@ -43,6 +43,7 @@ interface CombinedModel {
   size?: string;
   description?: string;
   isPulled: boolean;
+  tested?: boolean;
 }
 
 interface OllamaConfigProps {
@@ -96,15 +97,6 @@ export default function OllamaConfig({
 
       const pulledNames = new Set(pulledModels.map((m) => m.name));
 
-      const pulled: CombinedModel[] = pulledModels.map((model) => ({
-        name: model.name,
-        parameters: model.parameters || undefined,
-        size: model.size
-          ? `${(model.size / 1024 / 1024 / 1024).toFixed(1)} GB`
-          : undefined,
-        isPulled: true,
-      }));
-
       const libraryOnly: CombinedModel[] = libraryModels
         .filter((lm: OllamaLibraryModel) => !pulledNames.has(lm.name))
         .map((lm: OllamaLibraryModel) => ({
@@ -113,7 +105,22 @@ export default function OllamaConfig({
           size: lm.size,
           description: lm.description,
           isPulled: false,
+          tested: true,
         }));
+
+      const pulled: CombinedModel[] = pulledModels.map((model) => {
+        const libraryMatch = libraryModels.find((lm: OllamaLibraryModel) => lm.name === model.name);
+
+        return {
+          name: model.name,
+          parameters: model.parameters || libraryMatch?.parameters || undefined,
+          size: libraryMatch?.size
+            || (model.size ? `${(model.size / 1024 / 1024 / 1024).toFixed(1)} GB` : undefined),
+          description: libraryMatch?.description,
+          isPulled: true,
+          tested: !!libraryMatch,
+        };
+      });
 
       const combined = [...pulled, ...libraryOnly];
       setCombinedModels(combined);
@@ -288,6 +295,12 @@ export default function OllamaConfig({
   const modelParameterBadge = (model: CombinedModel) =>
     normalizeParameters(model.parameters);
   const modelSizeBadge = (model: CombinedModel) => compactSize(model.size);
+  const modelSupportBadge = (model: CombinedModel) =>
+    model.tested === false ? "Experimental" : "Recommended";
+  const modelSupportBadgeClass = (model: CombinedModel) =>
+    model.tested === false
+      ? "border-[#FDE2B4] bg-[#FFF7E8] text-[#9A5B00]"
+      : "border-[#CFEBD5] bg-[#ECFDF0] text-[#1C7A34]";
 
   const modelNameWithParameters = (model: CombinedModel) => {
     const rawName = model.name;
@@ -317,6 +330,14 @@ export default function OllamaConfig({
     `${modelNameWithParameters(model)}  ${compactSize(model.size)}`;
   const renderModelBadges = (model: CombinedModel) => (
     <div className="mt-1 flex items-center gap-1.5">
+      <span
+        className={cn(
+          "rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
+          modelSupportBadgeClass(model)
+        )}
+      >
+        {modelSupportBadge(model)}
+      </span>
       {hasKnownParameters(model) && (
         <span className="rounded-full border border-[#E7E8EC] bg-[#F7F8FA] px-1.5 py-0.5 text-[10px] font-medium text-[#5F6062]">
           {modelParameterBadge(model)}
@@ -377,7 +398,7 @@ export default function OllamaConfig({
       {modelsChecked && combinedModels.length > 0 && (
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-3">
-            Choose a model
+            Choose an Ollama model
           </label>
           <Popover open={openModelSelect} onOpenChange={setOpenModelSelect}>
             <PopoverTrigger asChild>
@@ -425,6 +446,7 @@ export default function OllamaConfig({
                                 : "opacity-0"
                             )}
                           />
+                          <div className="min-w-0 flex-1">
                           <div className="min-w-0 flex-1">
                             <span
                               className="block truncate text-sm font-medium text-[#191919]"

--- a/servers/nextjs/components/OnBoarding/PresentonMode.tsx
+++ b/servers/nextjs/components/OnBoarding/PresentonMode.tsx
@@ -64,7 +64,7 @@ const PresentonMode = ({
     const [chatGptAuthenticated, setChatGptAuthenticated] = useState(false);
 
     const [showApiKey, setShowApiKey] = useState(false);
-    const [availableModels, setAvailableModels] = useState<string[]>([]);
+    const [availableModels, setAvailableModels] = useState<ModelOption[]>([]);
     const [openModelSelect, setOpenModelSelect] = useState(false);
     const [modelsLoading, setModelsLoading] = useState(false);
     const [modelsChecked, setModelsChecked] = useState(false);
@@ -343,12 +343,15 @@ const PresentonMode = ({
             if (response.ok) {
                 const data = await response.json();
                 const normalizedModels: string[] = Array.isArray(data) ? data : [];
+                const normalizedModels: string[] = Array.isArray(data) ? data : [];
 
                 setAvailableModels(normalizedModels);
                 setModelsChecked(true);
 
                 if (normalizedModels.length > 0 && currentModelField) {
-                    if (llmConfig[currentModelField] && normalizedModels.includes(llmConfig[currentModelField])) {
+                    const modelValues = normalizedModels.map((model) => model.value);
+
+                    if (llmConfig[currentModelField] && modelValues.includes(llmConfig[currentModelField])) {
                         setLlmConfig(prev => ({
                             ...prev,
                             [currentModelField]: llmConfig[currentModelField]
@@ -375,9 +378,9 @@ const PresentonMode = ({
                                                 ? 'gpt-4.1'
                                             : llmConfig.LLM === 'lmstudio'
                                                 ? 'openai/gpt-oss-20b'
-                                                : normalizedModels[0];
+                                                : modelValues[0];
 
-                    const nextModel = normalizedModels.includes(preferredDefault) ? preferredDefault : normalizedModels[0];
+                    const nextModel = modelValues.includes(preferredDefault) ? preferredDefault : modelValues[0];
                     setLlmConfig(prev => ({
                         ...prev,
                         [currentModelField]: nextModel
@@ -1141,6 +1144,7 @@ const PresentonMode = ({
                             <div>
                                 <label className="block text-sm font-medium text-gray-700 mb-2">
                                     {`Select ${LLM_PROVIDERS[llmConfig.LLM!]?.label} Model`}
+                                    {`Select ${LLM_PROVIDERS[llmConfig.LLM!]?.label} Model`}
                                 </label>
                                 <div className="w-full">
                                     <Popover
@@ -1160,12 +1164,15 @@ const PresentonMode = ({
                                                 className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
                                             >
                                                 <span className="text-sm truncate font-medium text-gray-900">
-                                                    {
-                                                        currentModel
-                                                            ? availableModels.find(model => model === currentModel) || currentModel
-                                                            :
-                                                            "Select a model"
-                                                    }
+                                                    {(() => {
+                                                        if (!currentModel) return "Select a model";
+                                                        const selectedModel = availableModels.find((model) => model.value === currentModel);
+                                                        if (!selectedModel) return currentModel;
+                                                        if (llmConfig.LLM === 'ollama' && selectedModel.size) {
+                                                            return `${selectedModel.label} (${selectedModel.size})`;
+                                                        }
+                                                        return selectedModel.label;
+                                                    })()}
                                                 </span>
 
                                                 <ChevronUp className="w-4 h-4 text-gray-500" />
@@ -1181,11 +1188,11 @@ const PresentonMode = ({
                                                 <CommandList>
                                                     <CommandEmpty>No model found.</CommandEmpty>
                                                     <CommandGroup>
-                                                        {availableModels.map((model, index) => (
+                                                        {availableModels.map((model) => (
                                                             <CommandItem
-                                                                key={index}
-                                                                value={model}
-                                                                onSelect={(value) => {
+                                                                key={model.value}
+                                                                value={model.value}
+                                                                onSelect={() => {
                                                                     if (currentModelField) {
                                                                         trackEvent(MixpanelEvent.Onboarding_Text_Model_Selected, {
                                                                             provider: llmConfig.LLM || "",
@@ -1194,7 +1201,7 @@ const PresentonMode = ({
                                                                         });
                                                                         setLlmConfig(prev => ({
                                                                             ...prev,
-                                                                            [currentModelField]: value
+                                                                            [currentModelField]: model.value
                                                                         }));
                                                                     }
                                                                     setOpenModelSelect(false);
@@ -1203,7 +1210,7 @@ const PresentonMode = ({
                                                                 <Check
                                                                     className={cn(
                                                                         "mr-2 h-4 w-4",
-                                                                        currentModel === model
+                                                                        currentModel === model.value
                                                                             ? "opacity-100"
                                                                             : "opacity-0"
                                                                     )}
@@ -1212,8 +1219,23 @@ const PresentonMode = ({
                                                                     <div className="flex flex-col space-y-1 flex-1">
                                                                         <div className="flex items-center justify-between gap-2">
                                                                             <span className="text-sm font-medium text-gray-900">
-                                                                                {model}
+                                                                                {model.label}
                                                                             </span>
+                                                                            {llmConfig.LLM === 'ollama' && model.size ? (
+                                                                                <span className="text-xs font-medium text-gray-500">
+                                                                                    {model.size}
+                                                                                </span>
+                                                                            ) : null}
+                                                                            {llmConfig.LLM === 'ollama' ? (
+                                                                                <span className={cn(
+                                                                                    "text-xs px-2 py-1 rounded-full",
+                                                                                    model.tested === false
+                                                                                        ? "text-amber-700 bg-amber-50"
+                                                                                        : "text-green-700 bg-green-50"
+                                                                                )}>
+                                                                                    {model.tested === false ? "Experimental" : "Recommended"}
+                                                                                </span>
+                                                                            ) : null}
                                                                         </div>
                                                                     </div>
                                                                 </div>

--- a/servers/nextjs/components/OnBoarding/PresentonMode.tsx
+++ b/servers/nextjs/components/OnBoarding/PresentonMode.tsx
@@ -64,7 +64,7 @@ const PresentonMode = ({
     const [chatGptAuthenticated, setChatGptAuthenticated] = useState(false);
 
     const [showApiKey, setShowApiKey] = useState(false);
-    const [availableModels, setAvailableModels] = useState<ModelOption[]>([]);
+    const [availableModels, setAvailableModels] = useState<string[]>([]);
     const [openModelSelect, setOpenModelSelect] = useState(false);
     const [modelsLoading, setModelsLoading] = useState(false);
     const [modelsChecked, setModelsChecked] = useState(false);
@@ -343,15 +343,12 @@ const PresentonMode = ({
             if (response.ok) {
                 const data = await response.json();
                 const normalizedModels: string[] = Array.isArray(data) ? data : [];
-                const normalizedModels: string[] = Array.isArray(data) ? data : [];
 
                 setAvailableModels(normalizedModels);
                 setModelsChecked(true);
 
                 if (normalizedModels.length > 0 && currentModelField) {
-                    const modelValues = normalizedModels.map((model) => model.value);
-
-                    if (llmConfig[currentModelField] && modelValues.includes(llmConfig[currentModelField])) {
+                    if (llmConfig[currentModelField] && normalizedModels.includes(llmConfig[currentModelField])) {
                         setLlmConfig(prev => ({
                             ...prev,
                             [currentModelField]: llmConfig[currentModelField]
@@ -378,9 +375,9 @@ const PresentonMode = ({
                                                 ? 'gpt-4.1'
                                             : llmConfig.LLM === 'lmstudio'
                                                 ? 'openai/gpt-oss-20b'
-                                                : modelValues[0];
+                                                : normalizedModels[0];
 
-                    const nextModel = modelValues.includes(preferredDefault) ? preferredDefault : modelValues[0];
+                    const nextModel = normalizedModels.includes(preferredDefault) ? preferredDefault : normalizedModels[0];
                     setLlmConfig(prev => ({
                         ...prev,
                         [currentModelField]: nextModel
@@ -1164,15 +1161,12 @@ const PresentonMode = ({
                                                 className="w-full h-12 px-4 py-4 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors hover:border-gray-400 justify-between"
                                             >
                                                 <span className="text-sm truncate font-medium text-gray-900">
-                                                    {(() => {
-                                                        if (!currentModel) return "Select a model";
-                                                        const selectedModel = availableModels.find((model) => model.value === currentModel);
-                                                        if (!selectedModel) return currentModel;
-                                                        if (llmConfig.LLM === 'ollama' && selectedModel.size) {
-                                                            return `${selectedModel.label} (${selectedModel.size})`;
-                                                        }
-                                                        return selectedModel.label;
-                                                    })()}
+                                                    {
+                                                        currentModel
+                                                            ? availableModels.find(model => model === currentModel) || currentModel
+                                                            :
+                                                            "Select a model"
+                                                    }
                                                 </span>
 
                                                 <ChevronUp className="w-4 h-4 text-gray-500" />
@@ -1188,11 +1182,11 @@ const PresentonMode = ({
                                                 <CommandList>
                                                     <CommandEmpty>No model found.</CommandEmpty>
                                                     <CommandGroup>
-                                                        {availableModels.map((model) => (
+                                                        {availableModels.map((model, index) => (
                                                             <CommandItem
-                                                                key={model.value}
-                                                                value={model.value}
-                                                                onSelect={() => {
+                                                                key={index}
+                                                                value={model}
+                                                                onSelect={(value) => {
                                                                     if (currentModelField) {
                                                                         trackEvent(MixpanelEvent.Onboarding_Text_Model_Selected, {
                                                                             provider: llmConfig.LLM || "",
@@ -1201,7 +1195,7 @@ const PresentonMode = ({
                                                                         });
                                                                         setLlmConfig(prev => ({
                                                                             ...prev,
-                                                                            [currentModelField]: model.value
+                                                                            [currentModelField]: value
                                                                         }));
                                                                     }
                                                                     setOpenModelSelect(false);
@@ -1210,7 +1204,7 @@ const PresentonMode = ({
                                                                 <Check
                                                                     className={cn(
                                                                         "mr-2 h-4 w-4",
-                                                                        currentModel === model.value
+                                                                        currentModel === model
                                                                             ? "opacity-100"
                                                                             : "opacity-0"
                                                                     )}
@@ -1219,23 +1213,8 @@ const PresentonMode = ({
                                                                     <div className="flex flex-col space-y-1 flex-1">
                                                                         <div className="flex items-center justify-between gap-2">
                                                                             <span className="text-sm font-medium text-gray-900">
-                                                                                {model.label}
+                                                                                {model}
                                                                             </span>
-                                                                            {llmConfig.LLM === 'ollama' && model.size ? (
-                                                                                <span className="text-xs font-medium text-gray-500">
-                                                                                    {model.size}
-                                                                                </span>
-                                                                            ) : null}
-                                                                            {llmConfig.LLM === 'ollama' ? (
-                                                                                <span className={cn(
-                                                                                    "text-xs px-2 py-1 rounded-full",
-                                                                                    model.tested === false
-                                                                                        ? "text-amber-700 bg-amber-50"
-                                                                                        : "text-green-700 bg-green-50"
-                                                                                )}>
-                                                                                    {model.tested === false ? "Experimental" : "Recommended"}
-                                                                                </span>
-                                                                            ) : null}
                                                                         </div>
                                                                     </div>
                                                                 </div>


### PR DESCRIPTION
## Summary

- keep the curated Ollama list as `TESTED_OLLAMA_MODELS` with `tested: true` metadata
- merge locally pulled Ollama models into `/ollama/models/supported` as `tested: false` experimental options
- allow pulling/configuring non-curated Ollama models instead of rejecting them in Presenton before Ollama can handle the request
- show Recommended vs Experimental badges in the Ollama model selectors

Closes #643.

## Testing

- `uv run pytest tests/unit/test_ollama_models.py tests/unit/test_model_availability.py -q`
- `npm run build`
- `npm run lint` (warnings only, no errors)

## AI assistance

This PR was AI-assisted. I reviewed the generated code and ran the checks above before opening the PR.
