### PR TITLE
Fix provider model validation status

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/anthropic.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/anthropic.py
@@ -1,7 +1,10 @@
 from typing import Annotated, List
 from fastapi import APIRouter, Body, HTTPException
 
-from utils.available_models import list_available_anthropic_models
+from utils.available_models import (
+    ModelAvailabilityError,
+    list_available_anthropic_models,
+)
 
 ANTHROPIC_ROUTER = APIRouter(prefix="/anthropic", tags=["Anthropic"])
 
@@ -12,5 +15,7 @@ async def get_available_models(
 ):
     try:
         return await list_available_anthropic_models(api_key)
+    except ModelAvailabilityError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/servers/fastapi/api/v1/ppt/endpoints/google.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/google.py
@@ -1,7 +1,7 @@
 from typing import Annotated, List
 from fastapi import APIRouter, Body, HTTPException
 
-from utils.available_models import list_available_google_models
+from utils.available_models import ModelAvailabilityError, list_available_google_models
 
 GOOGLE_ROUTER = APIRouter(prefix="/google", tags=["Google"])
 
@@ -10,5 +10,7 @@ GOOGLE_ROUTER = APIRouter(prefix="/google", tags=["Google"])
 async def get_available_models(api_key: Annotated[str, Body(embed=True)]):
     try:
         return await list_available_google_models(api_key)
+    except ModelAvailabilityError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/servers/fastapi/api/v1/ppt/endpoints/openai.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/openai.py
@@ -1,7 +1,10 @@
 from typing import Annotated, List
 from fastapi import APIRouter, Body, HTTPException
 
-from utils.available_models import list_available_openai_compatible_models
+from utils.available_models import (
+    ModelAvailabilityError,
+    list_available_openai_compatible_models,
+)
 
 OPENAI_ROUTER = APIRouter(prefix="/openai", tags=["OpenAI"])
 
@@ -13,5 +16,7 @@ async def get_available_models(
 ):
     try:
         return await list_available_openai_compatible_models(url, api_key)
+    except ModelAvailabilityError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/servers/fastapi/tests/unit/test_model_availability_errors.py
+++ b/servers/fastapi/tests/unit/test_model_availability_errors.py
@@ -1,0 +1,61 @@
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from api.v1.ppt.endpoints import anthropic as anthropic_endpoint
+from api.v1.ppt.endpoints import google as google_endpoint
+from api.v1.ppt.endpoints import openai as openai_endpoint
+from utils.available_models import ModelAvailabilityError
+
+
+def test_model_availability_error_maps_provider_client_errors_to_bad_request():
+    error = ModelAvailabilityError(
+        "OpenAI-compatible provider",
+        "Incorrect API key provided.",
+        provider_status_code=401,
+    )
+
+    assert error.status_code == 400
+    assert "Incorrect API key provided." in str(error)
+
+
+def test_model_availability_error_keeps_provider_server_errors_internal():
+    error = ModelAvailabilityError(
+        "OpenAI-compatible provider",
+        "Provider unavailable.",
+        provider_status_code=503,
+    )
+
+    assert error.status_code == 500
+
+
+@pytest.mark.parametrize(
+    ("endpoint_module", "list_function_name", "args"),
+    [
+        (
+            openai_endpoint,
+            "list_available_openai_compatible_models",
+            ("https://api.openai.com/v1", "bad-key"),
+        ),
+        (google_endpoint, "list_available_google_models", ("bad-key",)),
+        (anthropic_endpoint, "list_available_anthropic_models", ("bad-key",)),
+    ],
+)
+def test_model_availability_endpoints_return_400_for_provider_validation_errors(
+    monkeypatch, endpoint_module, list_function_name, args
+):
+    async def fail_model_validation(*_args):
+        raise ModelAvailabilityError(
+            "Provider",
+            "Invalid API key.",
+            provider_status_code=401,
+        )
+
+    monkeypatch.setattr(endpoint_module, list_function_name, fail_model_validation)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(endpoint_module.get_available_models(*args))
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Provider model validation failed: Invalid API key."

