### PR TITLE
feat: enhance MCP server behavior for Electron app

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ The response includes:
 Notes:
 
 - If you rotate credentials with `AUTH_OVERRIDE_FROM_ENV=true`, previously issued session tokens are invalidated.
-- In Electron mode (`DISABLE_AUTH=true`), MCP auth is disabled to match the local desktop auth behavior.
+- MCP is not available in the Electron desktop app (`PRESENTON_ELECTRON=true`). Electron runs with `DISABLE_AUTH=true` by default, and the MCP server is disabled there to avoid auth conflicts.
 
 > Note: LLM and image variables above are forwarded from **`docker-compose.yml`** when set in `.env`.
 

--- a/electron/app/main.ts
+++ b/electron/app/main.ts
@@ -400,6 +400,7 @@ async function startServers(fastApiPort: number, nextjsPort: number) {
         USER_CONFIG_PATH: userConfigPath,
         MIGRATE_DATABASE_ON_STARTUP: "True",
         DISABLE_AUTH: disableAuthForElectron,
+        PRESENTON_ELECTRON: "true",
         ...buildImageMagickEnv(imageMagickRuntime),
         LITEPARSE_RUNNER_PATH: getLiteParseRunnerPath(),
         // Use Electron's embedded runtime for LiteParse so parsing does not
@@ -482,6 +483,7 @@ app.whenReady().then(async () => {
   const disableAuthForElectron = resolveElectronDisableAuth();
   process.env.DISABLE_AUTH = disableAuthForElectron;
   process.env.ELECTRON_DISABLE_AUTH = disableAuthForElectron;
+  process.env.PRESENTON_ELECTRON = "true";
 
   // Ensure all required directories exist before starting
   ensureDirectoriesExist();

--- a/servers/fastapi/mcp_server.py
+++ b/servers/fastapi/mcp_server.py
@@ -10,7 +10,7 @@ from fastmcp.server.auth import AccessToken, TokenVerifier
 from fastmcp.server.dependencies import get_access_token, get_http_headers
 import json
 
-from utils.get_env import is_disable_auth_enabled
+from utils.get_env import is_disable_auth_enabled, is_presenton_electron_desktop
 from utils.simple_auth import is_auth_configured, validate_session_token
 
 OPENAPI_SPEC_PATH = Path(__file__).with_name("openai_spec.json")
@@ -37,6 +37,11 @@ class PresentonTokenVerifier(TokenVerifier):
             scopes=[],
             claims={"u": username},
         )
+
+
+def is_mcp_server_enabled() -> bool:
+    """MCP is only supported in server/Docker deployments, not the Electron app."""
+    return not is_presenton_electron_desktop()
 
 
 def create_mcp_auth_provider() -> TokenVerifier | None:
@@ -79,6 +84,13 @@ async def attach_request_auth_header(request: httpx.Request) -> None:
 
 async def main():
     try:
+        if not is_mcp_server_enabled():
+            print(
+                "INFO: MCP server is disabled in the Presenton Electron desktop app "
+                "(PRESENTON_ELECTRON=true)."
+            )
+            return
+
         print("DEBUG: MCP (OpenAPI) Server startup initiated")
         parser = argparse.ArgumentParser(
             description="Run the MCP server (from OpenAPI)"

--- a/servers/fastapi/tests/unit/test_mcp_server_auth.py
+++ b/servers/fastapi/tests/unit/test_mcp_server_auth.py
@@ -6,6 +6,18 @@ import httpx
 import mcp_server
 
 
+def test_is_mcp_server_enabled_in_server_deployments(monkeypatch):
+    monkeypatch.setattr(mcp_server, "is_presenton_electron_desktop", lambda: False)
+
+    assert mcp_server.is_mcp_server_enabled() is True
+
+
+def test_is_mcp_server_disabled_in_electron_desktop(monkeypatch):
+    monkeypatch.setattr(mcp_server, "is_presenton_electron_desktop", lambda: True)
+
+    assert mcp_server.is_mcp_server_enabled() is False
+
+
 def test_create_mcp_auth_provider_disabled_when_auth_is_disabled(monkeypatch):
     monkeypatch.setattr(mcp_server, "is_disable_auth_enabled", lambda: True)
     monkeypatch.setattr(mcp_server, "is_auth_configured", lambda: True)

--- a/servers/fastapi/utils/get_env.py
+++ b/servers/fastapi/utils/get_env.py
@@ -46,6 +46,11 @@ def is_disable_auth_enabled():
     return _is_truthy(get_disable_auth_env())
 
 
+def is_presenton_electron_desktop():
+    """True when running inside the Presenton Electron desktop app."""
+    return _is_truthy(os.getenv("PRESENTON_ELECTRON"))
+
+
 def get_llm_provider_env():
     return os.getenv("LLM")
 


### PR DESCRIPTION
- Updated README to clarify that MCP is not available in the Electron desktop app when `PRESENTON_ELECTRON=true`.
- Introduced a new function to determine MCP server availability based on the Electron environment.
- Added checks in the MCP server to disable it when running in the Electron app, preventing authentication conflicts.
- Implemented unit tests to verify MCP server behavior in different deployment scenarios.