### PR TITLE
fix: Strip array size constraints for LiteLLM/custom structured output

### DIFF
--- a/servers/fastapi/utils/llm_utils.py
+++ b/servers/fastapi/utils/llm_utils.py
@@ -15,10 +15,37 @@ from llmai.shared import (
 )
 
 from utils.llm_config import get_extra_body
-from utils.schema_utils import get_schema_validation_errors
+from utils.llm_provider import is_custom_llm_selected, is_litellm_selected
+from utils.schema_utils import (
+    get_schema_validation_errors,
+    strip_array_size_constraints,
+)
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _sanitize_response_format(response_format: ResponseFormat) -> ResponseFormat:
+    """Strip array size constraints from the schema for OpenAI-compatible gateways.
+
+    LiteLLM/custom gateways may route to Bedrock, which rejects ``minItems``/
+    ``maxItems`` other than 0 or 1. This sanitizes only the schema sent to the
+    provider; the schema used for local response validation is left untouched.
+    """
+    if not (is_litellm_selected() or is_custom_llm_selected()):
+        return response_format
+
+    json_schema = getattr(response_format, "json_schema", None)
+    if not isinstance(json_schema, dict):
+        return response_format
+
+    sanitized = strip_array_size_constraints(json_schema)
+    if sanitized == json_schema:
+        return response_format
+
+    if hasattr(response_format, "model_copy"):
+        return response_format.model_copy(update={"json_schema": sanitized})
+    return response_format
 
 
 def get_generate_kwargs(
@@ -39,7 +66,7 @@ def get_generate_kwargs(
     if tools:
         kwargs["tools"] = tools
     if response_format is not None:
-        kwargs["response_format"] = response_format
+        kwargs["response_format"] = _sanitize_response_format(response_format)
 
     extra_body = get_extra_body(uses_tool_choice=bool(tools or response_format))
     if extra_body:

--- a/servers/fastapi/utils/schema_utils.py
+++ b/servers/fastapi/utils/schema_utils.py
@@ -262,6 +262,29 @@ def ensure_array_schemas_have_items(schema: dict) -> dict[str, Any]:
     return _ensure(result)
 
 
+def strip_array_size_constraints(schema: dict) -> dict[str, Any]:
+    """Recursively remove ``minItems``/``maxItems`` from a JSON schema (deep copy).
+
+    Some structured-output backends reject array size constraints. Notably,
+    Bedrock (reached via LiteLLM / OpenAI-compatible gateways) only allows
+    ``minItems`` of 0 or 1, so a schema like ``minItems: 6`` (our exact-slide-count
+    constraint) is rejected outright. The item count is still steered by the prompt.
+    """
+
+    def _strip(node: Any) -> Any:
+        if isinstance(node, dict):
+            node.pop("minItems", None)
+            node.pop("maxItems", None)
+            for value in node.values():
+                _strip(value)
+        elif isinstance(node, list):
+            for item in node:
+                _strip(item)
+        return node
+
+    return _strip(deepcopy(schema))
+
+
 def prepare_schema_for_validation(
     schema: dict,
     strict: bool = False,


### PR DESCRIPTION
LiteLLM and custom OpenAI-compatible gateways may route to Amazon Bedrock, whose structured-output validator only allows array `minItems` of 0 or 1. Presenton's dynamic outline/structure schemas set `min_length`/`max_length` equal to n_slides, producing `minItems: N` (e.g. 6), which Bedrock rejects with either:

  output_config.format.schema: For 'array' type, 'minItems' values
  other than 0 or 1 are not supported

or, for some models, the less obvious:

  output_config.format: Extra inputs are not permitted

Add `strip_array_size_constraints()` and apply it at the single `get_generate_kwargs` choke point, but only when the selected provider is `litellm` or `custom`. It sanitizes only the schema sent to the provider; the schema used for local response validation keeps its strict constraints, and the slide count is still steered by the prompt. Other providers (OpenAI, Anthropic, Google, etc.) are unaffected.