### PR TITLE
feat: add warning dialog for non-vision model template generation

### DIFF
--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/templates/components/CreateCustomTemplate.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/templates/components/CreateCustomTemplate.tsx
@@ -1,41 +1,97 @@
-import { Plus, Sparkles } from 'lucide-react'
+import { AlertTriangle, Plus, Sparkles } from 'lucide-react'
 import { useRouter } from 'next/navigation';
-import React from 'react'
+import React, { useState } from 'react'
 import { trackEvent, MixpanelEvent } from "@/utils/mixpanel";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
 
 const CreateCustomTemplate = () => {
     const router = useRouter();
-    return (
-        <div
-            onClick={() => {
-                trackEvent(MixpanelEvent.Templates_Build_Template_Clicked);
-                router.push('/custom-template')
-            }}
-            className='w-full rounded-[22px] border border-[#EDEEEF] cursor-pointer font-syne'>
-            <div className='relative h-[215px] flex justify-center items-center '>
-                <img src="/card_bg.svg" alt="" className="absolute top-0 z-[1] left-0 w-full h-full object-cover" />
-                <div className='w-[36px] h-[36px] relative z-[4]  rounded-full bg-[#7A5AF8] flex items-center justify-center'
-                    style={{
-                        background: 'linear-gradient(0deg, rgba(0, 0, 0, 0.20) 0%, rgba(0, 0, 0, 0.20) 100%), #FFF'
-                    }}
-                ><div className='w-[26px] h-[26px] rounded-full bg-white flex items-center justify-center'>
+    const [isWarningOpen, setIsWarningOpen] = useState(false);
+    const handleOpenWarning = () => {
+        trackEvent(MixpanelEvent.Templates_Build_Template_Clicked);
+        setIsWarningOpen(true);
+    };
+    const handleAgree = () => {
+        setIsWarningOpen(false);
+        router.push('/custom-template');
+    };
 
-                        <Plus className='w-4 h-4 text-[#A2A0A1]' />
+    return (
+        <>
+            <div
+                onClick={handleOpenWarning}
+                onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        handleOpenWarning();
+                    }
+                }}
+                role="button"
+                tabIndex={0}
+                className='w-full rounded-[22px] border border-[#EDEEEF] cursor-pointer font-syne'>
+                <div className='relative h-[215px] flex justify-center items-center '>
+                    <img src="/card_bg.svg" alt="" className="absolute top-0 z-[1] left-0 w-full h-full object-cover" />
+                    <div className='w-[36px] h-[36px] relative z-[4]  rounded-full bg-[#7A5AF8] flex items-center justify-center'
+                        style={{
+                            background: 'linear-gradient(0deg, rgba(0, 0, 0, 0.20) 0%, rgba(0, 0, 0, 0.20) 100%), #FFF'
+                        }}
+                    ><div className='w-[26px] h-[26px] rounded-full bg-white flex items-center justify-center'>
+
+                            <Plus className='w-4 h-4 text-[#A2A0A1]' />
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div className='px-5 py-4 bg-white flex items-center gap-4 overflow-hidden border-t  border-[#EDEEEF]'>
-                <div className='bg-[#7A5AF8] w-[45px] h-[45px] rounded-lg p-2 flex items-center justify-center'>
+                <div className='px-5 py-4 bg-white flex items-center gap-4 overflow-hidden border-t  border-[#EDEEEF]'>
+                    <div className='bg-[#7A5AF8] w-[45px] h-[45px] rounded-lg p-2 flex items-center justify-center'>
 
-                    <Sparkles className='w-6 h-6 text-white' />
-                </div>
-                <div>
-                    <h4 className='text-[#191919] text-sm font-semibold '>Build Template</h4>
-                    <p className='flex text-[#808080] text-sm  font-medium items-center gap-2'>Build Your Own Template</p>
-                </div>
+                        <Sparkles className='w-6 h-6 text-white' />
+                    </div>
+                    <div>
+                        <h4 className='text-[#191919] text-sm font-semibold '>Build Template</h4>
+                        <p className='flex text-[#808080] text-sm  font-medium items-center gap-2'>Build Your Own Template</p>
+                    </div>
 
