### PR TITLE
Refactor OutlinePage component to use isOutlineAssistantVisible for c…

### DIFF
--- a/servers/nextjs/app/(presentation-generator)/outline/components/OutlinePage.tsx
+++ b/servers/nextjs/app/(presentation-generator)/outline/components/OutlinePage.tsx
@@ -108,6 +108,8 @@ const OutlinePage: React.FC = () => {
   const hasSelectedTemplate = selectedTemplate !== null;
   const isOutlineReady =
     hasSelectedTemplate && hasOutlineStreamFinished && !outlineControlsBusy;
+  const isOutlineAssistantVisible =
+    activeTab === TABS.OUTLINE && isOutlineReady;
   const isRegenerateDisabled =
     !hasSelectedTemplate || (activeTab === TABS.OUTLINE && !isOutlineReady);
   const outlineStreamFinished =
@@ -276,7 +278,7 @@ const OutlinePage: React.FC = () => {
             <div
               className={cn(
                 "w-full gap-5",
-                activeTab === TABS.OUTLINE
+                isOutlineAssistantVisible
                   ? "grid lg:grid-cols-[minmax(0,1fr)_352px]"
                   : "block"
               )}
@@ -336,7 +338,7 @@ const OutlinePage: React.FC = () => {
                 </TabsContent>
               </div>
 
-              {activeTab === TABS.OUTLINE && (
+              {isOutlineAssistantVisible && (
                 <aside className="h-[min(760px,calc(100vh-250px))] overflow-hidden border border-[#EDEEEF] bg-white lg:sticky lg:top-[92px] lg:h-[min(760px,calc(100vh-250px))]">
                   <Chat
                     key={presentation_id}
@@ -353,7 +355,7 @@ const OutlinePage: React.FC = () => {
           <div
             className={cn(
               "fixed bottom-[26px] z-50",
-              activeTab === TABS.OUTLINE
+              isOutlineAssistantVisible
                 ? "left-5 sm:left-10 lg:left-auto lg:right-[calc(5rem+352px+2.5rem)]"
                 : "right-[26px]"
             )}


### PR DESCRIPTION
This pull request refactors the logic for displaying the outline assistant and related layout in the `OutlinePage` component. The main change is introducing a new variable to more precisely control when the outline assistant is visible, improving readability and maintainability.

**UI logic improvements:**

* Introduced the `isOutlineAssistantVisible` variable to clearly express when the outline assistant and its layout should be shown, replacing multiple checks for `activeTab === TABS.OUTLINE && isOutlineReady`.
* Updated layout and conditional rendering to use `isOutlineAssistantVisible` instead of directly checking tab and readiness state, affecting the grid layout, sidebar visibility, and floating button positioning. [[1]](diffhunk://#diff-3488c934b2d2ef2e87382bbe0891e26dd60c2e77401f5fcd350ae58f2e8a6542L279-R281) [[2]](diffhunk://#diff-3488c934b2d2ef2e87382bbe0891e26dd60c2e77401f5fcd350ae58f2e8a6542L339-R341) [[3]](diffhunk://#diff-3488c934b2d2ef2e87382bbe0891e26dd60c2e77401f5fcd350ae58f2e8a6542L356-R358)…onditional rendering