### PR TITLE
Display version name in startup banner when running Docker container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "presenton",
-  "version": "1.0.0",
+  "version": "0.8.7",
   "presentationExportVersion": "v0.3.6",
   "type": "module",
   "description": "Open-source AI presentation generator",

--- a/scripts/presenton-terminal-banner.mjs
+++ b/scripts/presenton-terminal-banner.mjs
@@ -58,6 +58,18 @@ function loadAsciiBanner() {
   }
 }
 
+function loadPackageVersion() {
+  const thisDir = path.dirname(fileURLToPath(import.meta.url));
+  const packageJsonPath = path.join(thisDir, "..", "package.json");
+
+  try {
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    return typeof pkg.version === "string" ? pkg.version : "";
+  } catch {
+    return "";
+  }
+}
+
 /** Visible width (strips SGR sequences). */
 function visLen(s) {
   return s.replace(/\x1b\[[0-9;:]*m/g, "").length;
@@ -79,6 +91,7 @@ export function printPresentonStartupBanner(opts = {}) {
   const mode = opts.mode === "development" ? "development" : "production";
   const nextPort = opts.nextPort ?? 3000;
   const fastapiPort = opts.fastapiPort ?? 8000;
+  const version = opts.version ?? loadPackageVersion();
   const hostHttpPort =
     opts.hostHttpPort ??
     process.env.PRESENTON_HTTP_HOST_PORT ??
@@ -130,6 +143,9 @@ export function printPresentonStartupBanner(opts = {}) {
           pipe(padVis("  " + BOLD + "Routing summary" + RESET, W)),
           boxDivider,
           pipe(padVis("  " + muted("Mode:                 ") + mode, W)),
+          ...(version
+            ? [pipe(padVis("  " + muted("Version:              ") + version, W))]
+            : []),
           pipe(padVis("  " + accent("/         ") + muted("→ Next.js"), W)),
           pipe(padVis("  " + accent("/api/v1/  ") + muted("→ FastAPI"), W)),
           pipe(padVis("  " + muted("Next.js docker URL: ") + nextUrl, W)),
@@ -148,6 +164,9 @@ export function printPresentonStartupBanner(opts = {}) {
           pipe(padVis("  " + BOLD + "Application URL" + RESET, W)),
           boxDivider,
           pipe(padVis("  " + muted("Mode:             ") + mode, W)),
+          ...(version
+            ? [pipe(padVis("  " + muted("Version:          ") + version, W))]
+            : []),
           pipe(
             padVis(
               "  " +


### PR DESCRIPTION
This pull request updates the startup banner in the terminal to display the current application version and ensures the correct version is shown from `package.json`. It also downgrades the version in `package.json` to `0.8.7`.

**Startup banner improvements:**

* Added a `loadPackageVersion` function to read the version from `package.json` and display it in the terminal banner if available (`scripts/presenton-terminal-banner.mjs`).
* Updated the startup banner to show the version in both the routing summary and application URL sections (`scripts/presenton-terminal-banner.mjs`). [[1]](diffhunk://#diff-335ccbe49a47a00eb91f70c93649c01dc7c680c0e21e6d5a6d2f343b1d5827a1R146-R148) [[2]](diffhunk://#diff-335ccbe49a47a00eb91f70c93649c01dc7c680c0e21e6d5a6d2f343b1d5827a1R167-R169)
* Modified the startup banner to use the loaded version, with an option to override via `opts.version` (`scripts/presenton-terminal-banner.mjs`).

**Version management:**

* Downgraded the application version in `package.json` from `1.0.0` to `0.8.7`.