### PR TITLE
Fix Ollama URL clearing and model checks

### DIFF
--- a/servers/fastapi/utils/user_config.py
+++ b/servers/fastapi/utils/user_config.py
@@ -176,9 +176,11 @@ def get_user_config():
     user_config_path = get_user_config_path_env()
 
     existing_config = UserConfig()
+    existing_config_data = {}
     try:
         if user_config_path:
-            existing_config = UserConfig(**read_user_config_file(user_config_path))
+            existing_config_data = read_user_config_file(user_config_path)
+            existing_config = UserConfig(**existing_config_data)
     except Exception:
         print("Error while loading user config")
         pass
@@ -239,7 +241,11 @@ def get_user_config():
         ANTHROPIC_API_KEY=existing_config.ANTHROPIC_API_KEY
         or get_anthropic_api_key_env(),
         ANTHROPIC_MODEL=existing_config.ANTHROPIC_MODEL or get_anthropic_model_env(),
-        OLLAMA_URL=existing_config.OLLAMA_URL or get_ollama_url_env(),
+        OLLAMA_URL=(
+            existing_config.OLLAMA_URL
+            if "OLLAMA_URL" in existing_config_data
+            else get_ollama_url_env()
+        ),
         OLLAMA_MODEL=existing_config.OLLAMA_MODEL or get_ollama_model_env(),
         CUSTOM_LLM_URL=existing_config.CUSTOM_LLM_URL or get_custom_llm_url_env(),
         CUSTOM_LLM_API_KEY=existing_config.CUSTOM_LLM_API_KEY
@@ -397,7 +403,7 @@ def update_env_with_user_config():
         set_anthropic_api_key_env(user_config.ANTHROPIC_API_KEY)
     if user_config.ANTHROPIC_MODEL:
         set_anthropic_model_env(user_config.ANTHROPIC_MODEL)
-    if user_config.OLLAMA_URL:
+    if user_config.OLLAMA_URL is not None:
         set_ollama_url_env(user_config.OLLAMA_URL)
     if user_config.OLLAMA_MODEL:
         set_ollama_model_env(user_config.OLLAMA_MODEL)

--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/SettingPage.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/SettingPage.tsx
@@ -174,7 +174,7 @@ const SettingsPage = () => {
         ))
       ) {
         throw new Error(
-          `The selected model "${llmConfig.OLLAMA_MODEL}" is not available at ${llmConfig.OLLAMA_URL}. Check models and select an available model.`
+          `The selected model "${llmConfig.OLLAMA_MODEL}" is not available at ${llmConfig.OLLAMA_URL || "the default Ollama URL"}. Check models and select an available model.`
         );
       }
       await handleSaveLLMConfig(llmConfig);

--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
@@ -35,7 +35,6 @@ import CodexConfig from "./SettingCodex";
 import VertexAzureManualFields from "@/components/VertexAzureManualFields";
 import BedrockManualFields from "@/components/BedrockManualFields";
 import { MixpanelEvent, trackEvent } from "@/utils/mixpanel";
-import { getDefaultOllamaUrl } from "@/utils/providerUtils";
 import OllamaConfig from "@/components/OllamaConfig";
 
 interface OpenAIConfigProps {
@@ -503,12 +502,6 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
                                     section: "text_provider",
                                     provider: value,
                                   });
-                                  if (
-                                    value === "ollama" &&
-                                    !(currentOllamaUrl || "").trim()
-                                  ) {
-                                    onInputChange(getDefaultOllamaUrl(), "OLLAMA_URL");
-                                  }
                                   onInputChange(value, "LLM");
                                   setOpenProviderSelect(false);
                                 }}

--- a/servers/nextjs/components/LLMSelection.tsx
+++ b/servers/nextjs/components/LLMSelection.tsx
@@ -9,7 +9,6 @@ import CodexConfig from "./CodexConfig";
 import {
   updateLLMConfig,
   changeProvider as changeProviderUtil,
-  getDefaultOllamaUrl,
 } from "@/utils/providerUtils";
 import { LLMConfig } from "@/types/llm_config";
 import ImageSelectionConfig from "./ImageSelectionConfig";
