### PR TITLE
Fix/presenton win specific export path 709

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ ENV APP_DATA_DIRECTORY=/app_data \
 
 RUN set -eux; \
     packages="ca-certificates curl nginx fontconfig imagemagick zstd chromium \
-      fonts-liberation fonts-noto-core xdg-utils \
+      findutils fonts-noto-core fonts-noto-extra fonts-noto-mono fonts-noto-cjk fonts-noto-color-emoji xdg-utils \
       libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64 libatspi2.0-0t64 \
       libcairo2 libcups2t64 libdbus-1-3 libdrm2 libexpat1 libgbm1 \
       libglib2.0-0t64 libgtk-3-0t64 libnspr4 libnss3 libpango-1.0-0 \
@@ -106,6 +106,11 @@ RUN set -eux; \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash -; \
     apt-get install -y --no-install-recommends nodejs; \
     rm -rf /var/lib/apt/lists/*
+
+# Remove any non-Noto fonts that may have been installed as dependencies.
+RUN find /usr/share/fonts -type f ! -iname 'Noto*' -delete \
+    && find /usr/share/fonts -type d -empty -delete \
+    && fc-cache -fsv
 
 RUN mkdir -p /app/scripts /app/servers/fastapi /app/servers/nextjs
 RUN mkdir -p /app_data/exports /app_data/images /app_data/uploads /app_data/fonts /app_data/pptx-to-html \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -23,7 +23,7 @@ ENV APP_DATA_DIRECTORY=/app_data \
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl unzip \
       nginx fontconfig imagemagick zstd chromium \
-      fonts-liberation xdg-utils \
+      findutils fonts-noto-core fonts-noto-extra fonts-noto-mono fonts-noto-cjk fonts-noto-color-emoji xdg-utils \
       libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64 libatspi2.0-0t64 \
       libcairo2 libcups2t64 libdbus-1-3 libdrm2 libexpat1 libgbm1 \
       libglib2.0-0t64 libgtk-3-0t64 libnspr4 libnss3 libpango-1.0-0 \