--- a/servers/fastapi/utils/available_models.py
+++ b/servers/fastapi/utils/available_models.py
@@ -1,6 +1,83 @@
+import json
+from typing import Any
+
 import aiohttp
+from openai import APIError as OpenAIAPIError
 from openai import AsyncOpenAI
 from google import genai
+from google.genai.errors import APIError as GoogleAPIError
+
+
+class ModelAvailabilityError(Exception):
+    def __init__(self, provider: str, message: str, *, provider_status_code: Any):
+        try:
+            status_code = int(provider_status_code)
+        except (TypeError, ValueError):
+            status_code = 500
+
+        self.provider = provider
+        self.provider_status_code = status_code
+        self.status_code = 400 if 400 <= status_code < 500 else 500
+        super().__init__(f"{provider} model validation failed: {message}")
+
+
+def _payload_error_message(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            message = error.get("message") or error.get("detail") or error.get("code")
+            if message:
+                return str(message)
+        if isinstance(error, str) and error:
+            return error
+
+        message = payload.get("message") or payload.get("detail")
+        if message:
+            return str(message)
+        return None
+
+    if isinstance(payload, str) and payload:
+        return payload
+
+    return None
+
+
+async def _aiohttp_error_message(response: aiohttp.ClientResponse) -> str:
+    text = await response.text()
+    if text:
+        try:
+            message = _payload_error_message(json.loads(text))
+            if message:
+                return message
+        except json.JSONDecodeError:
+            return text
+
+    return response.reason or f"Provider returned HTTP {response.status}"
+
+
+async def _raise_for_model_response(
+    response: aiohttp.ClientResponse, *, provider: str
+) -> None:
+    if response.status < 400:
+        return
+
+    raise ModelAvailabilityError(
+        provider,
+        await _aiohttp_error_message(response),
+        provider_status_code=response.status,
+    )
+
+
+def _openai_error_message(error: OpenAIAPIError) -> str:
+    message = _payload_error_message(getattr(error, "body", None))
+    if message:
+        return message
+
+    return getattr(error, "message", None) or str(error)
+
+
+def _google_error_message(error: GoogleAPIError) -> str:
+    return getattr(error, "message", None) or str(error)
 
 
 def normalize_openai_compatible_base_url(url: str) -> str:
@@ -55,7 +132,7 @@ async def list_together_models(url: str, api_key: str) -> list[str]:
 
     async with aiohttp.ClientSession(headers=headers) as session:
         async with session.get(models_url) as response:
-            response.raise_for_status()
+            await _raise_for_model_response(response, provider="Together")
             data = await response.json()
 
     return _model_ids_from_openai_compatible_payload(data)
@@ -69,7 +146,15 @@ async def list_available_openai_compatible_models(url: str, api_key: str) -> lis
     # Local LiteLLM / OpenAI-compatible proxies often omit auth; SDK rejects a blank key.
     effective_key = (api_key or "").strip() or "EMPTY"
     client = AsyncOpenAI(api_key=effective_key, base_url=url)
-    models = (await client.models.list()).data
+    try:
+        models = (await client.models.list()).data
+    except OpenAIAPIError as e:
+        raise ModelAvailabilityError(
+            "OpenAI-compatible provider",
+            _openai_error_message(e),
+            provider_status_code=getattr(e, "status_code", None) or 500,
+        ) from e
+
     if models:
         return [m.id for m in models if m.id]
     return []
@@ -86,7 +171,7 @@ async def list_available_anthropic_models(api_key: str) -> list[str]:
             "https://api.anthropic.com/v1/models",
             params={"limit": 50},
         ) as response:
-            response.raise_for_status()
+            await _raise_for_model_response(response, provider="Anthropic")
             data = await response.json()
 
     models = data.get("data", [])
