### PR TITLE
fix: React hooks called conditionally, bare except clause, unused import

### DIFF
--- a/servers/fastapi/utils/llm_provider.py
+++ b/servers/fastapi/utils/llm_provider.py
@@ -47,7 +47,7 @@ from utils.get_env import (
 def get_llm_provider():
     try:
         return LLMProvider(get_llm_provider_env())
-    except:
+    except Exception:
         raise HTTPException(
             status_code=500,
             detail=(

--- a/servers/nextjs/app/(presentation-generator)/components/ImageEditor.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/ImageEditor.tsx
@@ -11,7 +11,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { Wand2, Upload, Loader2, Delete, Trash, Search } from "lucide-react";
+import { Wand2, Upload, Loader2, Trash, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { PresentationGenerationApi } from "../services/api/presentation-generation";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/servers/nextjs/app/(presentation-generator)/components/PresentationMode.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/PresentationMode.tsx
@@ -34,12 +34,6 @@ const PresentationMode: React.FC<PresentationModeProps> = ({
 
 
 }) => {
-  if (slides === undefined || slides === null || slides.length === 0) {
-    return null;
-  }
-
-
-
   const recomputeScale = useCallback(() => {
     if (typeof window === "undefined") return;
     const padding = isFullscreen ? 0 : 64; // match p-8 when not fullscreen
@@ -145,6 +139,10 @@ const PresentationMode: React.FC<PresentationModeProps> = ({
     document.addEventListener("keydown", handleEscKey);
     return () => document.removeEventListener("keydown", handleEscKey);
   }, [isFullscreen, onFullscreenToggle]);
+
+  if (slides === undefined || slides === null || slides.length === 0) {
+    return null;
+  }
 
   return (
     <div


### PR DESCRIPTION
Found a React rules-of-hooks violation in PresentationMode:

The component returns early (\`if (!slides) return null\`) before \`useCallback\` and \`useEffect\` are called. React hooks must be called in the same order every render — conditional returns before hooks can cause unpredictable behavior or crashes. Moved the early return after all hook declarations.

Also:
- \`llm_provider.py\` had a bare \`except:\` which catches \`SystemExit\` and \`KeyboardInterrupt\` in addition to normal exceptions — changed to \`except Exception:\`
- ImageEditor imports \`Delete\` from lucide-react but only uses \`Trash\` — removed the unused import