### PR TITLE
feat: implement MCP authentication and update OpenAPI specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,43 @@ docker stop presenton && docker rm presenton && docker run -it --name presenton 
 
 Sign out from the app: **Settings → Other → Sign out**.
 
+#### MCP authentication
+
+When auth is configured (`AUTH_USERNAME` / `AUTH_PASSWORD`), the MCP endpoint at `/mcp` now requires authentication as well.
+
+1. Log in once to get a bearer token:
+
+```bash
+curl -s -X POST http://localhost:5000/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"changeme123"}'
+```
+
+The response includes:
+
+- `access_token` (session token)
+- `token_type` (`bearer`)
+
+2. Configure your MCP client to send that token on every request:
+
+```json
+{
+  "mcpServers": {
+    "presenton": {
+      "url": "http://localhost:5000/mcp",
+      "headers": {
+        "Authorization": "Bearer <access_token>"
+      }
+    }
+  }
+}
+```
+
+Notes:
+
+- If you rotate credentials with `AUTH_OVERRIDE_FROM_ENV=true`, previously issued session tokens are invalidated.
+- In Electron mode (`DISABLE_AUTH=true`), MCP auth is disabled to match the local desktop auth behavior.
+
 > Note: LLM and image variables above are forwarded from **`docker-compose.yml`** when set in `.env`.
 
 <br>