+                </div>
             </div>
-        </div>
+            <Dialog open={isWarningOpen} onOpenChange={setIsWarningOpen}>
+                <DialogContent className="w-[calc(100vw-32px)] rounded-2xl border border-[#EDEEEF] bg-white p-0 font-syne shadow-2xl sm:max-w-[440px]">
+                    <DialogHeader className="items-center px-6 pb-2 pt-7 text-center">
+                        <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-[#EBE9FE]">
+                            <AlertTriangle className="h-6 w-6 text-[#7A5AF8]" aria-hidden="true" />
+                        </div>
+                        <DialogTitle className="text-lg font-semibold text-[#191919]">
+                            Vision model required
+                        </DialogTitle>
+                        <DialogDescription className="text-sm leading-6 text-[#667085]">
+                            Custom template generation sends each slide as an image. It only works reliably with vision-capable text models. Please confirm your selected model supports image input before continuing.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter className="flex-row gap-3 border-t border-[#F2F4F7] px-6 py-4 sm:justify-end sm:space-x-0">
+                        <button
+                            type="button"
+                            onClick={() => setIsWarningOpen(false)}
+                            className="h-10 rounded-lg border border-[#D0D5DD] bg-white px-4 text-sm font-medium text-[#344054] hover:bg-[#F9FAFB]"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleAgree}
+                            className="h-10 rounded-lg bg-[#7A5AF8] px-4 text-sm font-semibold text-white hover:bg-[#6941C6]"
+                        >
+                            I agree
+                        </button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
     )
 }
 

--- a/servers/nextjs/app/(presentation-generator)/custom-template/components/FileUploadSection.tsx
+++ b/servers/nextjs/app/(presentation-generator)/custom-template/components/FileUploadSection.tsx
@@ -221,16 +221,6 @@ export const FileUploadSection: React.FC<FileUploadSectionProps> = ({
           </li>
         </ul>
 
-        <div className="mt-4 px-4 py-3 rounded-lg border border-[#EBE9FE]  flex items-start gap-2 shadow-md">
-          <svg className="mt-0.5 shrink-0" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 20 20" fill="none">
-            <circle cx="10" cy="10" r="10" fill="#EBE9FE" />
-            <path d="M10 6V10M10 14H10.0088" stroke="#5B49A1" strokeWidth="1.5" strokeLinecap="round" />
-          </svg>
-          <p className="text-sm md:text-base font-medium text-[#20165C] tracking-[-0.13px]">
-            <span className="font-bold text-[#5B49A1]">Note:</span> Each slide is sent to your configured text model as a <span className="font-semibold">screenshot plus HTML reference</span>. Only <span className="font-semibold">vision-capable</span> models (image input) can use the layout faithfully. Text-only models may error or produce weak layouts; pick a vision model in Settings for your provider.
-          </p>
-        </div>
-
       </div>
     </div>
 


### PR DESCRIPTION
This pull request improves the user experience and accessibility when creating a custom template by adding a confirmation dialog that warns users about the requirement for a vision-capable model. It also removes a redundant note from the file upload section, consolidating the warning into the new dialog. The main changes are as follows:

**User Experience Improvements**
* Added a modal dialog in `CreateCustomTemplate.tsx` that appears when users attempt to create a custom template, warning them that a vision-capable model is required and asking for confirmation before proceeding. [[1]](diffhunk://#diff-1b9f38a373f5c4516ddab56ead34a624d144685ed56330d7e1010ee655e1fc2fL1-R37) [[2]](diffhunk://#diff-1b9f38a373f5c4516ddab56ead34a624d144685ed56330d7e1010ee655e1fc2fR63-R94)
* The dialog includes clear messaging, accessible keyboard navigation, and styled action buttons for "Cancel" and "I agree".

**Accessibility Enhancements**
* The custom template card is now keyboard-accessible, using `role="button"` and `tabIndex={0}` with support for "Enter" and "Space" key activation.

**Code Cleanup**
* Removed the previous static "Note" warning about vision models from the `FileUploadSection`, as this is now handled by the dialog.