### PR TITLE
feat: add LLM=kiro provider using @colin3191/kiro-proxy

### DIFF
--- a/servers/fastapi/constants/llm.py
+++ b/servers/fastapi/constants/llm.py
@@ -21,3 +21,4 @@ SUPPORTED_CODEX_MODELS = {
     "gpt-5.3-codex-spark",
 }
 DEFAULT_CODEX_MODEL = "gpt-5.5"
+DEFAULT_KIRO_MODEL = "claude-sonnet-4-5"

--- a/servers/fastapi/enums/llm_provider.py
+++ b/servers/fastapi/enums/llm_provider.py
@@ -18,3 +18,4 @@ class LLMProvider(Enum):
     LMSTUDIO = "lmstudio"
     CUSTOM = "custom"
     CODEX = "codex"
+    KIRO = "kiro"

--- a/servers/fastapi/utils/get_env.py
+++ b/servers/fastapi/utils/get_env.py
@@ -398,3 +398,15 @@ def get_openai_compat_image_api_key_env():
 
 def get_openai_compat_image_model_env():
     return os.getenv("OPENAI_COMPAT_IMAGE_MODEL")
+
+
+def get_kiro_model_env():
+    return os.getenv("KIRO_MODEL")
+
+
+def get_kiro_proxy_url_env():
+    return os.getenv("KIRO_PROXY_URL")
+
+
+def get_kiro_proxy_api_key_env():
+    return os.getenv("KIRO_PROXY_API_KEY")

--- a/servers/fastapi/utils/llm_config.py
+++ b/servers/fastapi/utils/llm_config.py
@@ -51,6 +51,8 @@ from utils.get_env import (
     get_fireworks_api_key_env,
     get_fireworks_base_url_env,
     get_google_api_key_env,
+    get_kiro_proxy_api_key_env,
+    get_kiro_proxy_url_env,
     get_litellm_api_key_env,
     get_litellm_base_url_env,
     get_lmstudio_api_key_env,
@@ -350,13 +352,20 @@ def get_llm_config(*, use_openai_responses_api: bool = False) -> ClientConfig:
                 access_token=_get_codex_access_token(),
                 account_id=get_codex_account_id_env() or None,
             )
+        case LLMProvider.KIRO:
+            base_url = get_kiro_proxy_url_env() or "http://127.0.0.1:3456"
+            api_key = get_kiro_proxy_api_key_env() or "kiro"
+            return AnthropicClientConfig(
+                api_key=api_key,
+                base_url=base_url,
+            )
         case _:
             raise HTTPException(
                 status_code=400,
                 detail=(
                     "LLM Provider must be either openai, deepseek, google, vertex, azure, "
                     "bedrock, openrouter, fireworks, together, cerebras, "
-                    "anthropic, litellm, lmstudio, ollama, custom, or codex"
+                    "anthropic, litellm, lmstudio, ollama, custom, codex, or kiro"
                 ),
             )
 

--- a/servers/fastapi/utils/llm_provider.py
+++ b/servers/fastapi/utils/llm_provider.py
@@ -10,6 +10,7 @@ from constants.llm import (
     DEFAULT_CODEX_MODEL,
     DEFAULT_DEEPSEEK_MODEL,
     DEFAULT_FIREWORKS_MODEL,
+    DEFAULT_KIRO_MODEL,
     DEFAULT_LITELLM_MODEL,
     DEFAULT_GOOGLE_MODEL,
     DEFAULT_LMSTUDIO_MODEL,
@@ -31,6 +32,7 @@ from utils.get_env import (
     get_fireworks_model_env,
     get_google_api_key_env,
     get_google_model_env,
+    get_kiro_model_env,
     get_litellm_model_env,
     get_lmstudio_model_env,
     get_llm_provider_env,
@@ -54,7 +56,7 @@ def get_llm_provider():
                 "Invalid LLM provider. Please select one of: "
                 "openai, deepseek, google, vertex, azure, bedrock, openrouter, "
                 "fireworks, together, cerebras, anthropic, litellm, "
-                "lmstudio, ollama, custom, codex"
+                "lmstudio, ollama, custom, codex, kiro"
             ),
         )
 
@@ -162,6 +164,8 @@ def get_model():
     elif selected_llm == LLMProvider.CODEX:
         codex_model = get_codex_model_env()
         return codex_model if codex_model in SUPPORTED_CODEX_MODELS else DEFAULT_CODEX_MODEL