--- a/nginx.conf
+++ b/nginx.conf
@@ -45,6 +45,7 @@ http {
 
     # MCP
     location /mcp/ {
+      auth_request /_auth_check;
       proxy_pass http://localhost:8001/mcp/;
       proxy_read_timeout 30m;
       proxy_connect_timeout 30m;
@@ -55,6 +56,7 @@ http {
     }
 
     location /mcp {
+      auth_request /_auth_check;
       proxy_pass http://localhost:8001/mcp;
       proxy_read_timeout 30m;
       proxy_connect_timeout 30m;

--- a/servers/fastapi/api/v1/auth/router.py
+++ b/servers/fastapi/api/v1/auth/router.py
@@ -88,7 +88,13 @@ async def login(body: AuthCredentialsRequest, request: Request):
     username = body.username.strip()
     token = create_session_token(username)
     response = JSONResponse(
-        {"configured": True, "authenticated": True, "username": username}
+        {
+            "configured": True,
+            "authenticated": True,
+            "username": username,
+            "access_token": token,
+            "token_type": "bearer",
+        }
     )
     set_session_cookie(response, token, request)
     return response

--- a/servers/fastapi/constants/presentation.py
+++ b/servers/fastapi/constants/presentation.py
@@ -1,2 +1,51 @@
-DEFAULT_TEMPLATES = ["general", "modern", "standard", "swift"]
+import re
+from pathlib import Path
+
 MAX_NUMBER_OF_SLIDES = 50
+
+_PREFERRED_TEMPLATE_ORDER = [
+    "general",
+    "modern",
+    "standard",
+    "swift",
+    "code",
+    "education",
+    "product-overview",
+    "report",
+    "pitch-deck",
+    "neo-general",
+    "neo-standard",
+    "neo-modern",
+    "neo-swift",
+]
+
+
+def _normalize_template_group_id(directory_name: str) -> str:
+    """Map template folder names to the runtime template IDs."""
+    cleaned = re.sub(r"(?<!^)(?=[A-Z])", "-", directory_name).lower()
+    return cleaned.replace("_", "-")
+
+
+def _discover_default_templates() -> list[str]:
+    templates_dir = (
+        Path(__file__).resolve().parents[2]
+        / "nextjs"
+        / "app"
+        / "presentation-templates"
+    )
+
+    if not templates_dir.is_dir():
+        return list(_PREFERRED_TEMPLATE_ORDER)
+
+    discovered = {
+        _normalize_template_group_id(entry.name)
+        for entry in templates_dir.iterdir()
+        if entry.is_dir() and (entry / "settings.json").is_file()
+    }
+
+    ordered = [name for name in _PREFERRED_TEMPLATE_ORDER if name in discovered]
+    extras = sorted(discovered - set(ordered))
+    return ordered + extras
+
+
+DEFAULT_TEMPLATES = _discover_default_templates()

--- a/servers/fastapi/mcp_server.py
+++ b/servers/fastapi/mcp_server.py
@@ -2,24 +2,79 @@ import sys
 import argparse
 import asyncio
 import traceback
+from pathlib import Path
 
 import httpx
 from fastmcp import FastMCP
+from fastmcp.server.auth import AccessToken, TokenVerifier
+from fastmcp.server.dependencies import get_access_token, get_http_headers
 import json
 
-from utils.simple_auth import get_internal_auth_headers
+from utils.get_env import is_disable_auth_enabled
+from utils.simple_auth import is_auth_configured, validate_session_token
 
-with open("openai_spec.json", "r") as f:
+OPENAPI_SPEC_PATH = Path(__file__).with_name("openai_spec.json")
+MCP_API_BASE_URL = "http://127.0.0.1:8000"
+# Presentation generation can take several minutes; keep MCP upstream reads open.
+MCP_API_TIMEOUT_SECONDS = 600.0
+MCP_API_CONNECT_TIMEOUT_SECONDS = 15.0
+
+with OPENAPI_SPEC_PATH.open("r", encoding="utf-8") as f:
     openapi_spec = json.load(f)
 
 
-async def attach_internal_auth_header(request: httpx.Request) -> None:
+class PresentonTokenVerifier(TokenVerifier):
+    """Validate Presenton session tokens for MCP HTTP auth."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        username = validate_session_token(token)
+        if not username:
+            return None
+
+        return AccessToken(
+            token=token,
+            client_id=username,
+            scopes=[],
+            claims={"u": username},
+        )
+
+
+def create_mcp_auth_provider() -> TokenVerifier | None:
+    """Enable MCP bearer auth only when app auth is configured."""
+    if is_disable_auth_enabled() or not is_auth_configured():
+        return None
+    return PresentonTokenVerifier()
+
+
+def get_mcp_api_timeout() -> httpx.Timeout:
+    return httpx.Timeout(
+        timeout=MCP_API_TIMEOUT_SECONDS,
+        connect=MCP_API_CONNECT_TIMEOUT_SECONDS,
+    )
+
+
+def create_openapi_api_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url=MCP_API_BASE_URL,
+        timeout=get_mcp_api_timeout(),
+        event_hooks={"request": [attach_request_auth_header]},
+    )
+
+
+async def attach_request_auth_header(request: httpx.Request) -> None:
+    """Forward the authenticated MCP caller token to FastAPI tool endpoints."""
     if "authorization" in request.headers:
         return
 
-    auth_header = get_internal_auth_headers().get("Authorization")
-    if auth_header:
-        request.headers["Authorization"] = auth_header
+    access_token = get_access_token()
+    if access_token:
+        request.headers["Authorization"] = f"Bearer {access_token.token}"
+        return
+
+    forwarded_headers = get_http_headers(include={"authorization"})
+    incoming_auth_header = forwarded_headers.get("authorization")
+    if incoming_auth_header:
+        request.headers["Authorization"] = incoming_auth_header
 
 
 async def main():
@@ -41,32 +96,28 @@ async def main():
         args = parser.parse_args()
         print(f"DEBUG: Parsed args - port={args.port}")
 
-        # Create an HTTP client that the MCP server will use to call the API
-        api_client = httpx.AsyncClient(
-            base_url="http://127.0.0.1:8000",
-            timeout=60.0,
-            event_hooks={"request": [attach_internal_auth_header]},
-        )
+        async with create_openapi_api_client() as api_client:
+            # Build MCP server from OpenAPI
+            print("DEBUG: Creating FastMCP server from OpenAPI spec...")
+            mcp_auth_provider = create_mcp_auth_provider()
+            mcp = FastMCP.from_openapi(
+                openapi_spec=openapi_spec,
+                client=api_client,
+                name=args.name,
+                auth=mcp_auth_provider,
+            )
+            print("DEBUG: MCP server created from OpenAPI successfully")
 
-        # Build MCP server from OpenAPI
-        print("DEBUG: Creating FastMCP server from OpenAPI spec...")
-        mcp = FastMCP.from_openapi(
-            openapi_spec=openapi_spec,
-            client=api_client,
-            name=args.name,
-        )
-        print("DEBUG: MCP server created from OpenAPI successfully")
-
-        # Start the MCP server
-        uvicorn_config = {"reload": True}
-        print(f"DEBUG: Starting MCP server on host=127.0.0.1, port={args.port}")
-        await mcp.run_async(
-            transport="http",
-            host="127.0.0.1",
-            port=args.port,
-            uvicorn_config=uvicorn_config,
-        )
-        print("DEBUG: MCP server run_async completed")
+            # Start the MCP server
+            uvicorn_config = {"reload": True}
+            print(f"DEBUG: Starting MCP server on host=127.0.0.1, port={args.port}")
+            await mcp.run_async(
+                transport="http",
+                host="127.0.0.1",
+                port=args.port,
+                uvicorn_config=uvicorn_config,
+            )
+            print("DEBUG: MCP server run_async completed")
     except Exception as e:
         print(f"ERROR: MCP server startup failed: {e}")
         print(f"ERROR: Traceback: {traceback.format_exc()}")

--- a/servers/fastapi/openai_spec.json
+++ b/servers/fastapi/openai_spec.json
@@ -12,7 +12,7 @@
         "operationId": "generate_presentation",
         "requestBody": {
           "content": {
-            "multipart/form-data": {
+            "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/Body_generate_presentation_api_api_v1_ppt_presentation_generate_post"
               }
@@ -44,19 +44,45 @@
         }
       }
     },
-    "/api/v1/ppt/template-management/summary": {
+    "/api/v1/ppt/template/all": {
       "get": {
-        "tags": ["template-management"],
-        "summary": "Get all presentations with layout counts",
-        "description": "Returns a list of extra custom templates available for presenation creation.",
+        "tags": ["Template"],
+        "summary": "Get all templates",
+        "description": "Returns built-in and custom templates for presentation creation.",
         "operationId": "templates_list",
+        "parameters": [
+          {
+            "name": "include_defaults",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Include Defaults"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Presentations summary retrieved successfully",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetPresentationSummaryResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TemplateDetail"
+                  },
+                  "title": "Response Get All Templates Api V1 Ppt Template All Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -186,81 +212,31 @@
         "required": ["loc", "msg", "type"],
         "title": "ValidationError"
       },
-      "GetPresentationSummaryResponse": {
+      "TemplateDetail": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
+          "id": {
+            "type": "string",
+            "title": "Id"
           },
-          "presentations": {
-            "items": {
-              "$ref": "#/components/schemas/PresentationSummary"
-            },
-            "type": "array",
-            "title": "Presentations"
-          },
-          "total_presentations": {
-            "type": "integer",
-            "title": "Total Presentations"
+          "name": {
+            "type": "string",
+            "title": "Name"
           },
           "total_layouts": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Total Layouts"
-          },
-          "message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Message"
           }
         },
         "type": "object",
-        "required": ["success", "presentations", "total_presentations", "total_layouts"],
-        "title": "GetPresentationSummaryResponse"
-      },
-      "PresentationSummary": {
-        "properties": {
-          "presentation_id": {
-            "type": "string",
-            "title": "Presentation Id"
-          },
-          "layout_count": {
-            "type": "integer",
-            "title": "Layout Count"
-          },
-          "last_updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Updated At"
-          },
-          "template": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Template"
-          }
-        },
-        "type": "object",
-        "required": ["presentation_id", "layout_count"],
-        "title": "PresentationSummary"
+        "required": ["id", "name"],
+        "title": "TemplateDetail"
       },
       "ErrorResponse": {
         "properties": {

--- a/servers/fastapi/tests/integration/test_auth_endpoints.py
+++ b/servers/fastapi/tests/integration/test_auth_endpoints.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.v1.auth.router import API_V1_AUTH_ROUTER
+from utils.simple_auth import setup_initial_credentials, validate_session_token
+
+
+def _build_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(API_V1_AUTH_ROUTER)
+    return TestClient(app)
+
+
+def test_login_returns_bearer_access_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("USER_CONFIG_PATH", str(tmp_path / "userConfig.json"))
+    monkeypatch.delenv("DISABLE_AUTH", raising=False)
+    setup_initial_credentials("admin", "secret123")
+
+    client = _build_client()
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"username": "admin", "password": "secret123"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["configured"] is True
+    assert payload["authenticated"] is True
+    assert payload["username"] == "admin"
+    assert payload["token_type"] == "bearer"
+    assert isinstance(payload["access_token"], str)
+    assert validate_session_token(payload["access_token"]) == "admin"

--- a/servers/fastapi/tests/unit/test_mcp_openapi_templates.py
+++ b/servers/fastapi/tests/unit/test_mcp_openapi_templates.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from constants.presentation import DEFAULT_TEMPLATES
+
+
+def test_default_templates_match_supported_builtin_groups():
+    assert DEFAULT_TEMPLATES == [
+        "general",
+        "modern",
+        "standard",
+        "swift",
+        "code",
+        "education",
+        "product-overview",
+        "report",
+        "pitch-deck",
+        "neo-general",
+        "neo-standard",
+        "neo-modern",
+        "neo-swift",
+    ]
+
+
+def test_openapi_templates_list_points_to_combined_template_endpoint():
+    openapi_spec_path = Path(__file__).resolve().parents[2] / "openai_spec.json"
+    spec = json.loads(openapi_spec_path.read_text(encoding="utf-8"))
+
+    templates_path = spec["paths"]["/api/v1/ppt/template/all"]["get"]
+    assert templates_path["operationId"] == "templates_list"
+
+    include_defaults_param = next(
+        p for p in templates_path["parameters"] if p["name"] == "include_defaults"
+    )
+    assert include_defaults_param["schema"]["default"] is True
+
+    success_schema = templates_path["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+    assert success_schema["items"]["$ref"] == "#/components/schemas/TemplateDetail"

--- a/servers/fastapi/tests/unit/test_mcp_server_auth.py
+++ b/servers/fastapi/tests/unit/test_mcp_server_auth.py
@@ -1,0 +1,116 @@
+import asyncio
+from types import SimpleNamespace
+
+import httpx
+
+import mcp_server
+
+
+def test_create_mcp_auth_provider_disabled_when_auth_is_disabled(monkeypatch):
+    monkeypatch.setattr(mcp_server, "is_disable_auth_enabled", lambda: True)
+    monkeypatch.setattr(mcp_server, "is_auth_configured", lambda: True)
+
+    assert mcp_server.create_mcp_auth_provider() is None
+
+
+def test_create_mcp_auth_provider_disabled_when_auth_not_configured(monkeypatch):
+    monkeypatch.setattr(mcp_server, "is_disable_auth_enabled", lambda: False)
+    monkeypatch.setattr(mcp_server, "is_auth_configured", lambda: False)
+
+    assert mcp_server.create_mcp_auth_provider() is None
+
+
+def test_create_mcp_auth_provider_enabled_when_auth_configured(monkeypatch):
+    monkeypatch.setattr(mcp_server, "is_disable_auth_enabled", lambda: False)
+    monkeypatch.setattr(mcp_server, "is_auth_configured", lambda: True)
+
+    provider = mcp_server.create_mcp_auth_provider()
+    assert isinstance(provider, mcp_server.PresentonTokenVerifier)
+
+
+def test_presenton_token_verifier_accepts_valid_token(monkeypatch):
+    monkeypatch.setattr(
+        mcp_server,
+        "validate_session_token",
+        lambda token: "admin" if token == "valid-token" else None,
+    )
+    verifier = mcp_server.PresentonTokenVerifier()
+
+    access_token = asyncio.run(verifier.verify_token("valid-token"))
+
+    assert access_token is not None
+    assert access_token.token == "valid-token"
+    assert access_token.client_id == "admin"
+    assert access_token.claims["u"] == "admin"
+
+
+def test_presenton_token_verifier_rejects_invalid_token(monkeypatch):
+    monkeypatch.setattr(mcp_server, "validate_session_token", lambda _token: None)
+    verifier = mcp_server.PresentonTokenVerifier()
+
+    access_token = asyncio.run(verifier.verify_token("invalid-token"))
+
+    assert access_token is None
+
+
+def test_attach_request_auth_header_uses_authenticated_mcp_token(monkeypatch):
+    monkeypatch.setattr(
+        mcp_server,
+        "get_access_token",
+        lambda: SimpleNamespace(token="session-abc"),
+    )
+    request = httpx.Request("POST", "http://127.0.0.1:8000/api/v1/example")
+
+    asyncio.run(mcp_server.attach_request_auth_header(request))
+
+    assert request.headers["Authorization"] == "Bearer session-abc"
+
+
+def test_attach_request_auth_header_keeps_existing_auth_header(monkeypatch):
+    monkeypatch.setattr(
+        mcp_server,
+        "get_access_token",
+        lambda: SimpleNamespace(token="session-abc"),
+    )
+    request = httpx.Request(
+        "POST",
+        "http://127.0.0.1:8000/api/v1/example",
+        headers={"Authorization": "Bearer existing"},
+    )
+
+    asyncio.run(mcp_server.attach_request_auth_header(request))
+
+    assert request.headers["Authorization"] == "Bearer existing"
+
+
+def test_attach_request_auth_header_skips_when_no_mcp_access_token(monkeypatch):
+    monkeypatch.setattr(mcp_server, "get_access_token", lambda: None)
+    monkeypatch.setattr(mcp_server, "get_http_headers", lambda include=None: {})
+    request = httpx.Request("POST", "http://127.0.0.1:8000/api/v1/example")
+
+    asyncio.run(mcp_server.attach_request_auth_header(request))
+
+    assert "Authorization" not in request.headers
+
+
+def test_attach_request_auth_header_forwards_incoming_authorization_header(monkeypatch):
+    monkeypatch.setattr(mcp_server, "get_access_token", lambda: None)
+    monkeypatch.setattr(
+        mcp_server,
+        "get_http_headers",
+        lambda include=None: {"authorization": "Basic YWRtaW46c2VjcmV0MTIz"},
+    )
+    request = httpx.Request("POST", "http://127.0.0.1:8000/api/v1/example")
+
+    asyncio.run(mcp_server.attach_request_auth_header(request))
+
+    assert request.headers["Authorization"].startswith("Basic ")
+
+
+def test_get_mcp_api_timeout_supports_long_running_requests():
+    timeout = mcp_server.get_mcp_api_timeout()
+
+    assert timeout.read >= 300
+    assert timeout.write >= 300
+    assert timeout.pool >= 300
+    assert timeout.connect == mcp_server.MCP_API_CONNECT_TIMEOUT_SECONDS

--- a/servers/nextjs/next-env.d.ts
+++ b/servers/nextjs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next-build/types/routes.d.ts";
+import "./.next-build/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
- Added authentication requirements for the MCP endpoints, ensuring that requests to `/mcp` and `/mcp/` require a valid bearer token.
- Enhanced the README with instructions for MCP authentication, including token retrieval and usage.
- Updated OpenAPI specifications to reflect changes in the template management endpoint and introduced a new response schema for templates.
- Implemented a token verifier for session tokens and adjusted the MCP server to support authentication.
- Added integration and unit tests for authentication endpoints and MCP server behavior.