@@ -94,5 +179,14 @@ async def list_available_anthropic_models(api_key: str) -> list[str]:
 
 
 async def list_available_google_models(api_key: str) -> list[str]:
-    client = genai.Client(api_key=api_key)
-    return [x.name for x in client.models.list(config={"page_size": 50}) if x.name]
+    try:
+        client = genai.Client(api_key=api_key)
+        return [x.name for x in client.models.list(config={"page_size": 50}) if x.name]
+    except GoogleAPIError as e:
+        raise ModelAvailabilityError(
+            "Google",
+            _google_error_message(e),
+            provider_status_code=getattr(e, "code", None)
+            or getattr(e, "status_code", None)
+            or 500,
+        ) from e

--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { LLMConfig } from "@/types/llm_config";
-import { getApiUrl } from "@/utils/api";
+import { getApiErrorMessage, getApiUrl } from "@/utils/api";
 import { LLM_PROVIDERS } from "@/utils/providerConstants";
 import {
   Check,
@@ -373,13 +373,14 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
           onInputChange(nextModel, currentModelField);
         }
       } else {
+        const message = await getApiErrorMessage(
+          response,
+          `The server could not list ${modelLabel} models. Check your API key or endpoint and try again.`
+        );
         console.error("Failed to fetch models");
         setAvailableModels([]);
         setModelsChecked(true);
-        notify.error(
-          "Could not load models",
-          `The server could not list ${modelLabel} models. Check your API key or endpoint and try again.`
-        );
+        notify.error("Could not load models", message);
       }
     } catch (error) {
       console.error("Error fetching models:", error);

--- a/servers/nextjs/components/AnthropicConfig.tsx
+++ b/servers/nextjs/components/AnthropicConfig.tsx
@@ -14,7 +14,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { cn } from "@/lib/utils";
 import { notify } from "@/components/ui/sonner";
 import { Switch } from "./ui/switch";
-import { getApiUrl } from "@/utils/api";
+import { getApiErrorMessage, getApiUrl } from "@/utils/api";
 
 interface AnthropicConfigProps {
   anthropicApiKey: string;
@@ -70,7 +70,12 @@ export default function AnthropicConfig({
         setModelsChecked(true);
         onInputChange("claude-sonnet-4-20250514", "anthropic_model");
       } else {
+        const message = await getApiErrorMessage(
+          response,
+          "The server could not list models. Check your API key or endpoint and try again."
+        );
         console.error('Failed to fetch models');
+        notify.error("Could not load models", message);
         setAvailableModels([]);
         setModelsChecked(true);
       }

--- a/servers/nextjs/components/CustomConfig.tsx
+++ b/servers/nextjs/components/CustomConfig.tsx
@@ -13,7 +13,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { cn } from "@/lib/utils";
 import { notify } from "@/components/ui/sonner";
-import { getApiUrl } from "@/utils/api";
+import { getApiErrorMessage, getApiUrl } from "@/utils/api";
 import { Switch } from "./ui/switch";
 
 interface CustomConfigProps {
@@ -75,10 +75,14 @@ export default function CustomConfig({
         setCustomModels(data);
         setCustomModelsChecked(true);
       } else {
+        const message = await getApiErrorMessage(
+          response,
+          "The server could not list models. Check your API key or endpoint and try again."
+        );
         console.error('Failed to fetch custom models');
         setCustomModels([]);
         setCustomModelsChecked(true);
-        notify.error("Could not load models", "The server could not list models. Check your API key or endpoint and try again.");
+        notify.error("Could not load models", message);
       }
     } catch (error) {
       console.error('Error fetching custom models:', error);

--- a/servers/nextjs/components/GoogleConfig.tsx
+++ b/servers/nextjs/components/GoogleConfig.tsx
@@ -14,7 +14,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { cn } from "@/lib/utils";
 import { notify } from "@/components/ui/sonner";
 import { Switch } from "./ui/switch";
-import { getApiUrl } from "@/utils/api";
+import { getApiErrorMessage, getApiUrl } from "@/utils/api";
 
 interface GoogleConfigProps {
   googleApiKey: string;
@@ -67,7 +67,12 @@ export default function GoogleConfig({
         setModelsChecked(true);
         onInputChange("models/gemini-2.5-flash", "google_model");
       } else {
+        const message = await getApiErrorMessage(
+          response,
+          "The server could not list models. Check your API key or endpoint and try again."
+        );
         console.error('Failed to fetch models');
+        notify.error("Could not load models", message);
         setAvailableModels([]);
         setModelsChecked(true);
       }

--- a/servers/nextjs/components/OnBoarding/PresentonMode.tsx
+++ b/servers/nextjs/components/OnBoarding/PresentonMode.tsx
@@ -17,7 +17,7 @@ import { MixpanelEvent, trackEvent } from '@/utils/mixpanel';
 import { usePathname } from 'next/navigation';
 import { getLLMConfigValidationError, handleSaveLLMConfig } from '@/utils/storeHelpers';
 import { getDefaultOllamaUrl, isOllamaModelAvailable } from '@/utils/providerUtils';
-import { getApiUrl } from '@/utils/api';
+import { getApiErrorMessage, getApiUrl } from '@/utils/api';
 import CodexConfig from '../CodexConfig';
 import { CODEX_MODELS } from '@/utils/codexModels';
 import VertexAzureManualFields from '@/components/VertexAzureManualFields';
@@ -406,10 +406,14 @@ const PresentonMode = ({
                     }));
                 }
             } else {
+                const message = await getApiErrorMessage(
+                    response,
+                    `The server could not list ${LLM_PROVIDERS[llmConfig.LLM!]?.label} models. Check your API key or endpoint and try again.`
+                );
                 console.error('Failed to fetch models');
                 setAvailableModels([]);
                 setModelsChecked(true);
-                notify.error("Could not load models", `The server could not list ${LLM_PROVIDERS[llmConfig.LLM!]?.label} models. Check your API key or endpoint and try again.`);
+                notify.error("Could not load models", message);
             }
         } catch (error) {
             console.error('Error fetching models:', error);

--- a/servers/nextjs/components/OpenAICompatibleImageFields.tsx
+++ b/servers/nextjs/components/OpenAICompatibleImageFields.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { getApiUrl } from "@/utils/api";
+import { getApiErrorMessage, getApiUrl } from "@/utils/api";
 import { notify } from "@/components/ui/sonner";
 
 export interface OpenAICompatibleImageFieldsProps {
@@ -86,12 +86,16 @@ export default function OpenAICompatibleImageFields({
         setModels(Array.isArray(data) ? data : []);
         setModelsChecked(true);
       } else {
+        const message = await getApiErrorMessage(
+          response,
+          "The server could not list models. Check your API key or endpoint and try again."
+        );
         console.error("Failed to fetch models");
         setModels([]);
         setModelsChecked(true);
         notify.error(
           "Could not load models",
-          "The server could not list models. Check your API key or endpoint and try again."
+          message
         );
       }
     } catch (error) {

--- a/servers/nextjs/components/OpenAIConfig.tsx
+++ b/servers/nextjs/components/OpenAIConfig.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils";
 import { notify } from "@/components/ui/sonner";
 import { Switch } from "./ui/switch";
 import { LLMConfig } from "@/types/llm_config";
-import { getApiUrl } from "@/utils/api";
+import { getApiErrorMessage, getApiUrl } from "@/utils/api";
 
 interface OpenAIConfigProps {
   openaiApiKey: string;
@@ -74,7 +74,12 @@ const isImageGenerationDisabled = llmConfig?.DISABLE_IMAGE_GENERATION ?? false;
         setModelsChecked(true);
         onInputChange("gpt-4.1", "openai_model");
       } else {
+        const message = await getApiErrorMessage(
+          response,
+          "The server could not list models. Check your API key or endpoint and try again."
+        );
         console.error('Failed to fetch models');
+        notify.error("Could not load models", message);
         setAvailableModels([]);
         setModelsChecked(true);
       }

--- a/servers/nextjs/utils/api.ts
+++ b/servers/nextjs/utils/api.ts
@@ -2,6 +2,72 @@ function isAbsoluteHttpUrl(path: string): boolean {
   return /^https?:\/\//i.test(path);
 }
 
+interface ApiErrorResponse {
+  detail?: unknown;
+  message?: string;
+  error?: string;
+}
+
+function normalizeApiErrorDetail(detail: unknown): string | null {
+  if (!detail) return null;
+
+  if (typeof detail === "string") {
+    return detail;
+  }
+
+  if (Array.isArray(detail)) {
+    const parts = detail
+      .map((item) => {
+        if (typeof item === "string") return item;
+        if (item && typeof item === "object") {
+          const maybeMsg = (item as { msg?: unknown }).msg;
+          const maybeLoc = (item as { loc?: unknown }).loc;
+          const locPath = Array.isArray(maybeLoc)
+            ? maybeLoc
+                .filter((value) => typeof value === "string" || typeof value === "number")
+                .join(".")
+            : "";
+          if (typeof maybeMsg === "string") {
+            return locPath ? `${locPath}: ${maybeMsg}` : maybeMsg;
+          }
+        }
+        return null;
+      })
+      .filter((value): value is string => Boolean(value));
+
+    return parts.length ? parts.join("; ") : JSON.stringify(detail);
+  }
+
+  if (typeof detail === "object") {
+    return JSON.stringify(detail);
+  }
+
+  return String(detail);
+}
+
+export async function getApiErrorMessage(
+  response: Response,
+  fallbackMessage: string
+): Promise<string> {
+  try {
+    const errorData: unknown = await response.clone().json();
+    if (errorData && typeof errorData === "object" && !Array.isArray(errorData)) {
+      const apiError = errorData as ApiErrorResponse;
+      const normalizedDetail = normalizeApiErrorDetail(apiError.detail);
+      return normalizedDetail || apiError.message || apiError.error || fallbackMessage;
+    }
+
+    return normalizeApiErrorDetail(errorData) || fallbackMessage;
+  } catch {
+    try {
+      const text = await response.text();
+      return text || fallbackMessage;
+    } catch {
+      return fallbackMessage;
+    }
+  }
+}
+
 function withLeadingSlash(path: string): string {
   return path.startsWith("/") ? path : `/${path}`;
 }


### PR DESCRIPTION
This pull request improves error handling and user feedback for model listing endpoints across both the FastAPI backend and Next.js frontend. The main changes include introducing a structured error type for model availability issues, updating backend endpoints to use it, and enhancing frontend notifications to display more informative error messages based on backend responses.

**Backend error handling improvements:**

* Introduced a `ModelAvailabilityError` exception in `utils.available_models.py` to standardize error reporting for model listing failures, mapping provider-specific errors to appropriate HTTP status codes and messages.
* Updated all model listing functions (`list_available_openai_compatible_models`, `list_available_google_models`, `list_available_anthropic_models`, and `list_together_models`) to raise `ModelAvailabilityError` with detailed messages when provider APIs return errors, and refactored error extraction logic for clarity. [[1]](diffhunk://#diff-a1aea525048c4c02b7a0db2c72ef417f8cb473fa46a3b6b1d9925a294a7dbd6fL58-R135) [[2]](diffhunk://#diff-a1aea525048c4c02b7a0db2c72ef417f8cb473fa46a3b6b1d9925a294a7dbd6fR149-R157) [[3]](diffhunk://#diff-a1aea525048c4c02b7a0db2c72ef417f8cb473fa46a3b6b1d9925a294a7dbd6fL89-R192)
* Modified FastAPI endpoints for OpenAI, Google, and Anthropic providers to catch `ModelAvailabilityError` and return the correct HTTP status and error message to clients. [[1]](diffhunk://#diff-5b570149a0d1206941d3cf06f911a82b5e233d884a20a93b50b4224ca436bda4L4-R7) [[2]](diffhunk://#diff-5b570149a0d1206941d3cf06f911a82b5e233d884a20a93b50b4224ca436bda4R19-R20) [[3]](diffhunk://#diff-82333d6815e8cc01052f975b84627f05e7f0c765b725c7cf20eb4640623ffc81L4-R4) [[4]](diffhunk://#diff-82333d6815e8cc01052f975b84627f05e7f0c765b725c7cf20eb4640623ffc81R13-R14) [[5]](diffhunk://#diff-98fd6e6a15907655a012e4579f56a99787b11c8e2bbdead7d239cc7daa7b15d4L4-R7) [[6]](diffhunk://#diff-98fd6e6a15907655a012e4579f56a99787b11c8e2bbdead7d239cc7daa7b15d4R18-R19)
* Added unit tests in `test_model_availability_errors.py` to verify correct error mapping and endpoint behavior for various provider error scenarios.

**Frontend user feedback improvements:**

* Updated all relevant Next.js components (`TextProvider.tsx`, `AnthropicConfig.tsx`, `GoogleConfig.tsx`, `CustomConfig.tsx`, `OpenAIConfig.tsx`, `OpenAICompatibleImageFields.tsx`, `PresentonMode.tsx`) to use a new `getApiErrorMessage` helper, extracting and displaying detailed error messages from backend responses in user notifications, instead of generic fallback messages. [[1]](diffhunk://#diff-55159edd5f9d8cd6da234f575cc5f74ef0946a164dfd54fbfa2c2f697d010a42L22-R22) [[2]](diffhunk://#diff-55159edd5f9d8cd6da234f575cc5f74ef0946a164dfd54fbfa2c2f697d010a42R376-R383) [[3]](diffhunk://#diff-477bf8022aa5269cfd3836c509f19d556fcde5509e5f3890d26d091dbb97009cL17-R17) [[4]](diffhunk://#diff-477bf8022aa5269cfd3836c509f19d556fcde5509e5f3890d26d091dbb97009cR73-R78) [[5]](diffhunk://#diff-5c2f037e2e220ae79a0ca16edf718b1248e58a1c7fbac8f4c07a15c97ffc1c1aL16-R16) [[6]](diffhunk://#diff-5c2f037e2e220ae79a0ca16edf718b1248e58a1c7fbac8f4c07a15c97ffc1c1aR78-R85) [[7]](diffhunk://#diff-bee944a82373a068adcab6ae7171356e2eec90cae0ea89a301b50f258bb60e10L17-R17) [[8]](diffhunk://#diff-bee944a82373a068adcab6ae7171356e2eec90cae0ea89a301b50f258bb60e10R70-R75) [[9]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46L20-R20) [[10]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46R409-R416) [[11]](diffhunk://#diff-b65ede8729de6fa8f2d145e219449870525c0e737261fdedf8f6fd6688ec6828L16-R16) [[12]](diffhunk://#diff-b65ede8729de6fa8f2d145e219449870525c0e737261fdedf8f6fd6688ec6828R89-R98) [[13]](diffhunk://#diff-bce6a5359b4608bb32ce3629d7b694067e34b1cc9d78dd6179f0f7fc2ec84ed9L18-R18) [[14]](diffhunk://#diff-bce6a5359b4608bb32ce3629d7b694067e34b1cc9d78dd6179f0f7fc2ec84ed9R77-R82)

These changes result in clearer, more actionable error messages for users and a more maintainable error handling flow between backend and frontend.