@@ -32,6 +32,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       tesseract-ocr tesseract-ocr-eng \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && rm -rf /var/lib/apt/lists/*
+
+# Remove any non-Noto fonts that may have been installed as dependencies.
+RUN find /usr/share/fonts -type f ! -iname 'Noto*' -delete \
+    && find /usr/share/fonts -type d -empty -delete \
+    && fc-cache -fsv
 
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \

--- a/servers/nextjs/lib/run-bundled-presentation-export.ts
+++ b/servers/nextjs/lib/run-bundled-presentation-export.ts
@@ -86,6 +86,16 @@ export type BundledPresentationExportResult = { path: string };
 const EXPORT_DIRECTORY_MODE = 0o755;
 const EXPORT_FILE_MODE = 0o644;
 
+export function normalizeExportFileUrlPathname(
+  fsPath: string,
+  platform: NodeJS.Platform = process.platform
+): string {
+  if (platform === "win32" && /^\/[A-Za-z]:[\\/]/.test(fsPath)) {
+    return fsPath.slice(1);
+  }
+  return fsPath;
+}
+
 function normalizeExportOutputPath(params: {
   pathValue?: string;
   urlValue?: string;
@@ -115,7 +125,9 @@ function normalizeExportOutputPath(params: {
   if (urlValue && typeof urlValue === "string") {
     if (urlValue.startsWith("file://")) {
       const parsed = new URL(urlValue);
-      const fsPath = decodeURIComponent(parsed.pathname || "");
+      const fsPath = normalizeExportFileUrlPathname(
+        decodeURIComponent(parsed.pathname || "")
+      );
       if (fsPath.startsWith("/app_data/")) {
         return resolveAppDataRelative(fsPath);
       }

--- a/servers/nextjs/package.json
+++ b/servers/nextjs/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "test:export-output-path": "node --test tests/export-output-path.test.mjs",
     "test:layout-code": "node --test tests/layout-code-validator.test.mjs",
     "check:layout-code": "node scripts/check-layout-code.mjs"
   },

--- a/servers/nextjs/tests/export-output-path.test.mjs
+++ b/servers/nextjs/tests/export-output-path.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+
+import { build } from "esbuild";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function resolveNextAlias(importPath) {
+  const basePath = path.join(projectRoot, importPath.slice(2));
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    `${basePath}.js`,
+    path.join(basePath, "index.ts"),
+    path.join(basePath, "index.tsx"),
+    path.join(basePath, "index.js"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? basePath;
+}
+
+async function loadExportHelpers() {
+  const outDir = await mkdtemp(path.join(tmpdir(), "export-output-path-test-"));
+  const outfile = path.join(outDir, "export-output-path.mjs");
+
+  await build({
+    entryPoints: [path.join(projectRoot, "lib", "run-bundled-presentation-export.ts")],
+    outfile,
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    sourcemap: false,
+    logLevel: "silent",
+    plugins: [
+      {
+        name: "next-alias",
+        setup(builder) {
+          builder.onResolve({ filter: /^@\// }, (args) => ({
+            path: resolveNextAlias(args.path),
+          }));
+        },
+      },
+    ],
+  });
+
+  return import(pathToFileURL(outfile).href);
+}
+
+const exportHelpersPromise = loadExportHelpers();
+
+test("normalizes Windows drive paths from file URL pathnames", async () => {
+  const { normalizeExportFileUrlPathname } = await exportHelpersPromise;
+
+  assert.equal(
+    normalizeExportFileUrlPathname(
+      "/D:/www/web/presenton/app_data/exports/deck.pdf",
+      "win32"
+    ),
+    "D:/www/web/presenton/app_data/exports/deck.pdf"
+  );
+});
+
+test("leaves non-Windows drive-looking pathnames unchanged", async () => {
+  const { normalizeExportFileUrlPathname } = await exportHelpersPromise;
+
+  assert.equal(
+    normalizeExportFileUrlPathname(
+      "/D:/www/web/presenton/app_data/exports/deck.pdf",
+      "linux"
+    ),
+    "/D:/www/web/presenton/app_data/exports/deck.pdf"
+  );
+});
+
+test("does not rewrite app-data-relative file URL pathnames on Windows", async () => {
+  const { normalizeExportFileUrlPathname } = await exportHelpersPromise;
+
+  assert.equal(
+    normalizeExportFileUrlPathname("/app_data/exports/deck.pdf", "win32"),
+    "/app_data/exports/deck.pdf"
+  );
+});


### PR DESCRIPTION
This pull request improves font handling in the Docker images and fixes Windows path normalization for file URLs in export logic. It also adds targeted tests for the new path normalization helper.

**Docker image improvements:**

* Replaces `fonts-liberation` with a comprehensive set of `fonts-noto-*` packages and removes any non-Noto fonts after installation to ensure consistent font availability and reduce image size. (`Dockerfile`, `Dockerfile.dev`) [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L97-R97) [[2]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL26-R26) [[3]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R110-R114) [[4]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacR36-R40)

**Export path normalization and testing:**

* Adds a new helper function `normalizeExportFileUrlPathname` in `run-bundled-presentation-export.ts` to correctly handle Windows drive letter paths derived from file URLs, preventing issues when running on Windows.
* Updates export output path logic to use the new normalization helper for file URLs, improving cross-platform compatibility.
* Adds a dedicated test suite `export-output-path.test.mjs` and a corresponding npm script to verify path normalization behavior on different platforms. (`package.json`, `tests/export-output-path.test.mjs`) [[1]](diffhunk://#diff-5563d31000e9cb36d9e8a030e4371e3932346fae15c98bba431a83cc3bf720bbR11) [[2]](diffhunk://#diff-4bf3831aa27bd6554a4d9db651ddb58938e472e4e82daf5da20c091c320d73e2R1-R87)