### PR TITLE
fix: use default Ollama URL automatically

### DIFF
--- a/servers/nextjs/utils/storeHelpers.ts
+++ b/servers/nextjs/utils/storeHelpers.ts
@@ -2,6 +2,8 @@ import { setLLMConfig } from "@/store/slices/userConfig";
 import { store } from "@/store/store";
 import { LLMConfig } from "@/types/llm_config";
 
+const DEFAULT_OLLAMA_URL = "http://localhost:11434";
+
 function isProvided(value: unknown): boolean {
   return value !== "" && value !== null && value !== undefined;
 }
@@ -29,6 +31,14 @@ export const normalizeLLMConfig = (llmConfig: LLMConfig): LLMConfig => {
 
   if (!normalizedConfig.LLM) {
     normalizedConfig.LLM = "openai";
+  }
+
+  if (
+    normalizedConfig.LLM === "ollama" &&
+    !normalizedConfig.USE_CUSTOM_URL &&
+    !isProvided(normalizedConfig.OLLAMA_URL)
+  ) {
+    normalizedConfig.OLLAMA_URL = DEFAULT_OLLAMA_URL;
   }
 
   const parsedDisableImageGeneration = parseOptionalBool(


### PR DESCRIPTION
## Summary
- use the default Ollama URL when default URL mode is selected
- keep empty custom Ollama URLs invalid

Fixes PRE-313

## Verification
- `npx tsc --noEmit --incremental false`
- `npx eslint utils/storeHelpers.ts`
- behavior assertions for default and custom URL modes