### PR TITLE
feat: enhance image generation service to handle authorization header…

### DIFF
--- a/servers/fastapi/services/image_generation_service.py
+++ b/servers/fastapi/services/image_generation_service.py
@@ -858,9 +858,19 @@ class ImageGenerationService:
                 f.write(base64.b64decode(item.b64_json))
         elif item.url:
             image_url = item.url
-            if image_url.startswith("/"):
+            is_relative_url = image_url.startswith("/")
+            if is_relative_url:
                 image_url = origin + image_url
-            headers = {"Authorization": f"Bearer {api_key}"}
+            image_origin = urlparse(image_url)
+            headers = {}
+            if (
+                is_relative_url
+                or (
+                    image_origin.scheme == parsed.scheme
+                    and image_origin.netloc == parsed.netloc
+                )
+            ):
+                headers["Authorization"] = f"Bearer {api_key}"
             async with aiohttp.ClientSession(trust_env=True) as session:
                 dl_resp = await session.get(
                     image_url,

--- a/servers/fastapi/tests/test_image_generation_openai_compatible.py
+++ b/servers/fastapi/tests/test_image_generation_openai_compatible.py
@@ -208,6 +208,10 @@ class TestImageGenerationOpenAICompatible:
                                 "test prompt", mock_images_directory
                             )
 
+                        call_kwargs = mock_session.get.call_args.kwargs
+                        assert call_kwargs["headers"] == {
+                            "Authorization": "Bearer sk-test-key"
+                        }
                         assert os.path.exists(image_path)
                         assert image_path.startswith(mock_images_directory)
 
@@ -264,4 +268,60 @@ class TestImageGenerationOpenAICompatible:
                         call_args = mock_session.get.call_args
                         called_url = call_args[0][0]
                         assert called_url == "https://api.example.com/images/result.png"
+                        assert call_args.kwargs["headers"] == {
+                            "Authorization": "Bearer sk-test-key"
+                        }
+                        assert os.path.exists(image_path)
+
+    @pytest.mark.anyio
+    async def test_generate_image_openai_compatible_cross_origin_url_skips_auth(
+        self, mock_images_directory
+    ):
+        """Cross-origin asset URLs should not receive the API bearer token."""
+        service = ImageGenerationService(mock_images_directory)
+
+        with patch(
+            "services.image_generation_service.get_openai_compat_image_base_url_env",
+            return_value="https://api.example.com/v1",
+        ):
+            with patch(
+                "services.image_generation_service.get_openai_compat_image_api_key_env",
+                return_value="sk-test-key",
+            ):
+                with patch(
+                    "services.image_generation_service.get_openai_compat_image_model_env",
+                    return_value="custom-model",
+                ):
+                    with patch(
+                        "services.image_generation_service.AsyncOpenAI"
+                    ) as MockClient:
+                        mock_client_instance = MockClient.return_value
+                        mock_data = Mock()
+                        mock_data.b64_json = None
+                        mock_data.url = "https://cdn.example.net/images/result.png"
+                        mock_response = Mock()
+                        mock_response.data = [mock_data]
+                        mock_client_instance.images.generate = AsyncMock(
+                            return_value=mock_response
+                        )
+
+                        fake_image_bytes = b"\x89PNG\r\n\x1a\n"
+                        mock_dl_resp = AsyncMock()
+                        mock_dl_resp.status = 200
+                        mock_dl_resp.read = AsyncMock(return_value=fake_image_bytes)
+                        mock_session = AsyncMock()
+                        mock_session.get = AsyncMock(return_value=mock_dl_resp)
+                        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+                        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+                        with patch(
+                            "services.image_generation_service.aiohttp.ClientSession",
+                            return_value=mock_session,
+                        ):
+                            image_path = await service.generate_image_openai_compatible(
+                                "test prompt", mock_images_directory
+                            )
+
+                        call_kwargs = mock_session.get.call_args.kwargs
+                        assert call_kwargs["headers"] == {}
                         assert os.path.exists(image_path)


### PR DESCRIPTION
…s based on URL type

- Updated the ImageGenerationService to conditionally include the Authorization header for relative URLs and same-origin requests.
- Added unit tests to verify that cross-origin URLs do not receive the API bearer token, ensuring proper security measures are in place.