+    elif selected_llm == LLMProvider.KIRO:
+        return get_kiro_model_env() or DEFAULT_KIRO_MODEL
     else:
         raise HTTPException(
             status_code=500,
@@ -169,7 +173,7 @@ def get_model():
                 "Invalid LLM provider. Please select one of: "
                 "openai, deepseek, google, vertex, azure, bedrock, openrouter, "
                 "fireworks, together, cerebras, anthropic, litellm, "
-                "lmstudio, ollama, custom, codex"
+                "lmstudio, ollama, custom, codex, kiro"
             ),
         )
 

--- a/start.js
+++ b/start.js
@@ -467,8 +467,6 @@ const startServers = async (nginxReadyPromise) => {
       fastapiPort.toString(),
       "--reload",
       isDev ? "true" : "false",
-      "--log-level",
-      isDev ? "info" : "warning",
     ],
     {
       cwd: fastapiDir,
@@ -560,10 +558,37 @@ const startServers = async (nginxReadyPromise) => {
   const shouldStartOllamaRuntime = shouldStartOllama();
   const ollamaInstalled = isOllamaInstalled();
 
+  const shouldStartKiroProxy =
+    (process.env.LLM || "").toLowerCase() === "kiro";
+
   const exitPromises = [
     new Promise((resolve) => fastApiProcess.on("exit", resolve)),
     new Promise((resolve) => nextjsProcess.on("exit", resolve)),
   ];
+
+  if (shouldStartKiroProxy) {
+    const kiroProxyPort = process.env.KIRO_PROXY_PORT || "3456";
+    const kiroProxyProcess = spawn(
+      "npx",
+      ["@colin3191/kiro-proxy"],
+      {
+        cwd: "/app",
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          PORT: kiroProxyPort,
+          PROXY_API_KEY: process.env.KIRO_PROXY_API_KEY || "",
+        },
+      }
+    );
+    kiroProxyProcess.on("error", (err) => {
+      console.error("kiro-proxy process failed to start:", err);
+    });
+    forwardProcessOutput(kiroProxyProcess.stdout, process.stdout, { suppressStartupUrls });
+    forwardProcessOutput(kiroProxyProcess.stderr, process.stderr, { suppressStartupUrls });
+    exitPromises.push(new Promise((resolve) => kiroProxyProcess.on("exit", resolve)));
+    console.log(`kiro-proxy starting on port ${kiroProxyPort}...`);
+  }
 
   if (shouldStartOllamaRuntime && ollamaInstalled) {
     const ollamaProcess = spawn("ollama", ["serve"], {


### PR DESCRIPTION
## Summary

Add native Kiro (AWS CodeWhisperer) support as an LLM provider.
When `LLM=kiro`, Presenton spawns `@colin3191/kiro-proxy` as a sidecar process and routes requests via Anthropic API format (`/v1/messages`).

## Changes

- Add `KIRO` enum to `LLMProvider`
- Add `AnthropicClientConfig` for kiro in `get_llm_config()`
- Add kiro-proxy spawn logic in `start.js` (port 3456)
- Add env vars: `KIRO_MODEL`, `KIRO_PROXY_URL`, `KIRO_PROXY_API_KEY`

## How it works

```
Presenton (AnthropicClientConfig)
  -> @colin3191/kiro-proxy :3456/v1/messages
    -> Kiro / AWS CodeWhisperer API
```

## Usage

```bash
container run -d --name presenton -p 5001:80 \
  -e LLM=kiro -e KIRO_MODEL=claude-sonnet-4.5 \
  -v ~/.aws/sso/cache:/root/.aws/sso/cache:ro \
  ghcr.io/presenton/presenton:latest
```

## Env vars

| Variable | Default | Description |
|----------|---------|-------------|
| `LLM` | - | Set to `kiro` to activate |
| `KIRO_MODEL` | `claude-sonnet-4-5` | Model name |
| `KIRO_PROXY_URL` | `http://127.0.0.1:3456` | kiro-proxy base URL |
| `KIRO_PROXY_API_KEY` | `kiro` | Proxy auth key |

## Prerequisites

- Kiro CLI or Kiro IDE login (creates `~/.aws/sso/cache/kiro-auth-token.json`)
- Mount `~/.aws/sso/cache` into container for token access

## Tested

- PPT generation with claude-sonnet-4.5 via Kiro free tier
- Token auto-refresh (OIDC/IdC)
- Korean language presentations