### PR TITLE
Fix font check oversized upload response

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -33,6 +33,8 @@ http {
     }
 
     location /api/v1/ {
+      client_max_body_size 110M;
+      error_page 413 = @request_entity_too_large;
       proxy_pass http://localhost:8000;
       proxy_read_timeout 30m;
       proxy_send_timeout 30m;
@@ -41,6 +43,11 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location @request_entity_too_large {
+      default_type application/json;
+      return 413 '{"detail":"File size must be less than 100MB."}';
     }
 
     # MCP

--- a/servers/fastapi/templates/fonts_and_slides_preview.py
+++ b/servers/fastapi/templates/fonts_and_slides_preview.py
@@ -75,6 +75,8 @@ class _PreviewLogger:
 
 PREVIEW_WIDTH = 1280
 PREVIEW_HEIGHT = 720
+MAX_FONT_CHECK_UPLOAD_SIZE_BYTES = 100 * 1024 * 1024
+FONT_CHECK_UPLOAD_SIZE_ERROR = "File size must be less than 100MB."
 
 
 def _preview_dimensions_from_document(width: float, height: float) -> Tuple[int, int]:
@@ -588,6 +590,11 @@ def _build_modified_pptx_filename(original_filename: str) -> str:
     return f"{base_stem}-modified{extension or '.pptx'}"
 
 
+def _raise_if_font_check_upload_too_large(size: int | None) -> None:
+    if size is not None and size >= MAX_FONT_CHECK_UPLOAD_SIZE_BYTES:
+        raise HTTPException(status_code=413, detail=FONT_CHECK_UPLOAD_SIZE_ERROR)
+
+
 async def check_fonts_in_pptx_handler(pptx_file: UploadFile) -> FontCheckResponse:
     """
     Extract fonts from a PPTX file and check their availability in Google Fonts.
@@ -601,11 +608,13 @@ async def check_fonts_in_pptx_handler(pptx_file: UploadFile) -> FontCheckRespons
         raise HTTPException(
             status_code=400, detail="Invalid file type. Expected PPTX file"
         )
+    _raise_if_font_check_upload_too_large(getattr(pptx_file, "size", None))
 
     with tempfile.TemporaryDirectory() as temp_dir:
         # Save uploaded PPTX file
         pptx_path = os.path.join(temp_dir, "presentation.pptx")
         pptx_content = await pptx_file.read()
+        _raise_if_font_check_upload_too_large(len(pptx_content))
         await asyncio.to_thread(_write_bytes_to_path, pptx_path, pptx_content)
         font_variants_by_name = await asyncio.to_thread(
             extract_used_font_variants_from_pptx, pptx_path

--- a/servers/fastapi/tests/test_pptx_font_utils.py
+++ b/servers/fastapi/tests/test_pptx_font_utils.py
@@ -17,10 +17,19 @@ class DummyLogger:
         return None
 
 
+_SIZE_UNSET = object()
+
+
 class DummyUploadFile:
-    def __init__(self, filename: str, content: bytes = b"font") -> None:
+    def __init__(
+        self,
+        filename: str,
+        content: bytes = b"font",
+        size: int | None | object = _SIZE_UNSET,
+    ) -> None:
         self.filename = filename
         self._content = content
+        self.size = len(content) if size is _SIZE_UNSET else size
 
     async def read(self) -> bytes:
         return self._content
@@ -39,6 +48,35 @@ def test_build_google_fonts_stylesheet_url_includes_regular_and_bold_weights():
 
 def test_normalize_font_family_name_strips_localized_bold_token():
     assert pptx_font_utils.normalize_font_family_name("Arial Gras") == "Arial"
+
+
+def test_check_fonts_in_pptx_rejects_100mb_file_from_upload_size():
+    upload = DummyUploadFile(
+        "deck.pptx",
+        content=b"",
+        size=fonts_and_slides_preview.MAX_FONT_CHECK_UPLOAD_SIZE_BYTES,
+    )
+
+    with pytest.raises(fonts_and_slides_preview.HTTPException) as exc_info:
+        asyncio.run(fonts_and_slides_preview.check_fonts_in_pptx_handler(upload))
+
+    assert exc_info.value.status_code == 413
+    assert exc_info.value.detail == "File size must be less than 100MB."
+
+
+def test_check_fonts_in_pptx_rejects_oversize_after_read_when_size_missing(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        fonts_and_slides_preview, "MAX_FONT_CHECK_UPLOAD_SIZE_BYTES", 4
+    )
+    upload = DummyUploadFile("deck.pptx", content=b"abcd", size=None)
+
+    with pytest.raises(fonts_and_slides_preview.HTTPException) as exc_info:
+        asyncio.run(fonts_and_slides_preview.check_fonts_in_pptx_handler(upload))
+
+    assert exc_info.value.status_code == 413
+    assert exc_info.value.detail == "File size must be less than 100MB."
 
 
 def test_build_google_fonts_stylesheet_url_sorts_and_deduplicates_weights():


### PR DESCRIPTION
This pull request introduces a 100MB upload size limit for PPTX font checking endpoints, ensuring that users receive clear and consistent error messages when files exceed this limit. The changes span NGINX configuration, backend validation, and automated tests to enforce and verify the new restriction.

**API and Backend Validation:**
- Enforces a 100MB file size limit for uploads to the PPTX font check endpoint, with backend checks both before and after reading the file content. If the limit is exceeded, a 413 error with a clear message is returned. [[1]](diffhunk://#diff-686f5aae0119032d31544f3a1de29b7f229508703eebfe464adc271f3a0c8fcbR78-R79) [[2]](diffhunk://#diff-686f5aae0119032d31544f3a1de29b7f229508703eebfe464adc271f3a0c8fcbR593-R597) [[3]](diffhunk://#diff-686f5aae0119032d31544f3a1de29b7f229508703eebfe464adc271f3a0c8fcbR611-R617)

**NGINX Configuration:**
- Updates `nginx.conf` to set `client_max_body_size` to 110MB for `/api/v1/` routes and returns a JSON error message for requests exceeding 100MB. [[1]](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaR36-R37) [[2]](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaR48-R52)

**Testing Enhancements:**
- Adds tests to ensure files at or above the 100MB limit are properly rejected, both when the file size is known and when it is determined after reading the file. Also updates the `DummyUploadFile` test helper to support explicit file size simulation. [[1]](diffhunk://#diff-a707936f9d04a2422278c72ea8389e8cb6c5be89521c7d0f40cc0cb2319b13c5R20-R32) [[2]](diffhunk://#diff-a707936f9d04a2422278c72ea8389e8cb6c5be89521c7d0f40cc0cb2319b13c5R53-R81)