@@ -78,8 +77,6 @@ export default function LLMProviderSelection({
 
     const needsApiKey = needsProviderApiKey || needsImageProviderApiKey;
 
-    const needsOllamaUrl = llmConfig.LLM === "ollama" && !llmConfig.OLLAMA_URL;
-
     const needsComfyUIConfig =
       !llmConfig.DISABLE_IMAGE_GENERATION &&
       llmConfig.IMAGE_PROVIDER === "comfyui" &&
@@ -102,7 +99,6 @@ export default function LLMProviderSelection({
       isDisabled:
         needsModelSelection ||
         needsApiKey ||
-        needsOllamaUrl ||
         needsComfyUIConfig ||
         needsOpenWebUIImageUrl ||
         needsOpenAICompatImageConfig,
@@ -110,15 +106,13 @@ export default function LLMProviderSelection({
         ? "Please Select a Model"
         : needsApiKey
           ? "Please Enter API Key"
-          : needsOllamaUrl
-            ? "Please Enter Ollama URL"
-            : needsComfyUIConfig
-              ? "Please Configure ComfyUI"
-              : needsOpenWebUIImageUrl
-                ? "Please Enter Open WebUI URL"
-                : needsOpenAICompatImageConfig
-                  ? "Please Configure Custom Image API"
-                  : "Save Configuration",
+          : needsComfyUIConfig
+            ? "Please Configure ComfyUI"
+            : needsOpenWebUIImageUrl
+              ? "Please Enter Open WebUI URL"
+              : needsOpenAICompatImageConfig
+                ? "Please Configure Custom Image API"
+                : "Save Configuration",
       showProgress: false,
     });
   }, [llmConfig]);
@@ -184,10 +178,6 @@ export default function LLMProviderSelection({
         } else {
           updates.IMAGE_PROVIDER = "pexels";
         }
-      }
-
-      if (!prevConfig.OLLAMA_URL) {
-        updates.OLLAMA_URL = getDefaultOllamaUrl();
       }
 
       if (Object.keys(updates).length === 0) {

--- a/servers/nextjs/components/OllamaConfig.tsx
+++ b/servers/nextjs/components/OllamaConfig.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef } from "react";
 import {
   Check,
   ChevronsUpDown,
@@ -60,6 +60,8 @@ export default function OllamaConfig({
   const [combinedModels, setCombinedModels] = useState<CombinedModel[]>([]);
   const [ollamaModelsLoading, setOllamaModelsLoading] = useState(false);
   const [modelsChecked, setModelsChecked] = useState(false);
+  const [modelsCheckError, setModelsCheckError] = useState<string | null>(null);
+  const [resolvedOllamaUrl, setResolvedOllamaUrl] = useState<string | null>(null);
   const [openModelSelect, setOpenModelSelect] = useState(false);
 
   const [pullDialogOpen, setPullDialogOpen] = useState(false);
@@ -75,23 +77,23 @@ export default function OllamaConfig({
   const pullRequestIdRef = useRef(0);
   const isElectronRuntime =
     typeof window !== "undefined" && !!window.electron;
-
-  useEffect(() => {
-    if (!ollamaUrl.trim()) {
-      onInputChange(getDefaultOllamaUrl(), "ollama_url");
-    }
-  }, [ollamaUrl, onInputChange]);
+  const defaultOllamaUrl = getDefaultOllamaUrl();
+  const trimmedOllamaUrl = ollamaUrl.trim();
+  const activeOllamaUrl = trimmedOllamaUrl || resolvedOllamaUrl || "";
 
   const fetchOllamaModels = useCallback(async () => {
     setOllamaModelsLoading(true);
+    setModelsCheckError(null);
     try {
-      const reachable = await getReachableOllamaModels(ollamaUrl);
+      const requestedUrl = ollamaUrl.trim();
+      const reachable = await getReachableOllamaModels(requestedUrl);
       const [pulledModels, libraryModels] = await Promise.all([
         Promise.resolve(reachable.models),
         getOllamaLibraryModels(),
       ]);
+      setResolvedOllamaUrl(reachable.resolvedUrl);
 
-      if (reachable.resolvedUrl !== ollamaUrl.trim()) {
+      if (requestedUrl && reachable.resolvedUrl !== requestedUrl) {
         onInputChange(reachable.resolvedUrl, "ollama_url");
       }
 
@@ -145,10 +147,12 @@ export default function OllamaConfig({
       if (reachable.usedFallback) {
         notify.success(
           "Using in-container Ollama",
-          "host.docker.internal did not respond, so Presenton switched Ollama URL to localhost."
+          requestedUrl
+            ? "host.docker.internal did not respond, so Presenton switched Ollama URL to localhost."
+            : "host.docker.internal did not respond, so this check used localhost."
         );
       }
-      if (!reachable.usedFallback && reachable.resolvedUrl !== ollamaUrl.trim()) {
+      if (!reachable.usedFallback && requestedUrl && reachable.resolvedUrl !== requestedUrl) {
         notify.success(
           "Updated Ollama URL",
           `Using ${reachable.resolvedUrl} for Ollama checks.`
@@ -157,7 +161,11 @@ export default function OllamaConfig({
     } catch (error) {
       setCombinedModels([]);
       setModelsChecked(true);
+      setResolvedOllamaUrl(null);
       onInputChange("", "ollama_model");
+      setModelsCheckError(
+        error instanceof Error ? error.message : "Check the Ollama URL and try again."
+      );
       notify.error(
         "Could not connect to Ollama",
         error instanceof Error ? error.message : "Check the Ollama URL and try again."
@@ -186,7 +194,7 @@ export default function OllamaConfig({
 
       pullOllamaModel(
         modelName,
-        ollamaUrl,
+        activeOllamaUrl,
         (event: OllamaPullProgressEvent) => {
           if (
             pullRequestIdRef.current !== requestId ||
@@ -242,7 +250,7 @@ export default function OllamaConfig({
         }
       });
     },
-    [ollamaUrl, onInputChange]
+    [activeOllamaUrl, onInputChange]
   );
 
   const handleCancelPull = useCallback(() => {
@@ -359,7 +367,6 @@ export default function OllamaConfig({
         </label>
         <input
           type="text"
-          required
           placeholder={
             isElectronRuntime
               ? "http://localhost:11434"
@@ -372,18 +379,21 @@ export default function OllamaConfig({
             onInputChange("", "ollama_model");
             setCombinedModels([]);
             setModelsChecked(false);
+            setModelsCheckError(null);
+            setResolvedOllamaUrl(null);
           }}
         />
         <p className="mt-2 text-sm text-gray-500">
-          {isElectronRuntime
-            ? "Default: http://localhost:11434"
-            : "Default: http://host.docker.internal:11434. If Ollama runs in the same container, Presenton will switch to localhost automatically."}
+          Leave blank to use the default {defaultOllamaUrl}
+          {!isElectronRuntime
+            ? ". If Ollama runs in the same container, Presenton will try localhost when needed."
+            : "."}
         </p>
         <Button
           type="button"
           variant="outline"
           className="mt-4"
-          disabled={ollamaModelsLoading || !ollamaUrl.trim()}
+          disabled={ollamaModelsLoading}
           onClick={fetchOllamaModels}
         >
           {ollamaModelsLoading ? (
@@ -506,8 +516,9 @@ export default function OllamaConfig({
 
       {modelsChecked && combinedModels.length === 0 && (
         <p className="text-sm text-gray-500">
-          Ollama is reachable, but no models are installed. Pull a model in
-          Ollama, then check again.
+          {modelsCheckError
+            ? modelsCheckError
+            : "Ollama is reachable, but no models are installed. Pull a model in Ollama, then check again."}
         </p>
       )}
 

--- a/servers/nextjs/components/OnBoarding/PresentonMode.tsx
+++ b/servers/nextjs/components/OnBoarding/PresentonMode.tsx
@@ -16,7 +16,7 @@ import { Select, SelectItem, SelectContent, SelectValue, SelectTrigger } from '.
 import { MixpanelEvent, trackEvent } from '@/utils/mixpanel';
 import { usePathname } from 'next/navigation';
 import { getLLMConfigValidationError, handleSaveLLMConfig } from '@/utils/storeHelpers';
-import { getDefaultOllamaUrl, isOllamaModelAvailable } from '@/utils/providerUtils';
+import { isOllamaModelAvailable } from '@/utils/providerUtils';
 import { getApiErrorMessage, getApiUrl } from '@/utils/api';
 import CodexConfig from '../CodexConfig';
 import { CODEX_MODELS } from '@/utils/codexModels';
@@ -93,9 +93,6 @@ const PresentonMode = ({
         setLlmConfig(prev => ({
             ...prev,
             LLM: provider,
-            ...(provider === "ollama" && !(prev.OLLAMA_URL || "").trim()
-                ? { OLLAMA_URL: getDefaultOllamaUrl() }
-                : {})
         }));
         setOpenProviderSelect(false);
         setAvailableModels([]);
@@ -724,7 +721,7 @@ const PresentonMode = ({
                 !(await isOllamaModelAvailable(llmConfig.OLLAMA_MODEL, currentOllamaUrl))
             ) {
                 throw new Error(
-                    `The selected model "${llmConfig.OLLAMA_MODEL}" is not available at ${currentOllamaUrl}. Check models and select an available model.`
+                    `The selected model "${llmConfig.OLLAMA_MODEL}" is not available at ${currentOllamaUrl || "the default Ollama URL"}. Check models and select an available model.`
                 );
             }
             await handleSaveLLMConfig(llmConfig);
@@ -993,9 +990,6 @@ const PresentonMode = ({
             setLlmConfig(prev => ({
                 ...prev,
                 LLM: nextProvider,
-                ...(nextProvider === "ollama" && !(prev.OLLAMA_URL || "").trim()
-                    ? { OLLAMA_URL: getDefaultOllamaUrl() }
-                    : {})
             }));
             setAvailableModels([]);
             setModelsChecked(false);

--- a/servers/nextjs/utils/providerUtils.ts
+++ b/servers/nextjs/utils/providerUtils.ts
@@ -3,6 +3,15 @@ import { LLMConfig } from "@/types/llm_config";
 
 const LOCALHOST_OLLAMA_URL = "http://localhost:11434";
 const DOCKER_HOST_OLLAMA_URL = "http://host.docker.internal:11434";
+const OLLAMA_MODELS_CACHE_TTL_MS = 30_000;
+
+type OllamaModelsCacheEntry = {
+  expiresAt: number;
+  promise: Promise<AvailableOllamaModel[]>;
+};
+
+let ollamaLibraryModelsPromise: Promise<OllamaLibraryModel[]> | null = null;
+const ollamaModelsCache = new Map<string, OllamaModelsCacheEntry>();
 
 export interface OllamaModel {
   label: string;
@@ -50,6 +59,18 @@ function isElectronRuntime(): boolean {
 
 function normalizeOllamaUrl(url?: string): string {
   return (url || "").trim().replace(/\/+$/, "");
+}
+
+function getOllamaModelsCacheKey(ollamaUrl?: string): string {
+  return normalizeOllamaUrl(ollamaUrl) || "__default__";
+}
+
+export function clearOllamaModelsCache(ollamaUrl?: string) {
+  if (ollamaUrl === undefined) {
+    ollamaModelsCache.clear();
+    return;
+  }
+  ollamaModelsCache.delete(getOllamaModelsCacheKey(ollamaUrl));
 }
 
 export function getDefaultOllamaUrl(): string {
@@ -187,11 +208,11 @@ export const isOllamaModelAvailable = async (
   ollamaModel: string,
   ollamaUrl?: string
 ): Promise<boolean> => {
-  const models = await getAvailableOllamaModels(ollamaUrl);
+  const { models } = await getReachableOllamaModels(ollamaUrl);
   return models.some((model) => model.name === ollamaModel);
 };
 
-export const getAvailableOllamaModels = async (
+const fetchAvailableOllamaModels = async (
   ollamaUrl?: string
 ): Promise<AvailableOllamaModel[]> => {
   const normalizedUrl = normalizeOllamaUrl(ollamaUrl);
@@ -226,6 +247,31 @@ export const getAvailableOllamaModels = async (
       },
     ];
   });
+};
+
+export const getAvailableOllamaModels = async (
+  ollamaUrl?: string
+): Promise<AvailableOllamaModel[]> => {
+  const cacheKey = getOllamaModelsCacheKey(ollamaUrl);
+  const now = Date.now();
+  const cached = ollamaModelsCache.get(cacheKey);
+
+  if (cached && cached.expiresAt > now) {
+    return cached.promise;
+  }
+
+  const promise = fetchAvailableOllamaModels(ollamaUrl);
+  ollamaModelsCache.set(cacheKey, {
+    expiresAt: now + OLLAMA_MODELS_CACHE_TTL_MS,
+    promise,
+  });
+
+  try {
+    return await promise;
+  } catch (error) {
+    ollamaModelsCache.delete(cacheKey);
+    throw error;
+  }
 };
 
 export const getReachableOllamaModels = async (
@@ -269,6 +315,20 @@ async function getApiErrorMessage(
 }
 
 export const getOllamaLibraryModels = async (): Promise<OllamaLibraryModel[]> => {
+  if (ollamaLibraryModelsPromise) {
+    return ollamaLibraryModelsPromise;
+  }
+
+  ollamaLibraryModelsPromise = fetchOllamaLibraryModels();
+  try {
+    return await ollamaLibraryModelsPromise;
+  } catch (error) {
+    ollamaLibraryModelsPromise = null;
+    throw error;
+  }
+};
+
+const fetchOllamaLibraryModels = async (): Promise<OllamaLibraryModel[]> => {
   const response = await fetch(
     getApiUrl("/api/v1/ppt/ollama/models/library")
   );
@@ -351,7 +411,10 @@ export const pullOllamaModel = async (
               return;
             }
             onEvent(data);
-            if (data.type === "complete") return;
+            if (data.type === "complete") {
+              clearOllamaModelsCache(ollamaUrl);
+              return;
+            }
           } catch {
           }
         }

--- a/servers/nextjs/utils/storeHelpers.ts
+++ b/servers/nextjs/utils/storeHelpers.ts
@@ -3,16 +3,6 @@ import { store } from "@/store/store";
 import { LLMConfig } from "@/types/llm_config";
 import { isSupportedCodexModel } from "@/utils/codexModels";
 
-const DEFAULT_OLLAMA_URL_ELECTRON = "http://localhost:11434";
-const DEFAULT_OLLAMA_URL_DOCKER = "http://host.docker.internal:11434";
-
-function getDefaultOllamaUrl(): string {
-  if (typeof window !== "undefined" && window.electron) {
-    return DEFAULT_OLLAMA_URL_ELECTRON;
-  }
-  return DEFAULT_OLLAMA_URL_DOCKER;
-}
-
 function isProvided(value: unknown): boolean {
   return value !== "" && value !== null && value !== undefined;
 }
@@ -40,13 +30,6 @@ export const normalizeLLMConfig = (llmConfig: LLMConfig): LLMConfig => {
 
   if (!normalizedConfig.LLM) {
     normalizedConfig.LLM = "openai";
-  }
-
-  if (
-    normalizedConfig.LLM === "ollama" &&
-    !isProvided(normalizedConfig.OLLAMA_URL)
-  ) {
-    normalizedConfig.OLLAMA_URL = getDefaultOllamaUrl();
   }
 
   const parsedDisableImageGeneration = parseOptionalBool(
@@ -179,9 +162,6 @@ export const getLLMConfigValidationError = (
       return 'No Anthropic model selected. Use "Check models" after entering your API key, then choose a model.';
     }
   } else if (llm === "ollama") {
-    if (!isProvided(llmConfig.OLLAMA_URL)) {
-      return "Ollama server URL is required.";
-    }
     if (!isProvided(llmConfig.OLLAMA_MODEL)) {
       return "Select an Ollama model. If none appear, confirm Ollama is running and reachable.";
     }


### PR DESCRIPTION
This pull request improves the handling of Ollama URL configuration and model selection across both the FastAPI backend and the Next.js frontend. The changes focus on making the Ollama URL optional (defaulting to a sensible value when not provided), refining user feedback and validation, and introducing caching for available Ollama models to improve performance and reliability.

**Ollama URL Handling and User Experience:**

* The Ollama URL is now treated as optional in both backend and frontend. If left blank, the system will use a default value and attempt to resolve the best endpoint automatically (e.g., switching between Docker host and localhost as needed). User-facing messages have been updated to clarify this behavior. [[1]](diffhunk://#diff-9dda0d1536a6bf65725d4d5c49ab0d08c4ba9e2c6137344a99919ca7ba77f6deL242-R248) [[2]](diffhunk://#diff-05836de66bce9d644ba15a20646c97e08efb5222723b16a5378be987dcc38d6cL177-R177) [[3]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46L727-R724) [[4]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06R382-R396)
* Improved error messages and user notifications when the selected Ollama model is not available, including fallback to default URLs in error descriptions. [[1]](diffhunk://#diff-05836de66bce9d644ba15a20646c97e08efb5222723b16a5378be987dcc38d6cL177-R177) [[2]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46L727-R724)
* The Ollama URL input is no longer required in the UI; leaving it blank triggers the default behavior. The UI now clearly communicates this to users. [[1]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06L362) [[2]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06R382-R396)

**Frontend Codebase Simplification and Logic Improvements:**

* Removed redundant logic that previously forced the Ollama URL to be set when selecting the Ollama provider. The system now handles defaulting internally, reducing complexity in provider selection and onboarding flows. [[1]](diffhunk://#diff-55159edd5f9d8cd6da234f575cc5f74ef0946a164dfd54fbfa2c2f697d010a42L506-L511) [[2]](diffhunk://#diff-30cbbd69d2a94dd0d1335bc4489a27ebc76d2175762ef2739689163e2b56b8d8L81-L82) [[3]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46L96-L98) [[4]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46L996-L998)
* Enhanced the `OllamaConfig` component to track and display errors more clearly, manage resolved URLs, and provide improved feedback when models cannot be loaded or the URL is unreachable. [[1]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06R63-R64) [[2]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06L78-R96) [[3]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06L148-R155) [[4]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06R164-R168) [[5]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06L509-R521)

**Backend Robustness:**

* The FastAPI backend now more carefully checks whether the Ollama URL is present in the user config before using it, ensuring that the environment variable fallback works as intended. [[1]](diffhunk://#diff-9dda0d1536a6bf65725d4d5c49ab0d08c4ba9e2c6137344a99919ca7ba77f6deR179-R183) [[2]](diffhunk://#diff-9dda0d1536a6bf65725d4d5c49ab0d08c4ba9e2c6137344a99919ca7ba77f6deL242-R248) [[3]](diffhunk://#diff-9dda0d1536a6bf65725d4d5c49ab0d08c4ba9e2c6137344a99919ca7ba77f6deL400-R406)

**Performance:**

* Introduced a cache for available Ollama models in the frontend, reducing redundant network requests and improving responsiveness when checking or selecting models. [[1]](diffhunk://#diff-7e3b64ae8f5120fc870051a787ffffa13d1330e9ae8a33d9ef9ae5c3dbc64113R6-R14) [[2]](diffhunk://#diff-7e3b64ae8f5120fc870051a787ffffa13d1330e9ae8a33d9ef9ae5c3dbc64113R64-R75) [[3]](diffhunk://#diff-7e3b64ae8f5120fc870051a787ffffa13d1330e9ae8a33d9ef9ae5c3dbc64113L190-R215) [[4]](diffhunk://#diff-7e3b64ae8f5120fc870051a787ffffa13d1330e9ae8a33d9ef9ae5c3dbc64113R252-R276)

**Code Cleanup:**

* Removed unused imports and simplified logic related to Ollama provider utilities across several frontend files. [[1]](diffhunk://#diff-55159edd5f9d8cd6da234f575cc5f74ef0946a164dfd54fbfa2c2f697d010a42L38) [[2]](diffhunk://#diff-30cbbd69d2a94dd0d1335bc4489a27ebc76d2175762ef2739689163e2b56b8d8L12) [[3]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46L19-R19) [[4]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06L3-R3)

---

**Ollama URL Handling and User Experience**
- Ollama URL is now optional; if left blank, the system uses a default and resolves the best endpoint automatically, with improved user-facing messages. [[1]](diffhunk://#diff-9dda0d1536a6bf65725d4d5c49ab0d08c4ba9e2c6137344a99919ca7ba77f6deL242-R248) [[2]](diffhunk://#diff-05836de66bce9d644ba15a20646c97e08efb5222723b16a5378be987dcc38d6cL177-R177) [[3]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46L727-R724) [[4]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06R382-R396)
- Enhanced error messages and notifications for unavailable Ollama models, including fallback to default URLs. [[1]](diffhunk://#diff-05836de66bce9d644ba15a20646c97e08efb5222723b16a5378be987dcc38d6cL177-R177) [[2]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46L727-R724)
- Ollama URL input in the UI is no longer required; the UI explains the defaulting behavior. [[1]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06L362) [[2]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06R382-R396)

**Frontend Logic and UX Improvements**
- Removed redundant logic for setting Ollama URL on provider selection; defaulting is now handled internally. [[1]](diffhunk://#diff-55159edd5f9d8cd6da234f575cc5f74ef0946a164dfd54fbfa2c2f697d010a42L506-L511) [[2]](diffhunk://#diff-30cbbd69d2a94dd0d1335bc4489a27ebc76d2175762ef2739689163e2b56b8d8L81-L82) [[3]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46L96-L98) [[4]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46L996-L998)
- Improved error handling and feedback in the `OllamaConfig` component, including error tracking and resolved URL display. [[1]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06R63-R64) [[2]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06L78-R96) [[3]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06L148-R155) [[4]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06R164-R168) [[5]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06L509-R521)

**Backend Robustness**
- Backend now checks for Ollama URL presence before using it, ensuring proper fallback to environment variables. [[1]](diffhunk://#diff-9dda0d1536a6bf65725d4d5c49ab0d08c4ba9e2c6137344a99919ca7ba77f6deR179-R183) [[2]](diffhunk://#diff-9dda0d1536a6bf65725d4d5c49ab0d08c4ba9e2c6137344a99919ca7ba77f6deL242-R248) [[3]](diffhunk://#diff-9dda0d1536a6bf65725d4d5c49ab0d08c4ba9e2c6137344a99919ca7ba77f6deL400-R406)

**Performance**
- Added a cache for available Ollama models in the frontend, reducing unnecessary network requests and improving UI responsiveness. [[1]](diffhunk://#diff-7e3b64ae8f5120fc870051a787ffffa13d1330e9ae8a33d9ef9ae5c3dbc64113R6-R14) [[2]](diffhunk://#diff-7e3b64ae8f5120fc870051a787ffffa13d1330e9ae8a33d9ef9ae5c3dbc64113R64-R75) [[3]](diffhunk://#diff-7e3b64ae8f5120fc870051a787ffffa13d1330e9ae8a33d9ef9ae5c3dbc64113L190-R215) [[4]](diffhunk://#diff-7e3b64ae8f5120fc870051a787ffffa13d1330e9ae8a33d9ef9ae5c3dbc64113R252-R276)

**Code Cleanup**
- Removed unused imports and simplified Ollama provider utility usage across frontend files. [[1]](diffhunk://#diff-55159edd5f9d8cd6da234f575cc5f74ef0946a164dfd54fbfa2c2f697d010a42L38) [[2]](diffhunk://#diff-30cbbd69d2a94dd0d1335bc4489a27ebc76d2175762ef2739689163e2b56b8d8L12) [[3]](diffhunk://#diff-575ab63680f6eaf467cde13b1b899dcbb793c11004efc4485904493d6ea2ae46L19-R19) [[4]](diffhunk://#diff-0dcb19237b2ecaf8c6b0ab2a44c587eaf03e2ee1f622e996ea7f1896eab80d06L3-R3)