### PR TITLE
Update build configuration to include all node_modules for LiteParse …

### DIFF
--- a/electron/build.js
+++ b/electron/build.js
@@ -437,11 +437,8 @@ const config = {
   asar: true,
   asarUnpack: [
     "resources/**",
-    "node_modules/**/*.node",
-    "node_modules/sharp/**",
-    "node_modules/@img/**",
-    "node_modules/detect-libc/**",
-    "node_modules/semver/**",
+    // LiteParse runs from FastAPI via Electron-as-Node and needs real package dirs.
+    "node_modules/**",
   ],
   copyright: "Copyright © 2026 Presenton",
   directories: {


### PR DESCRIPTION
This pull request makes a configuration change to the Electron build process. The main update is to the `asarUnpack` setting, ensuring that all `node_modules` directories are unpacked, which is necessary for LiteParse to run correctly when invoked from FastAPI via Electron-as-Node.

**Build configuration update:**

* Updated the `asarUnpack` array in `electron/build.js` to unpack all contents in `node_modules/**` instead of a selective list of subdirectories, ensuring required packages are available for LiteParse when run from FastAPI.…compatibility