### PR TITLE
Sudip/pre 510 keep current model selected in settings

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/outlines.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/outlines.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from constants.presentation import MAX_NUMBER_OF_SLIDES
 from models.presentation_outline_model import PresentationOutlineModel
 from models.sql.presentation import PresentationModel
 from models.sse_response import (
@@ -27,6 +28,7 @@ from utils.outline_utils import (
     get_no_of_outlines_to_generate_for_n_slides,
     get_presentation_title_from_presentation_outline,
 )
+from utils.outline_limits import normalize_outline_payload
 from utils.llm_calls.generate_presentation_outlines import (
     OutlineGenerationStatus,
     generate_ppt_outline,
@@ -207,7 +209,12 @@ async def stream_outlines(
             ).to_string()
             return
 
-        presentation_outlines = PresentationOutlineModel(**presentation_outlines_json)
+        presentation_outlines = PresentationOutlineModel(
+            **normalize_outline_payload(
+                presentation_outlines_json,
+                MAX_NUMBER_OF_SLIDES,
+            )
+        )
 
         if (
             n_slides_to_generate is not None

--- a/servers/fastapi/api/v1/ppt/endpoints/presentation.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/presentation.py
@@ -73,6 +73,7 @@ from utils.outline_utils import (
     get_presentation_outline_model_with_toc,
     get_presentation_title_from_presentation_outline,
 )
+from utils.outline_limits import normalize_outline_payload
 from utils.process_slides import (
     process_slide_add_placeholder_assets,
     process_slide_and_fetch_assets,
@@ -1376,6 +1377,11 @@ async def prepare_presentation(
 ):
     if not outlines:
         raise HTTPException(status_code=400, detail="Outlines are required")
+    if len(outlines) > MAX_NUMBER_OF_SLIDES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Number of outlines cannot be greater than {MAX_NUMBER_OF_SLIDES}",
+        )
 
     presentation = await sql_session.get(PresentationModel, presentation_id)
     if not presentation:
@@ -1712,6 +1718,16 @@ async def update_presentation(
 
     presentation_update_dict = {}
     if n_slides is not None:
+        if n_slides < 1:
+            raise HTTPException(
+                status_code=400,
+                detail="Number of slides must be greater than 0",
+            )
+        if n_slides > MAX_NUMBER_OF_SLIDES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Number of slides cannot be greater than {MAX_NUMBER_OF_SLIDES}",
+            )
         presentation_update_dict["n_slides"] = n_slides
     if title:
         presentation_update_dict["title"] = title
@@ -1721,6 +1737,11 @@ async def update_presentation(
     if presentation_update_dict:
         presentation.sqlmodel_update(presentation_update_dict)
     if slides:
+        if len(slides) > MAX_NUMBER_OF_SLIDES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Number of slides cannot be greater than {MAX_NUMBER_OF_SLIDES}",
+            )
         # Just to make sure id is UUID
         for slide in slides:
             slide.presentation = uuid.UUID(slide.presentation)
@@ -1780,6 +1801,15 @@ async def check_if_api_request_is_valid(
         )
 
     if (
+        request.slides_markdown is not None
+        and len(request.slides_markdown) > MAX_NUMBER_OF_SLIDES
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Number of slides cannot be greater than {MAX_NUMBER_OF_SLIDES}",
+        )
+
+    if (
         request.include_table_of_contents
         and request.n_slides is not None
         and request.n_slides < 3
@@ -1825,6 +1855,11 @@ async def generate_presentation_handler(
 
         if request.slides_markdown:
             using_slides_markdown = True
+            if len(request.slides_markdown) > MAX_NUMBER_OF_SLIDES:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Number of slides cannot be greater than {MAX_NUMBER_OF_SLIDES}",
+                )
             request.n_slides = len(request.slides_markdown)
 
         if not using_slides_markdown:
@@ -1914,7 +1949,10 @@ async def generate_presentation_handler(
                     detail="Failed to generate presentation outlines. Please try again.",
                 )
             presentation_outlines = PresentationOutlineModel(
-                **presentation_outlines_json
+                **normalize_outline_payload(
+                    presentation_outlines_json,
+                    MAX_NUMBER_OF_SLIDES,
+                )
             )
 
             if (

--- a/servers/fastapi/constants/presentation.py
+++ b/servers/fastapi/constants/presentation.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 
 MAX_NUMBER_OF_SLIDES = 50
+MAX_OUTLINE_CONTENT_WORDS = 500
 
 _PREFERRED_TEMPLATE_ORDER = [
     "general",

--- a/servers/fastapi/models/presentation_outline_model.py
+++ b/servers/fastapi/models/presentation_outline_model.py
@@ -1,13 +1,27 @@
 from typing import List
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
+
+from constants.presentation import MAX_NUMBER_OF_SLIDES, MAX_OUTLINE_CONTENT_WORDS
+from utils.outline_limits import normalize_outline_content
 
 
 class SlideOutlineModel(BaseModel):
-    content: str
+    content: str = Field(
+        ...,
+        description=f"Markdown content for the slide. Maximum {MAX_OUTLINE_CONTENT_WORDS} words.",
+    )
+
+    @field_validator("content", mode="before")
+    @classmethod
+    def limit_content_words(cls, value):
+        return normalize_outline_content(value)
 
 
 class PresentationOutlineModel(BaseModel):
-    slides: List[SlideOutlineModel]
+    slides: List[SlideOutlineModel] = Field(
+        description="List of slide outlines",
+        max_length=MAX_NUMBER_OF_SLIDES,
+    )
 
     def to_string(self):
         message = ""

--- a/servers/fastapi/services/chat/memory_layer.py
+++ b/servers/fastapi/services/chat/memory_layer.py
@@ -9,6 +9,7 @@ from jsonschema import Draft202012Validator
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from constants.presentation import MAX_NUMBER_OF_SLIDES
 from models.image_prompt import ImagePrompt
 from models.presentation_outline_model import PresentationOutlineModel, SlideOutlineModel
 from models.sql.image_asset import ImageAsset
@@ -28,6 +29,7 @@ from utils.asset_directory_utils import (
 )
 from utils.icon_weights import DEFAULT_ICON_WEIGHT
 from utils.outline_utils import get_presentation_title_from_presentation_outline
+from utils.outline_limits import normalize_outline_content
 from utils.process_slides import (
     process_old_and_new_slides_and_fetch_assets,
     process_slide_and_fetch_assets,
@@ -463,8 +465,15 @@ class PresentationChatMemoryLayer:
             }
 
         slides = self._normalize_outline_slides(presentation.outlines)
+        if len(slides) >= MAX_NUMBER_OF_SLIDES:
+            return {
+                "saved": False,
+                "message": f"Outline slide limit reached. You can have at most {MAX_NUMBER_OF_SLIDES} outlines.",
+                "slide_count": len(slides),
+                "max_slide_count": MAX_NUMBER_OF_SLIDES,
+            }
         insert_index = len(slides) if index is None else min(max(0, index), len(slides))
-        slides.insert(insert_index, {"content": content.strip()})
+        slides.insert(insert_index, {"content": normalize_outline_content(content.strip())})
         await self._save_outline_slides(presentation, slides)
 
         return {
@@ -493,7 +502,7 @@ class PresentationChatMemoryLayer:
                 "slide_count": len(slides),
             }
 
-        slides[target_index] = {"content": content.strip()}
+        slides[target_index] = {"content": normalize_outline_content(content.strip())}
         await self._save_outline_slides(presentation, slides)
 
         return {
@@ -636,6 +645,13 @@ class PresentationChatMemoryLayer:
             .order_by(SlideModel.index)
         )
         slides = list(slides_result)
+        if len(slides) >= MAX_NUMBER_OF_SLIDES:
+            return {
+                "added": False,
+                "message": f"Slide limit reached. You can have at most {MAX_NUMBER_OF_SLIDES} slides.",
+                "slide_count": len(slides),
+                "max_slide_count": MAX_NUMBER_OF_SLIDES,
+            }
         insert_index = (
             len(slides)
             if index is None
@@ -784,6 +800,14 @@ class PresentationChatMemoryLayer:
             .order_by(SlideModel.index)
         )
         slides = list(slides_result)
+        if len(slides) >= MAX_NUMBER_OF_SLIDES:
+            return {
+                "saved": False,
+                "message": f"Slide limit reached. You can have at most {MAX_NUMBER_OF_SLIDES} slides.",
+                "validation_errors": [],
+                "slide_count": len(slides),
+                "max_slide_count": MAX_NUMBER_OF_SLIDES,
+            }
 
         if slides:
             max_index = max(slide.index for slide in slides)
@@ -2576,7 +2600,7 @@ class PresentationChatMemoryLayer:
                 except Exception:
                     content = str(raw_content)
 
-            slides.append({"content": content})
+            slides.append({"content": normalize_outline_content(content)})
 
         return slides
 

--- a/servers/fastapi/services/chat/prompts.py
+++ b/servers/fastapi/services/chat/prompts.py
@@ -1,10 +1,13 @@
+from constants.presentation import MAX_NUMBER_OF_SLIDES, MAX_OUTLINE_CONTENT_WORDS
+
+
 def _trim_block(label: str, text: str) -> str:
     value = (text or "").strip()
     if not value:
         return ""
     return f"\n{label}\n{value}\n"
 
-CHAT_AI_ASSISTANT_SYSTEM_PROMPT = """
+CHAT_AI_ASSISTANT_SYSTEM_PROMPT = f"""
 You need to be a helpful slide AI assistant. Be concise, accurate, and action-oriented.
 Use the available tools to inspect and edit the current presentation.
 
@@ -80,6 +83,8 @@ Use the available tools to inspect and edit the current presentation.
 - For outline draft edits, use addOutline, updateOutline, and deleteOutline only.
 - Outline tools mutate presentation.outlines only.
 - Outline edits do not require layouts, assets, or rendered slide inspection unless the user also asks to edit slides.
+- Keep outline drafts to at most {MAX_NUMBER_OF_SLIDES} slides.
+- Keep each outline slide content to at most {MAX_OUTLINE_CONTENT_WORDS} words.
 
 # Common prompts:
 1. Fix the slide

--- a/servers/fastapi/services/chat/schemas.py
+++ b/servers/fastapi/services/chat/schemas.py
@@ -4,6 +4,8 @@ from typing import Any, Literal
 import dirtyjson  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from constants.presentation import MAX_OUTLINE_CONTENT_WORDS
+
 
 class StrictSchemaModel(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
@@ -34,7 +36,7 @@ class AddOutlineInput(OpenAIStrictSchemaModel):
         ...,
         min_length=1,
         max_length=20000,
-        description="Markdown content for the new outline slide.",
+        description=f"Markdown content for the new outline slide. Maximum {MAX_OUTLINE_CONTENT_WORDS} words.",
     )
     index: int | None = Field(
         ...,
@@ -49,7 +51,7 @@ class UpdateOutlineInput(StrictSchemaModel):
     content: str = Field(
         min_length=1,
         max_length=20000,
-        description="Replacement markdown content for this outline slide.",
+        description=f"Replacement markdown content for this outline slide. Maximum {MAX_OUTLINE_CONTENT_WORDS} words.",
     )
 
 

--- a/servers/fastapi/services/chat/tools.py
+++ b/servers/fastapi/services/chat/tools.py
@@ -6,6 +6,7 @@ from typing import Any, Awaitable, Callable, Literal
 import dirtyjson  # type: ignore[import-untyped]
 from llmai.shared import AssistantToolCall, Tool  # type: ignore[import-not-found]
 
+from constants.presentation import MAX_NUMBER_OF_SLIDES, MAX_OUTLINE_CONTENT_WORDS
 from services.chat.schemas import (
     AddElementInput,
     AddNewSlideInput,
@@ -75,7 +76,9 @@ class ChatTools:
                 name="addOutline",
                 description=(
                     "Insert a new markdown outline item into the outline draft. "
-                    "This edits presentation.outlines only and does not require a layout."
+                    "This edits presentation.outlines only and does not require a layout. "
+                    f"Do not exceed {MAX_NUMBER_OF_SLIDES} outline slides or "
+                    f"{MAX_OUTLINE_CONTENT_WORDS} words in this outline item."
                 ),
                 schema=AddOutlineInput,
                 strict=True,
@@ -84,7 +87,8 @@ class ChatTools:
                 name="updateOutline",
                 description=(
                     "Replace the markdown content of one outline item by zero-based index. "
-                    "This edits presentation.outlines only and does not require a layout."
+                    "This edits presentation.outlines only and does not require a layout. "
+                    f"Keep this outline item within {MAX_OUTLINE_CONTENT_WORDS} words."
                 ),
                 schema=UpdateOutlineInput,
                 strict=True,

--- a/servers/fastapi/tests/integration/test_presentation_generation_flow.py
+++ b/servers/fastapi/tests/integration/test_presentation_generation_flow.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import HTTPException
 
 from api.v1.ppt.endpoints import presentation as presentation_endpoint
+from constants.presentation import MAX_NUMBER_OF_SLIDES
 from models.generate_presentation_request import GeneratePresentationRequest
 from models.presentation_and_path import PresentationAndPath
 from models.presentation_outline_model import SlideOutlineModel
@@ -239,6 +240,64 @@ def test_prepare_presentation_clears_stale_language_for_reviewed_outlines():
         )
 
     assert response.language == ""
+
+
+def test_prepare_presentation_rejects_too_many_outlines():
+    presentation_id = uuid.uuid4()
+    presentation = PresentationModel(
+        id=presentation_id,
+        content="deck",
+        n_slides=MAX_NUMBER_OF_SLIDES,
+        language="English",
+        tone="default",
+        verbosity="standard",
+        instructions=None,
+    )
+    session = FakeAsyncSession(get_results={presentation_id: presentation})
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(
+            presentation_endpoint.prepare_presentation(
+                presentation_id=presentation_id,
+                outlines=[
+                    SlideOutlineModel(content=f"## Slide {index}")
+                    for index in range(MAX_NUMBER_OF_SLIDES + 1)
+                ],
+                layout=_mock_layout(),
+                sql_session=session,
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    assert (
+        exc_info.value.detail
+        == f"Number of outlines cannot be greater than {MAX_NUMBER_OF_SLIDES}"
+    )
+
+
+def test_check_api_request_rejects_too_many_slides_markdown(fake_async_session):
+    request = GeneratePresentationRequest(
+        content="",
+        slides_markdown=[
+            f"## Slide {index}" for index in range(MAX_NUMBER_OF_SLIDES + 1)
+        ],
+        export_as="pdf",
+        template="general",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(
+            presentation_endpoint.check_if_api_request_is_valid(
+                request=request,
+                sql_session=fake_async_session,
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    assert (
+        exc_info.value.detail
+        == f"Number of slides cannot be greater than {MAX_NUMBER_OF_SLIDES}"
+    )
 
 
 def test_prepare_presentation_accepts_template_v2_layout_id():

--- a/servers/fastapi/tests/unit/test_outline_utils.py
+++ b/servers/fastapi/tests/unit/test_outline_utils.py
@@ -1,6 +1,9 @@
 import pytest
+from pydantic import ValidationError
 
+from constants.presentation import MAX_NUMBER_OF_SLIDES, MAX_OUTLINE_CONTENT_WORDS
 from models.presentation_outline_model import PresentationOutlineModel, SlideOutlineModel
+from utils.outline_limits import count_outline_words
 from utils.outline_utils import (
     _extract_outline_title,
     get_images_for_slides_from_outline,
@@ -22,6 +25,28 @@ def test_get_presentation_title_handles_prefixed_page_heading():
 def test_get_presentation_title_for_empty_outline():
     outline = PresentationOutlineModel(slides=[])
     assert get_presentation_title_from_presentation_outline(outline) == "Untitled Presentation"
+
+
+def test_slide_outline_content_is_trimmed_to_word_limit():
+    content = " ".join(
+        f"word{i}" for i in range(MAX_OUTLINE_CONTENT_WORDS + 3)
+    )
+
+    slide = SlideOutlineModel(content=content)
+
+    assert count_outline_words(slide.content) == MAX_OUTLINE_CONTENT_WORDS
+    assert f"word{MAX_OUTLINE_CONTENT_WORDS - 1}" in slide.content
+    assert f"word{MAX_OUTLINE_CONTENT_WORDS}" not in slide.content
+
+
+def test_presentation_outline_rejects_more_than_max_slides():
+    with pytest.raises(ValidationError):
+        PresentationOutlineModel(
+            slides=[
+                SlideOutlineModel(content=f"## Slide {index}")
+                for index in range(MAX_NUMBER_OF_SLIDES + 1)
+            ]
+        )
 
 
 @pytest.mark.parametrize(

--- a/servers/fastapi/tests/unit/test_slide_ui_chat_tools.py
+++ b/servers/fastapi/tests/unit/test_slide_ui_chat_tools.py
@@ -5,10 +5,12 @@ from unittest.mock import AsyncMock, patch
 
 from llmai.shared import AssistantToolCall  # type: ignore[import-not-found]
 
+from constants.presentation import MAX_NUMBER_OF_SLIDES, MAX_OUTLINE_CONTENT_WORDS
 from models.sql.presentation import PresentationModel, PresentationVersion
 from models.sql.slide import SlideModel
 from services.chat.memory_layer import PresentationChatMemoryLayer
 from services.chat.tools import ChatTools
+from utils.outline_limits import count_outline_words
 
 
 def _run(coro):
@@ -935,3 +937,113 @@ def test_save_slide_for_template_v2_payload_persists_renderable_ui():
     title_element = saved_slide.ui["components"][0]["elements"][0]
     assert title_element["runs"][0]["text"] == "Thank You"
     assert title_element["text"] == "Thank You"
+
+
+def test_chat_add_outline_refuses_more_than_max_slides():
+    presentation_id = uuid.uuid4()
+    presentation = _template_v2_presentation(presentation_id)
+    presentation.outlines = {
+        "slides": [
+            {"content": f"## Slide {index}"}
+            for index in range(MAX_NUMBER_OF_SLIDES)
+        ]
+    }
+    session = _FakeSaveSlideSession(presentation)
+    memory = PresentationChatMemoryLayer(session, presentation_id)
+
+    result = _run(memory.add_outline(content="## Extra", index=None))
+
+    assert result["saved"] is False
+    assert result["slide_count"] == MAX_NUMBER_OF_SLIDES
+    assert result["max_slide_count"] == MAX_NUMBER_OF_SLIDES
+    assert session.commit_count == 0
+
+
+def test_chat_update_outline_trims_content_to_word_limit():
+    presentation_id = uuid.uuid4()
+    presentation = _template_v2_presentation(presentation_id)
+    presentation.outlines = {"slides": [{"content": "## Existing"}]}
+    session = _FakeSaveSlideSession(presentation)
+    memory = PresentationChatMemoryLayer(session, presentation_id)
+    content = " ".join(
+        f"word{i}" for i in range(MAX_OUTLINE_CONTENT_WORDS + 4)
+    )
+
+    with patch(
+        "services.chat.memory_layer.MEM0_PRESENTATION_MEMORY_SERVICE.store_generated_outlines",
+        new=AsyncMock(),
+    ):
+        result = _run(memory.update_outline(index=0, content=content))
+
+    assert result["saved"] is True
+    saved_content = presentation.outlines["slides"][0]["content"]
+    assert count_outline_words(saved_content) == MAX_OUTLINE_CONTENT_WORDS
+    assert f"word{MAX_OUTLINE_CONTENT_WORDS - 1}" in saved_content
+    assert f"word{MAX_OUTLINE_CONTENT_WORDS}" not in saved_content
+
+
+def test_chat_add_blank_slide_refuses_more_than_max_slides():
+    presentation_id = uuid.uuid4()
+    presentation = _template_v2_presentation(presentation_id)
+    session = _FakeSaveSlideSession(presentation)
+    session.slides = [
+        SlideModel(
+            presentation=presentation_id,
+            layout_group="template-v2",
+            layout="thanks",
+            index=index,
+            content={},
+            properties=None,
+            ui={},
+        )
+        for index in range(MAX_NUMBER_OF_SLIDES)
+    ]
+    memory = PresentationChatMemoryLayer(session, presentation_id)
+
+    result = _run(memory.add_blank_slide(index=None))
+
+    assert result["added"] is False
+    assert result["slide_count"] == MAX_NUMBER_OF_SLIDES
+    assert result["max_slide_count"] == MAX_NUMBER_OF_SLIDES
+    assert session.commit_count == 0
+
+
+def test_chat_save_slide_refuses_new_slide_at_max_slides():
+    presentation_id = uuid.uuid4()
+    presentation = _template_v2_presentation(presentation_id)
+    session = _FakeSaveSlideSession(presentation)
+    session.slides = [
+        SlideModel(
+            presentation=presentation_id,
+            layout_group="template-v2",
+            layout="thanks",
+            index=index,
+            content={},
+            properties=None,
+            ui={},
+        )
+        for index in range(MAX_NUMBER_OF_SLIDES)
+    ]
+    memory = PresentationChatMemoryLayer(session, presentation_id)
+
+    with patch.object(
+        memory,
+        "_get_presentation_icon_weight",
+        new=AsyncMock(return_value="regular"),
+    ), patch(
+        "services.chat.memory_layer.get_images_directory",
+        return_value="/tmp",
+    ):
+        result = _run(
+            memory.save_slide(
+                content={"hero": {"Title": "Extra"}},
+                layout_id="thanks",
+                index=MAX_NUMBER_OF_SLIDES,
+                replace_old_slide_at_index=False,
+            )
+        )
+
+    assert result["saved"] is False
+    assert result["slide_count"] == MAX_NUMBER_OF_SLIDES
+    assert result["max_slide_count"] == MAX_NUMBER_OF_SLIDES
+    assert session.commit_count == 0

--- a/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
+++ b/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
@@ -14,6 +14,7 @@ from llmai.shared import (
 )
 
 from models.presentation_outline_model import PresentationOutlineModel
+from constants.presentation import MAX_NUMBER_OF_SLIDES, MAX_OUTLINE_CONTENT_WORDS
 from utils.get_dynamic_models import get_presentation_outline_model_with_n_slides
 from utils.llm_calls.generate_web_search_query import generate_web_search_query
 from utils.llm_client_error_handler import handle_llm_client_exceptions
@@ -95,6 +96,8 @@ def get_system_prompt(
         "Generate flow based on user **content** and use **context** just for reference.\n"
         "Presentation title should be plain text, not markdown. It should be a concise title for the presentation.\n"
         "Each slide content should contain the content for that slide.\n"
+        f"Never generate more than {MAX_NUMBER_OF_SLIDES} slide outlines, even if the user asks for more. "
+        f"Each slide outline must be {MAX_OUTLINE_CONTENT_WORDS} words or fewer.\n"
         f"{verbosity_instruction}\n"
         "Follow user instructions strictly and literally without reinterpretation or generalization.\n"
         "Apply slide-specific instructions only to the exact slide mentioned and only once. "
@@ -141,7 +144,7 @@ def _resolve_prompt_language(language: Optional[str]) -> str:
 
 def _resolve_prompt_n_slides(n_slides: Optional[int]) -> str:
     if n_slides is None:
-        return "auto-detect"
+        return f"auto-detect, maximum {MAX_NUMBER_OF_SLIDES}"
     return str(n_slides)
 
 
@@ -161,6 +164,8 @@ def get_user_prompt(
     return (
         f"Content: {content or ''}\n"
         f"Number of Slides: {display_slides}\n"
+        f"Maximum Slide Outlines: {MAX_NUMBER_OF_SLIDES}\n"
+        f"Maximum Words Per Outline: {MAX_OUTLINE_CONTENT_WORDS}\n"
         f"Language: {display_language}\n"
         f"Tone: {tone or ''}\n"
         f"Today's Date: {datetime.now().strftime('%Y-%m-%d')}\n"

--- a/servers/fastapi/utils/outline_limits.py
+++ b/servers/fastapi/utils/outline_limits.py
@@ -1,0 +1,51 @@
+import re
+from typing import Any
+
+from constants.presentation import MAX_OUTLINE_CONTENT_WORDS
+
+
+OUTLINE_WORD_PATTERN = re.compile(r"\S+")
+
+
+def count_outline_words(text: str) -> int:
+    return len(OUTLINE_WORD_PATTERN.findall(text or ""))
+
+
+def trim_text_to_word_limit(
+    text: str,
+    max_words: int = MAX_OUTLINE_CONTENT_WORDS,
+) -> str:
+    if max_words <= 0:
+        return ""
+
+    matches = list(OUTLINE_WORD_PATTERN.finditer(text or ""))
+    if len(matches) <= max_words:
+        return text
+
+    return text[: matches[max_words - 1].end()].rstrip()
+
+
+def normalize_outline_content(value: Any) -> str:
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        value = str(value)
+    return trim_text_to_word_limit(value, MAX_OUTLINE_CONTENT_WORDS)
+
+
+def normalize_outline_payload(payload: dict[str, Any], max_slides: int) -> dict[str, Any]:
+    normalized = dict(payload)
+    raw_slides = normalized.get("slides")
+    if not isinstance(raw_slides, list):
+        return normalized
+
+    normalized["slides"] = [
+        {
+            **slide,
+            "content": normalize_outline_content(slide.get("content", "")),
+        }
+        if isinstance(slide, dict)
+        else {"content": normalize_outline_content(slide)}
+        for slide in raw_slides[:max_slides]
+    ]
+    return normalized

--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
@@ -161,17 +161,12 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
   const modelOptions = useMemo(() => {
     if (!currentModel) return availableModels;
 
-    const hasCurrentModel = availableModels.some(
-      (model) => model.value === currentModel
-    );
-    if (hasCurrentModel) return availableModels;
-
     return [
       {
         value: currentModel,
         label: currentModel,
       },
-      ...availableModels,
+      ...availableModels.filter((model) => model.value !== currentModel),
     ];
   }, [availableModels, currentModel]);
   const providerApiKeyLabel =
@@ -871,6 +866,12 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
                         <CommandList>
                           <CommandEmpty>No model found.</CommandEmpty>
                           <CommandGroup>
+                            {modelsLoading ? (
+                              <div className="flex items-center gap-2 px-3 py-2.5 text-sm text-gray-600">
+                                <Loader2 className="h-4 w-4 animate-spin text-gray-500" />
+                                Fetching models...
+                              </div>
+                            ) : null}
                             {modelOptions.map((model) => (
                               <CommandItem
                                 key={model.value}

--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/settings/TextProvider.tsx
@@ -158,6 +158,22 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
   const currentTogetherUrl = (llmConfig.TOGETHER_BASE_URL || "").trim();
   const currentOllamaUrl = llmConfig.OLLAMA_URL || "";
   const modelLabel = selectedProviderMeta?.label || selectedProvider;
+  const modelOptions = useMemo(() => {
+    if (!currentModel) return availableModels;
+
+    const hasCurrentModel = availableModels.some(
+      (model) => model.value === currentModel
+    );
+    if (hasCurrentModel) return availableModels;
+
+    return [
+      {
+        value: currentModel,
+        label: currentModel,
+      },
+      ...availableModels,
+    ];
+  }, [availableModels, currentModel]);
   const providerApiKeyLabel =
     selectedProvider === "custom"
       ? "Custom LLM API Key"
@@ -199,9 +215,6 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
 
     setAvailableModels([]);
     setModelsChecked(false);
-    if (currentModelField) {
-      onInputChange("", currentModelField);
-    }
   }, [
     selectedProvider,
     currentApiKey,
@@ -252,6 +265,7 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
   };
 
   const fetchAvailableModels = async () => {
+    if (modelsLoading) return;
     if (isManualModelProvider) return;
     if (selectedProvider === "openai" && !currentApiKey) return;
     if (selectedProvider === "deepseek" && !currentApiKey) return;
@@ -397,6 +411,13 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
       }
     } finally {
       setModelsLoading(false);
+    }
+  };
+
+  const handleModelSelectOpenChange = (isOpen: boolean) => {
+    setOpenModelSelect(isOpen);
+    if (isOpen) {
+      fetchAvailableModels();
     }
   };
 
@@ -760,6 +781,7 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
               {!isManualModelProvider &&
                 selectedProvider !== "codex" &&
                 selectedProvider !== "ollama" &&
+                !currentModel &&
                 (!modelsChecked ||
                   availableModels.length === 0) && (
                   <button
@@ -799,8 +821,7 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
           {!isManualModelProvider &&
           selectedProvider !== "codex" &&
           selectedProvider !== "ollama" &&
-          modelsChecked &&
-          availableModels.length > 0 ? (
+          (currentModel || (modelsChecked && modelOptions.length > 0)) ? (
             <div className="w-[262px]">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-3">
@@ -811,7 +832,7 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
                 <div className="w-full">
                   <Popover
                     open={openModelSelect}
-                    onOpenChange={setOpenModelSelect}
+                    onOpenChange={handleModelSelectOpenChange}
                   >
                     <PopoverTrigger asChild>
                       <Button
@@ -823,7 +844,7 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
                         <span className="text-sm truncate font-medium text-gray-900">
                           {(() => {
                             if (!currentModel) return "Select a model";
-                            const selectedModel = availableModels.find(
+                            const selectedModel = modelOptions.find(
                               (model) => model.value === currentModel
                             );
                             if (!selectedModel) return currentModel;
@@ -850,7 +871,7 @@ const TextProvider = ({ onInputChange, llmConfig }: OpenAIConfigProps) => {
                         <CommandList>
                           <CommandEmpty>No model found.</CommandEmpty>
                           <CommandGroup>
-                            {availableModels.map((model) => (
+                            {modelOptions.map((model) => (
                               <CommandItem
                                 key={model.value}
                                 value={model.value}

--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/templates/components/CreateCustomTemplate.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/templates/components/CreateCustomTemplate.tsx
@@ -2,95 +2,13 @@
 
 import { Plus, Sparkles } from 'lucide-react'
 import { useRouter } from 'next/navigation';
-import { useSelector } from 'react-redux';
-import { toast } from 'sonner';
 import { trackEvent, MixpanelEvent } from "@/utils/mixpanel";
-import type { RootState } from '@/store/store';
-import type { LLMConfig } from '@/types/llm_config';
-
-const NON_SOTA_TEMPLATE_TOAST_KEY = "presenton.nonSotaTemplateToastDismissed";
-const NON_SOTA_TEMPLATE_TOAST_ID = "non-sota-template-generation";
-
-const OPENAI_SOTA_VISION_MODELS = [
-    "gpt-5.5",
-    "gpt-5.5-pro",
-    "gpt-5.4",
-    "gpt-5.4-pro",
-    "gpt-5",
-    "gpt-5-pro",
-    "gpt-5-chat-latest",
-    "gpt-4.1",
-    "gpt-4o",
-    "gpt-4-turbo",
-];
-
-function selectedTextModel(config: LLMConfig): string {
-    switch (config.LLM) {
-        case "openai":
-            return config.OPENAI_MODEL || "";
-        case "azure":
-            return config.AZURE_OPENAI_MODEL || "";
-        case "openrouter":
-            return config.OPENROUTER_MODEL || "";
-        case "anthropic":
-            return config.ANTHROPIC_MODEL || "";
-        case "bedrock":
-            return config.BEDROCK_MODEL || "";
-        case "codex":
-            return config.CODEX_MODEL || "";
-        default:
-            return "";
-    }
-}
-
-function normalizeModelName(model: string): string {
-    return model.trim().toLowerCase().split("/").pop()?.replace(/^.*anthropic\./, "") || "";
-}
-
-function matchesOpenAIModel(model: string, family: string): boolean {
-    return model === family || model.startsWith(`${family}-20`);
-}
-
-function isSotaTemplateModel(config: LLMConfig): boolean {
-    const model = normalizeModelName(selectedTextModel(config));
-
-    if (!model) return false;
-    if (OPENAI_SOTA_VISION_MODELS.some((family) => matchesOpenAIModel(model, family))) return true;
-    return model.includes("claude-") && (model.includes("opus") || model.includes("sonnet"));
-}
-
-function hasDismissedNonSotaToast(): boolean {
-    try {
-        return typeof window !== "undefined" && window.localStorage.getItem(NON_SOTA_TEMPLATE_TOAST_KEY) === "1";
-    } catch {
-        return false;
-    }
-}
-
-function rememberNonSotaToastDismissed() {
-    try {
-        window.localStorage.setItem(NON_SOTA_TEMPLATE_TOAST_KEY, "1");
-    } catch {
-        // Best effort only.
-    }
-}
 
 const CreateCustomTemplate = () => {
     const router = useRouter();
-    const llmConfig = useSelector((state: RootState) => state.userConfig.llm_config);
 
     const handleOpenTemplateBuilder = () => {
         trackEvent(MixpanelEvent.Templates_Build_Template_Clicked);
-
-        if (!isSotaTemplateModel(llmConfig) && !hasDismissedNonSotaToast()) {
-            toast.info("Template quality may vary", {
-                id: NON_SOTA_TEMPLATE_TOAST_ID,
-                description: "For best results, use a recent OpenAI vision model or Claude Opus/Sonnet.",
-                onDismiss: rememberNonSotaToastDismissed,
-                onAutoClose: rememberNonSotaToastDismissed,
-            });
-        }
-
         router.push('/custom-template');
     };
 

--- a/servers/nextjs/app/(presentation-generator)/components/NewSlide.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/NewSlide.tsx
@@ -23,6 +23,7 @@ import {
   BLANK_SLIDE_LAYOUT_ID,
   BLANK_TEMPLATE_V2_LAYOUT,
 } from "../_shared/blank-slide";
+import { MAX_NUMBER_OF_SLIDES } from "@/utils/presentationLimits";
 
 interface LayoutItemProps {
   layout: any;
@@ -164,6 +165,10 @@ const NewSlideV1 = ({
   const presentationLayout = useSelector(
     (state: RootState) => state.presentationGeneration.presentationData?.layout
   );
+  const slideCount = useSelector((state: RootState) => {
+    const slides = state.presentationGeneration.presentationData?.slides;
+    return Array.isArray(slides) ? slides.length : 0;
+  });
   const [layouts, setLayouts] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -181,6 +186,14 @@ const NewSlideV1 = ({
 
   const handleNewSlide = useCallback(
     (sampleData: any, id: string) => {
+      if (slideCount >= MAX_NUMBER_OF_SLIDES) {
+        notify.warning(
+          "Slide limit reached",
+          `You can have up to ${MAX_NUMBER_OF_SLIDES} slides.`
+        );
+        return;
+      }
+
       try {
         const newSlide = {
           id: uuidv4(),
@@ -206,6 +219,7 @@ const NewSlideV1 = ({
       setShowNewSlideSelection,
       isCustomTemplate,
       isTemplateV2,
+      slideCount,
     ]
   );
 

--- a/servers/nextjs/app/(presentation-generator)/custom-template/CustomTemplatePage.tsx
+++ b/servers/nextjs/app/(presentation-generator)/custom-template/CustomTemplatePage.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useCallback, useReducer, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, Download, Loader2, RefreshCw, Wrench, X } from "lucide-react";
 import { toast } from "sonner";
+import { useSelector } from "react-redux";
 
 
 
@@ -28,6 +29,11 @@ import { validateLayoutCodeForClient } from "./utils/layoutCodeValidation";
 import { useFontLoader as loadFontAssets } from "../hooks/useFontLoad";
 import Header from "@/app/(presentation-generator)/(dashboard)/dashboard/components/Header";
 import { normalizeBackendAssetUrls } from "@/utils/api";
+import type { RootState } from "@/store/store";
+import {
+    dismissTemplateV2ModelWarning,
+    showTemplateV2ModelWarningIfNeeded,
+} from "./utils/templateModelWarning";
 
 type LibreOfficeGateState = "checking" | "ready" | "missing" | "installing" | "error";
 type LibreOfficeGateSnapshot = {
@@ -408,6 +414,7 @@ const CustomTemplatePage = ({
     useTemplateV2Generation = false,
 }: CustomTemplatePageProps) => {
     const router = useRouter();
+    const llmConfig = useSelector((state: RootState) => state.userConfig.llm_config);
 
     const [schemaEditorSlideIndex, setSchemaEditorSlideIndex] = useState<number | null>(null);
     const [schemaPreviewData, setSchemaPreviewData] = useState<Record<number, Record<string, any>>>({});
@@ -447,6 +454,16 @@ const CustomTemplatePage = ({
         saveLayout,
     } = useLayoutSaving(slides);
 
+
+    useEffect(() => {
+        if (useTemplateV2Generation) {
+            showTemplateV2ModelWarningIfNeeded(llmConfig);
+        }
+
+        return () => {
+            dismissTemplateV2ModelWarning();
+        };
+    }, [llmConfig, useTemplateV2Generation]);
 
     useEffect(() => {
         const existingScript = document.querySelector('script[src*="tailwindcss.com"]');

--- a/servers/nextjs/app/(presentation-generator)/custom-template/utils/templateModelWarning.ts
+++ b/servers/nextjs/app/(presentation-generator)/custom-template/utils/templateModelWarning.ts
@@ -1,0 +1,94 @@
+import { notify } from "@/components/ui/sonner";
+import type { LLMConfig } from "@/types/llm_config";
+
+const NON_SOTA_TEMPLATE_TOAST_KEY = "presenton.nonSotaTemplateToastDismissed";
+const NON_SOTA_TEMPLATE_TOAST_ID = "non-sota-template-generation";
+
+const OPENAI_SOTA_VISION_MODELS = [
+    "gpt-5.5",
+    "gpt-5.5-pro",
+    "gpt-5.4",
+    "gpt-5.4-pro",
+    "gpt-5",
+    "gpt-5-pro",
+    "gpt-5-chat-latest",
+    "gpt-4.1",
+    "gpt-4o",
+    "gpt-4-turbo",
+];
+
+function selectedTextModel(config: LLMConfig): string {
+    switch (config.LLM) {
+        case "openai":
+            return config.OPENAI_MODEL || "";
+        case "azure":
+            return config.AZURE_OPENAI_MODEL || "";
+        case "openrouter":
+            return config.OPENROUTER_MODEL || "";
+        case "anthropic":
+            return config.ANTHROPIC_MODEL || "";
+        case "bedrock":
+            return config.BEDROCK_MODEL || "";
+        case "codex":
+            return config.CODEX_MODEL || "";
+        default:
+            return "";
+    }
+}
+
+function normalizeModelName(model: string): string {
+    return model.trim().toLowerCase().split("/").pop()?.replace(/^.*anthropic\./, "") || "";
+}
+
+function matchesOpenAIModel(model: string, family: string): boolean {
+    return model === family || model.startsWith(`${family}-20`);
+}
+
+function isSotaTemplateModel(config: LLMConfig): boolean {
+    const model = normalizeModelName(selectedTextModel(config));
+
+    if (!model) return false;
+    if (OPENAI_SOTA_VISION_MODELS.some((family) => matchesOpenAIModel(model, family))) return true;
+    return model.includes("claude-") && (model.includes("opus") || model.includes("sonnet"));
+}
+
+function hasDismissedNonSotaToast(): boolean {
+    try {
+        return typeof window !== "undefined" && window.localStorage.getItem(NON_SOTA_TEMPLATE_TOAST_KEY) === "1";
+    } catch {
+        return false;
+    }
+}
+
+function rememberNonSotaToastDismissed() {
+    try {
+        window.localStorage.setItem(NON_SOTA_TEMPLATE_TOAST_KEY, "1");
+    } catch {
+        // Best effort only.
+    }
+}
+
+export function showTemplateV2ModelWarningIfNeeded(config: LLMConfig) {
+    if (isSotaTemplateModel(config) || hasDismissedNonSotaToast()) return;
+
+    notify.warning(
+        "Template model warning",
+        "Template V2 works best with vision-capable models. Use a recent OpenAI vision model or Claude Opus/Sonnet for reliable template generation.",
+        {
+            id: NON_SOTA_TEMPLATE_TOAST_ID,
+            duration: Infinity,
+            className: "template-v2-model-warning-toast",
+            action: {
+                label: "Don't show again",
+                onClick: () => {
+                    rememberNonSotaToastDismissed();
+                    dismissTemplateV2ModelWarning();
+                },
+            },
+        }
+    );
+}
+
+export function dismissTemplateV2ModelWarning() {
+    notify.dismiss(NON_SOTA_TEMPLATE_TOAST_ID);
+}

--- a/servers/nextjs/app/(presentation-generator)/documents-preview/components/DocumentPreviewPage.tsx
+++ b/servers/nextjs/app/(presentation-generator)/documents-preview/components/DocumentPreviewPage.tsx
@@ -28,6 +28,7 @@ import { ChevronRight, PanelRightOpen, X } from "lucide-react";
 import ToolTip from "@/components/ToolTip";
 import Header from "@/app/(presentation-generator)/(dashboard)/dashboard/components/Header";
 import { trackEvent, MixpanelEvent } from "@/utils/mixpanel";
+import { parseLimitedSlideCount } from "@/utils/presentationLimits";
 
 // Types
 interface LoadingState {
@@ -154,7 +155,7 @@ const DocumentsPreviewPage: React.FC = () => {
         {
           content: config?.prompt ?? "",
           version: "v1-standard",
-          n_slides: config?.slides ? parseInt(config.slides) : null,
+          n_slides: parseLimitedSlideCount(config?.slides),
           file_paths: documentPaths,
           language: config?.language ?? "",
           tone: config?.tone,

--- a/servers/nextjs/app/(presentation-generator)/outline/components/OutlineContent.tsx
+++ b/servers/nextjs/app/(presentation-generator)/outline/components/OutlineContent.tsx
@@ -16,6 +16,8 @@ import {
 import { OutlineItem } from "./OutlineItem";
 import { Button } from "@/components/ui/button";
 import { FileText, Loader2 } from "lucide-react";
+import { MAX_NUMBER_OF_SLIDES } from "@/utils/presentationLimits";
+import { cn } from "@/lib/utils";
 
 interface OutlineContentProps {
   outlines: { content: string }[] | null;
@@ -38,6 +40,8 @@ const OutlineContent: React.FC<OutlineContentProps> = ({
   onDragEnd,
   onAddSlide,
 }) => {
+  const hasReachedSlideLimit =
+    (outlines?.length ?? 0) >= MAX_NUMBER_OF_SLIDES;
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
@@ -111,12 +115,25 @@ const OutlineContent: React.FC<OutlineContentProps> = ({
           <Button
             variant="outline"
             onClick={() => {
+              if (hasReachedSlideLimit) return;
               onAddSlide();
             }}
-            disabled={isLoading || isStreaming}
-            className="w-full my-4 text-blue-600 border-blue-200"
+            disabled={isLoading || isStreaming || hasReachedSlideLimit}
+            aria-disabled={isLoading || isStreaming || hasReachedSlideLimit}
+            title={
+              hasReachedSlideLimit
+                ? `Maximum ${MAX_NUMBER_OF_SLIDES} slides`
+                : undefined
+            }
+            className={cn(
+              "w-full my-4 text-blue-600 border-blue-200",
+              hasReachedSlideLimit &&
+                "cursor-not-allowed border-gray-200 text-gray-400 opacity-60 hover:bg-white hover:text-gray-400"
+            )}
           >
-            + Add Slide
+            {hasReachedSlideLimit
+              ? `Maximum ${MAX_NUMBER_OF_SLIDES} slides reached`
+              : "+ Add Slide"}
           </Button>
         </div>
       )}

--- a/servers/nextjs/app/(presentation-generator)/outline/components/OutlineItem.tsx
+++ b/servers/nextjs/app/(presentation-generator)/outline/components/OutlineItem.tsx
@@ -18,6 +18,7 @@ import {
   type ChangeEvent,
 } from "react";
 import { marked } from "marked";
+import { trimTextToWordLimit } from "@/utils/presentationLimits";
 
 interface OutlineItemProps {
   sortableId: string;
@@ -58,10 +59,11 @@ export function OutlineItem({
 
   const handleSlideChange = (newOutline: any) => {
     if (isStreaming) return;
+    const limitedOutline = trimTextToWordLimit(String(newOutline ?? ""));
     const newData = outlines?.map((each: any, idx: any) => {
       if (idx === index - 1) {
         return {
-          content: newOutline,
+          content: limitedOutline,
         };
       }
       return each;

--- a/servers/nextjs/app/(presentation-generator)/outline/components/OutlinePage.tsx
+++ b/servers/nextjs/app/(presentation-generator)/outline/components/OutlinePage.tsx
@@ -25,6 +25,11 @@ import { setPptGenUploadState } from "@/store/slices/presentationGenUpload";
 import { LanguageType, PresentationConfig, ToneType, VerbosityType } from "../../upload/type";
 import { PresentationGenerationApi } from "../../services/api/presentation-generation";
 import { toast } from "sonner";
+import {
+  clampSlideCountValue,
+  limitOutlines,
+  parseLimitedSlideCount,
+} from "@/utils/presentationLimits";
 
 const DEFAULT_OUTLINE_CONFIG: PresentationConfig = {
   slides: null,
@@ -37,6 +42,13 @@ const DEFAULT_OUTLINE_CONFIG: PresentationConfig = {
   includeTitleSlide: false,
   webSearch: false,
 };
+
+const normalizeOutlineConfig = (
+  config: PresentationConfig
+): PresentationConfig => ({
+  ...config,
+  slides: config.slides ? clampSlideCountValue(config.slides) || null : null,
+});
 
 const getDocumentPaths = (files: unknown): string[] => {
   if (!Array.isArray(files)) {
@@ -59,7 +71,7 @@ const getOutlinesFromResponse = (outline: any): { content: string }[] => {
     return [];
   }
 
-  return slides.map((slide) => {
+  return limitOutlines(slides.map((slide) => {
     const content = slide?.content;
     if (typeof content === "string") {
       return { content };
@@ -68,7 +80,7 @@ const getOutlinesFromResponse = (outline: any): { content: string }[] => {
       return { content: "" };
     }
     return { content: String(content) };
-  });
+  }));
 };
 
 interface OutlinePageProps {
@@ -89,7 +101,7 @@ const OutlinePage: React.FC<OutlinePageProps> = ({
   const [activeTab, setActiveTab] = useState<string>(TABS.LAYOUTS);
   const [selectedTemplate, setSelectedTemplate] = useState<TemplateLayoutsWithSettings | string | null>(null);
   const [draftConfig, setDraftConfig] = useState<PresentationConfig>(
-    savedConfig ?? DEFAULT_OUTLINE_CONFIG
+    savedConfig ? normalizeOutlineConfig(savedConfig) : DEFAULT_OUTLINE_CONFIG
   );
   const [isRegeneratingOutline, setIsRegeneratingOutline] = useState(false);
   const [hasOutlineStreamFinished, setHasOutlineStreamFinished] =
@@ -125,7 +137,7 @@ const OutlinePage: React.FC<OutlinePageProps> = ({
 
   useEffect(() => {
     if (savedConfig) {
-      setDraftConfig(savedConfig);
+      setDraftConfig(normalizeOutlineConfig(savedConfig));
     }
   }, [savedConfig]);
 
@@ -164,9 +176,13 @@ const OutlinePage: React.FC<OutlinePageProps> = ({
   };
 
   const handleConfigChange = (key: keyof PresentationConfig, value: unknown) => {
+    const nextValue =
+      key === "slides" && typeof value === "string"
+        ? clampSlideCountValue(value)
+        : value;
     setDraftConfig((previous) => ({
       ...previous,
-      [key]: value,
+      [key]: nextValue,
     }));
   };
 
@@ -212,7 +228,7 @@ const OutlinePage: React.FC<OutlinePageProps> = ({
     try {
       const createResponse = await PresentationGenerationApi.createPresentation({
         content: draftConfig.prompt ?? "",
-        n_slides: draftConfig.slides ? parseInt(draftConfig.slides, 10) : null,
+        n_slides: parseLimitedSlideCount(draftConfig.slides),
         file_paths: documentPaths,
         language: draftConfig.language ?? "",
         tone: draftConfig.tone,

--- a/servers/nextjs/app/(presentation-generator)/outline/hooks/useOutlineManagement.ts
+++ b/servers/nextjs/app/(presentation-generator)/outline/hooks/useOutlineManagement.ts
@@ -2,6 +2,8 @@ import { useCallback } from "react";
 import { useDispatch } from "react-redux";
 import { arrayMove } from "@dnd-kit/sortable";
 import { setOutlines } from "@/store/slices/presentationGeneration";
+import { notify } from "@/components/ui/sonner";
+import { MAX_NUMBER_OF_SLIDES } from "@/utils/presentationLimits";
 
 export const useOutlineManagement = (outlines: { content: string }[] | null) => {
   const dispatch = useDispatch();
@@ -25,10 +27,17 @@ export const useOutlineManagement = (outlines: { content: string }[] | null) => 
 
   const handleAddSlide = useCallback(() => {
     if (!outlines) return;
+    if (outlines.length >= MAX_NUMBER_OF_SLIDES) {
+      notify.warning(
+        "Slide limit reached",
+        `You can have up to ${MAX_NUMBER_OF_SLIDES} outline slides.`
+      );
+      return;
+    }
 
     const updatedOutlines = [...outlines, { content: "Outline title" }];
     dispatch(setOutlines(updatedOutlines));
   }, [outlines, dispatch]);
 
   return { handleDragEnd, handleAddSlide };
-}; 
+};

--- a/servers/nextjs/app/(presentation-generator)/outline/hooks/useOutlineStreaming.ts
+++ b/servers/nextjs/app/(presentation-generator)/outline/hooks/useOutlineStreaming.ts
@@ -5,6 +5,7 @@ import { setOutlines } from "@/store/slices/presentationGeneration";
 import { jsonrepair } from "jsonrepair";
 import { RootState } from "@/store/store";
 import { getApiUrl } from "@/utils/api";
+import { limitOutlines } from "@/utils/presentationLimits";
 
 const MAX_STREAM_RETRIES = 3;
 const STREAM_RETRY_DELAY_MS = 1_000;
@@ -133,7 +134,7 @@ export const useOutlineStreaming = (
 
               if (partialData.slides) {
                 const nextSlides: { content: string }[] =
-                  partialData.slides || [];
+                  limitOutlines(partialData.slides || []);
                 try {
                   const prev = prevSlidesRef.current || [];
                   let changedIndex: number | null = null;
@@ -171,7 +172,7 @@ export const useOutlineStreaming = (
           case "complete":
             try {
               const outlinesData: { content: string }[] =
-                data.presentation.outlines.slides;
+                limitOutlines(data.presentation.outlines.slides);
               dispatch(setOutlines(outlinesData));
               setIsStreaming(false);
               setIsLoading(false);

--- a/servers/nextjs/app/(presentation-generator)/outline/hooks/usePresentationGeneration.ts
+++ b/servers/nextjs/app/(presentation-generator)/outline/hooks/usePresentationGeneration.ts
@@ -9,6 +9,10 @@ import { TemplateLayoutsWithSettings } from "@/app/presentation-templates/utils"
 import { getCustomTemplateDetails } from "@/app/hooks/useCustomTemplates";
 import { MixpanelEvent, trackEvent } from "@/utils/mixpanel";
 import { parseTemplateV2SelectionId } from "../utils/templateSelection";
+import {
+  limitOutlines,
+  MAX_NUMBER_OF_SLIDES,
+} from "@/utils/presentationLimits";
 
 const DEFAULT_LOADING_STATE: LoadingState = {
   message: "",
@@ -47,6 +51,14 @@ export const usePresentationGeneration = (
       return false;
     }
 
+    if (outlines.length > MAX_NUMBER_OF_SLIDES) {
+      notify.warning(
+        "Slide limit reached",
+        `Use ${MAX_NUMBER_OF_SLIDES} or fewer outline slides before generating.`
+      );
+      return false;
+    }
+
     return true;
   }, [outlines, selectedTemplate]);
 
@@ -77,6 +89,7 @@ export const usePresentationGeneration = (
       return;
     }
     if (!validateInputs()) return;
+    const preparedOutlines = limitOutlines(outlines);
 
     const selectedTemplateId =
       typeof selectedTemplate === "string"
@@ -104,7 +117,7 @@ export const usePresentationGeneration = (
     trackEvent(MixpanelEvent.Outline_Presentation_Generation_Started, {
       pathname,
       presentation_id: presentationId,
-      outline_count: outlines?.length || 0,
+      outline_count: preparedOutlines.length,
       template_id: selectedTemplateId,
       template_type: selectedTemplateType,
       template_name: selectedTemplateName,
@@ -129,7 +142,7 @@ export const usePresentationGeneration = (
 
         const response = await PresentationGenerationApi.presentationPrepare({
           presentation_id: presentationId,
-          outlines: outlines,
+          outlines: preparedOutlines,
           layout: selectedTemplateV2Id,
         });
 
@@ -208,7 +221,7 @@ export const usePresentationGeneration = (
 
       const response = await PresentationGenerationApi.presentationPrepare({
         presentation_id: presentationId,
-        outlines: outlines,
+        outlines: preparedOutlines,
         layout: layout,
       });
 

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/Chat.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/Chat.tsx
@@ -46,6 +46,10 @@ import type {
 import ToolTip from "@/components/ToolTip";
 import { cn } from "@/lib/utils";
 import type { TemplateV2SurfaceSelectedDetail } from "@/components/slide-editor/events/events";
+import {
+  MAX_NUMBER_OF_SLIDES,
+  MAX_OUTLINE_CONTENT_WORDS,
+} from "@/utils/presentationLimits";
 
 const suggestions: { id: string; icon: ReactNode; suggestion: string }[] = [
   {
@@ -1063,7 +1067,7 @@ const Chat = ({
 
     if (variant === "outline") {
       contextLines.push(
-        "UI context: the user is editing the outline draft. Use addOutline, updateOutline, and deleteOutline for outline edits."
+        `UI context: the user is editing the outline draft. Use addOutline, updateOutline, and deleteOutline for outline edits. Keep at most ${MAX_NUMBER_OF_SLIDES} outline slides, and keep each outline content within ${MAX_OUTLINE_CONTENT_WORDS} words.`
       );
     }
     if (variant === "template-v2") {

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/NewSlide.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/NewSlide.tsx
@@ -25,6 +25,7 @@ import {
   BLANK_SLIDE_LAYOUT_ID,
   BLANK_TEMPLATE_V2_LAYOUT,
 } from "../../_shared/blank-slide";
+import { MAX_NUMBER_OF_SLIDES } from "@/utils/presentationLimits";
 
 interface LayoutItemProps {
   layout: any;
@@ -175,6 +176,10 @@ const NewSlideV1 = ({
   const presentationLayout = useSelector(
     (state: RootState) => state.presentationGeneration.presentationData?.layout
   );
+  const slideCount = useSelector((state: RootState) => {
+    const slides = state.presentationGeneration.presentationData?.slides;
+    return Array.isArray(slides) ? slides.length : 0;
+  });
   const [layouts, setLayouts] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -192,6 +197,14 @@ const NewSlideV1 = ({
 
   const handleNewSlide = useCallback(
     (sampleData: any, id: string) => {
+      if (slideCount >= MAX_NUMBER_OF_SLIDES) {
+        notify.warning(
+          "Slide limit reached",
+          `You can have up to ${MAX_NUMBER_OF_SLIDES} slides.`
+        );
+        return;
+      }
+
       try {
         const slideId = uuidv4();
         const newSlide = {
@@ -239,6 +252,7 @@ const NewSlideV1 = ({
       isTemplateV2,
       pathname,
       onSlideAdded,
+      slideCount,
     ]
   );
 

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/SlideActionBar.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/SlideActionBar.tsx
@@ -36,6 +36,7 @@ import {
   BLANK_TEMPLATE_V2_LAYOUT,
 } from "../../_shared/blank-slide";
 import NewSlide from "./NewSlide";
+import { MAX_NUMBER_OF_SLIDES } from "@/utils/presentationLimits";
 
 interface SlideActionBarProps {
   slide: any;
@@ -90,6 +91,7 @@ const SlideActionBar = ({
     ? presentationData.slides
     : [];
   const slideCount = slides.length;
+  const hasReachedSlideLimit = slideCount >= MAX_NUMBER_OF_SLIDES;
   const currentIndex =
     typeof slide?.index === "number" ? slide.index : selectedSlide;
   const slideLayout = typeof slide?.layout === "string" ? slide.layout : "";
@@ -114,7 +116,19 @@ const SlideActionBar = ({
     );
   };
 
+  const notifySlideLimitReached = () => {
+    notify.warning(
+      "Slide limit reached",
+      `You can have up to ${MAX_NUMBER_OF_SLIDES} slides.`
+    );
+  };
+
   const handleBlankSlide = () => {
+    if (hasReachedSlideLimit) {
+      notifySlideLimitReached();
+      return;
+    }
+
     if (!templateId) {
       notify.error(
         "Could not add blank slide",
@@ -163,6 +177,11 @@ const SlideActionBar = ({
   };
 
   const handleDuplicateSlide = () => {
+    if (hasReachedSlideLimit) {
+      notifySlideLimitReached();
+      return;
+    }
+
     rememberSlides("DUPLICATE_SLIDE");
     dispatch(
       duplicatePresentationSlide({
@@ -224,6 +243,11 @@ const SlideActionBar = ({
   };
 
   const openTemplatePicker = () => {
+    if (hasReachedSlideLimit) {
+      notifySlideLimitReached();
+      return;
+    }
+
     if (!templateId) {
       notify.error(
         "Could not open templates",
@@ -276,7 +300,11 @@ const SlideActionBar = ({
           <button
             type="button"
             onClick={handleBlankSlide}
-            className="flex h-8 shrink-0 items-center gap-2 rounded-[6px] px-2 text-sm font-normal leading-none text-[#111324] transition-colors hover:bg-[#F7F6F9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5141e5]"
+            disabled={hasReachedSlideLimit}
+            className={cn(
+              "flex h-8 shrink-0 items-center gap-2 rounded-[6px] px-2 text-sm font-normal leading-none text-[#111324] transition-colors hover:bg-[#F7F6F9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5141e5]",
+              hasReachedSlideLimit && "cursor-not-allowed opacity-50"
+            )}
           >
             <span>Blank</span>
             <Plus className="h-4 w-4" strokeWidth={2.4} />
@@ -287,7 +315,11 @@ const SlideActionBar = ({
           <button
             type="button"
             onClick={openTemplatePicker}
-            className="flex h-8 shrink-0 items-center gap-2 rounded-[6px] px-2 text-sm font-normal leading-none text-[#111324] transition-colors hover:bg-[#F7F6F9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5141e5]"
+            disabled={hasReachedSlideLimit}
+            className={cn(
+              "flex h-8 shrink-0 items-center gap-2 rounded-[6px] px-2 text-sm font-normal leading-none text-[#111324] transition-colors hover:bg-[#F7F6F9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5141e5]",
+              hasReachedSlideLimit && "cursor-not-allowed opacity-50"
+            )}
           >
             <span>Use Template</span>
             <Plus className="h-4 w-4" strokeWidth={2.4} />
@@ -360,6 +392,7 @@ const SlideActionBar = ({
                 className="z-[90] w-[188px] overflow-hidden rounded-[10px] border border-[#E6E6EC] bg-white py-2 font-syne shadow-[0_8px_24px_rgba(17,24,39,0.14)]"
               >
                 <DropdownMenu.Item
+                  disabled={hasReachedSlideLimit}
                   className={menuItemClass}
                   onSelect={handleDuplicateSlide}
                 >

--- a/servers/nextjs/app/(presentation-generator)/services/api/presentation-generation.ts
+++ b/servers/nextjs/app/(presentation-generator)/services/api/presentation-generation.ts
@@ -2,6 +2,10 @@ import { getHeader, getHeaderForFormData } from "./header";
 import { IconSearch, ImageGenerate, ImageSearch, PreviousGeneratedImagesResponse } from "./params";
 import { ApiResponseHandler } from "./api-error-handler";
 import { getApiUrl, resolveBackendAssetUrl } from "@/utils/api";
+import {
+  limitOutlines,
+  MAX_NUMBER_OF_SLIDES,
+} from "@/utils/presentationLimits";
 
 export class PresentationGenerationApi {
   static async uploadDoc(documents: File[]) {
@@ -81,6 +85,10 @@ export class PresentationGenerationApi {
     web_search?: boolean;
   }) {
     try {
+      const limitedSlideCount =
+        typeof n_slides === "number"
+          ? Math.min(Math.max(n_slides, 1), MAX_NUMBER_OF_SLIDES)
+          : null;
       const response = await fetch(
         getApiUrl(`/api/v1/ppt/presentation/create`),
         {
@@ -89,7 +97,7 @@ export class PresentationGenerationApi {
           body: JSON.stringify({
             content,
             version,
-            n_slides,
+            n_slides: limitedSlideCount,
             file_paths,
             language,
             tone,
@@ -156,12 +164,19 @@ export class PresentationGenerationApi {
 
   static async presentationPrepare(presentationData: any) {
     try {
+      const body =
+        Array.isArray(presentationData?.outlines)
+          ? {
+              ...presentationData,
+              outlines: limitOutlines(presentationData.outlines),
+            }
+          : presentationData;
       const response = await fetch(
         getApiUrl(`/api/v1/ppt/presentation/prepare`),
         {
           method: "POST",
           headers: getHeader(),
-          body: JSON.stringify(presentationData),
+          body: JSON.stringify(body),
           cache: "no-cache",
         }
       );
@@ -201,7 +216,7 @@ export class PresentationGenerationApi {
         {
           method: "PUT",
           headers: getHeader(),
-          body: JSON.stringify({ slides: outlines }),
+          body: JSON.stringify({ slides: limitOutlines(outlines) }),
           cache: "no-cache",
         }
       );

--- a/servers/nextjs/app/(presentation-generator)/upload/components/ConfigurationSelects.tsx
+++ b/servers/nextjs/app/(presentation-generator)/upload/components/ConfigurationSelects.tsx
@@ -17,6 +17,10 @@ import {
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import AdvanceSettings from "./AdvanceSettings";
+import {
+  clampSlideCountValue,
+  MAX_NUMBER_OF_SLIDES,
+} from "@/utils/presentationLimits";
 
 // Types
 interface ConfigurationSelectsProps {
@@ -87,10 +91,7 @@ const SlideCountSelect: React.FC<{
   }, [open]);
 
   const sanitizeToPositiveInteger = (raw: string): string => {
-    const digitsOnly = raw.replace(/\D+/g, "");
-    if (!digitsOnly) return "";
-    const noLeadingZeros = digitsOnly.replace(/^0+/, "");
-    return noLeadingZeros;
+    return clampSlideCountValue(raw);
   };
 
   const applyCustomValue = () => {
@@ -150,6 +151,7 @@ const SlideCountSelect: React.FC<{
             <Input
               inputMode="numeric"
               pattern="[0-9]*"
+              max={MAX_NUMBER_OF_SLIDES}
               value={customInput}
               onMouseDown={(e) => e.stopPropagation()}
               onPointerDown={(e) => e.stopPropagation()}

--- a/servers/nextjs/app/(presentation-generator)/upload/components/NumberOfSlide.tsx
+++ b/servers/nextjs/app/(presentation-generator)/upload/components/NumberOfSlide.tsx
@@ -1,5 +1,6 @@
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { clampSlideCountValue, MAX_NUMBER_OF_SLIDES } from '@/utils/presentationLimits';
 import React, { useState } from 'react'
 
 const SLIDE_OPTIONS: string[] = ["5", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"];
@@ -10,11 +11,7 @@ const NumberOfSlide = ({ value, onValueChange }: { value: string, onValueChange:
     );
 
     const sanitizeToPositiveInteger = (raw: string): string => {
-        const digitsOnly = raw.replace(/\D+/g, "");
-        if (!digitsOnly) return "";
-        // Remove leading zeros
-        const noLeadingZeros = digitsOnly.replace(/^0+/, "");
-        return noLeadingZeros;
+        return clampSlideCountValue(raw);
     };
 
     const applyCustomValue = () => {
@@ -43,6 +40,7 @@ const NumberOfSlide = ({ value, onValueChange }: { value: string, onValueChange:
                         <Input
                             inputMode="numeric"
                             pattern="[0-9]*"
+                            max={MAX_NUMBER_OF_SLIDES}
                             value={customInput}
                             onMouseDown={(e) => e.stopPropagation()}
                             onPointerDown={(e) => e.stopPropagation()}

--- a/servers/nextjs/app/(presentation-generator)/upload/components/UploadPage.tsx
+++ b/servers/nextjs/app/(presentation-generator)/upload/components/UploadPage.tsx
@@ -30,6 +30,10 @@ import { RootState } from "@/store/store";
 import { ImagesApi } from "../../services/api/images";
 import CurrentConfig from "./CurrentConfig";
 import { LLMConfig } from "@/types/llm_config";
+import {
+  clampSlideCountValue,
+  parseLimitedSlideCount,
+} from "@/utils/presentationLimits";
 
 const STOCK_IMAGE_PROVIDERS = new Set(["pexels", "pixabay"]);
 const FILE_TYPE_WORD = new Set([".doc", ".docx", ".docm", ".odt", ".rtf"]);
@@ -154,8 +158,7 @@ const UploadPage = () => {
     const trimmedInstructions = (config.instructions || "").trim();
     const attachmentCategories = Array.from(new Set(files.map(getFileCategory))).sort();
     const imageGenerationEnabled = !llmConfig?.DISABLE_IMAGE_GENERATION;
-    const parsedSlides =
-      config.slides && /^\d+$/.test(config.slides) ? Number(config.slides) : null;
+    const parsedSlides = parseLimitedSlideCount(config.slides);
 
     return {
       pathname,
@@ -192,7 +195,11 @@ const UploadPage = () => {
   };
 
   const handleConfigChange = (key: keyof PresentationConfig, value: unknown) => {
-    setConfig((prev) => ({ ...prev, [key]: value } as PresentationConfig));
+    const nextValue =
+      key === "slides" && typeof value === "string"
+        ? clampSlideCountValue(value)
+        : value;
+    setConfig((prev) => ({ ...prev, [key]: nextValue } as PresentationConfig));
   };
 
   const ensureStockImageProviderReady = async (): Promise<boolean> => {
@@ -342,7 +349,7 @@ const UploadPage = () => {
     const createResponse = await PresentationGenerationApi.createPresentation({
       content: config?.prompt ?? "",
       version: "v1-standard",
-      n_slides: config?.slides ? parseInt(config.slides, 10) : null,
+      n_slides: parseLimitedSlideCount(config?.slides),
       file_paths: [],
       language: selectedLanguage,
       tone: config?.tone,

--- a/servers/nextjs/components/ui/sonner.tsx
+++ b/servers/nextjs/components/ui/sonner.tsx
@@ -4,7 +4,16 @@ import type React from "react"
 import { BadgeCheck, Loader2, ShieldAlert, TriangleAlert } from "lucide-react"
 import { Toaster as Sonner, toast as sonnerToast, type ExternalToast } from "sonner"
 
-type NotifyOptions = Pick<ExternalToast, "duration" | "id">
+type NotifyOptions = Pick<
+  ExternalToast,
+  | "duration"
+  | "id"
+  | "action"
+  | "cancel"
+  | "onDismiss"
+  | "onAutoClose"
+  | "className"
+>
 
 function toastOptions(
   description?: string,
@@ -71,6 +80,10 @@ const Toaster = ({ icons, ...props }: ToasterProps) => {
           [data-sonner-toaster] {
             --width: min(100dvw - 2rem, 24rem) !important;
           }
+        }
+
+        [data-sonner-toaster]:has(.template-v2-model-warning-toast) {
+          --width: min(100dvw - 2rem, 48rem) !important;
         }
 
         /* Neutral "card" toast container — design tokens */
@@ -209,6 +222,60 @@ const Toaster = ({ icons, ...props }: ToasterProps) => {
 
         [data-sonner-toast][data-styled="true"] [data-button]:hover {
           background: rgb(248 250 252) !important; /* slate-50 */
+        }
+
+        [data-sonner-toast][data-styled="true"].template-v2-model-warning-toast {
+          align-items: center !important;
+          gap: 14px !important;
+          padding: 14px 16px !important;
+          width: min(100dvw - 2rem, 48rem) !important;
+          max-width: min(100dvw - 2rem, 48rem) !important;
+        }
+
+        [data-sonner-toast][data-styled="true"].template-v2-model-warning-toast [data-icon] {
+          align-self: flex-start !important;
+          margin-top: 2px !important;
+        }
+
+        [data-sonner-toast][data-styled="true"].template-v2-model-warning-toast [data-content] {
+          flex: 1 1 auto !important;
+          max-width: none !important;
+          min-width: 0 !important;
+        }
+
+        [data-sonner-toast][data-styled="true"].template-v2-model-warning-toast [data-title] {
+          font-size: 0.9375rem !important;
+          line-height: 1.3 !important;
+        }
+
+        [data-sonner-toast][data-styled="true"].template-v2-model-warning-toast [data-description] {
+          max-width: 34rem !important;
+          line-height: 1.45 !important;
+        }
+
+        [data-sonner-toast][data-styled="true"].template-v2-model-warning-toast [data-button] {
+          margin-left: auto !important;
+          white-space: nowrap !important;
+        }
+
+        [data-sonner-toast][data-styled="true"].template-v2-model-warning-toast [data-close-button] {
+          margin-left: 0 !important;
+          white-space: nowrap !important;
+        }
+
+        @media (max-width: 640px) {
+          [data-sonner-toast][data-styled="true"].template-v2-model-warning-toast {
+            flex-wrap: wrap !important;
+            align-items: flex-start !important;
+          }
+
+          [data-sonner-toast][data-styled="true"].template-v2-model-warning-toast [data-content] {
+            flex-basis: calc(100% - 38px) !important;
+          }
+
+          [data-sonner-toast][data-styled="true"].template-v2-model-warning-toast [data-button] {
+            margin-left: 38px !important;
+          }
         }
 
         /* Dark mode — same radius, border weight, shadow; frosted dark surface */

--- a/servers/nextjs/store/slices/presentationGeneration.ts
+++ b/servers/nextjs/store/slices/presentationGeneration.ts
@@ -1,5 +1,9 @@
 import { Theme } from "@/app/(presentation-generator)/services/api/types";
 import { Slide } from "@/app/(presentation-generator)/types/slide";
+import {
+  limitOutlines,
+  MAX_NUMBER_OF_SLIDES,
+} from "@/utils/presentationLimits";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 export interface PresentationData {
@@ -75,7 +79,7 @@ const presentationGenerationSlice = createSlice({
     },
     // Set outlines
     setOutlines: (state, action: PayloadAction<{ content: string }[]>) => {
-      state.outlines = action.payload;
+      state.outlines = limitOutlines(action.payload);
     },
     // Set presentation data
     setPresentationData: (state, action: PayloadAction<PresentationData>) => {
@@ -100,6 +104,10 @@ const presentationGenerationSlice = createSlice({
       action: PayloadAction<{ slide: Slide; index: number }>
     ) => {
       if (state.presentationData?.slides) {
+        if (state.presentationData.slides.length >= MAX_NUMBER_OF_SLIDES) {
+          return;
+        }
+
         // Insert the new slide at the specified index
         state.presentationData.slides.splice(
           action.payload.index,
@@ -114,6 +122,7 @@ const presentationGenerationSlice = createSlice({
             index: idx,
           })
         );
+        state.presentationData.n_slides = state.presentationData.slides.length;
       }
     },
     deletePresentationSlide: (state, action: PayloadAction<number>) => {
@@ -134,6 +143,7 @@ const presentationGenerationSlice = createSlice({
             index: idx,
           })
         );
+        state.presentationData.n_slides = state.presentationData.slides.length;
       }
     },
     duplicatePresentationSlide: (
@@ -142,6 +152,10 @@ const presentationGenerationSlice = createSlice({
     ) => {
       if (state.presentationData?.slides) {
         const slides = state.presentationData.slides;
+        if (slides.length >= MAX_NUMBER_OF_SLIDES) {
+          return;
+        }
+
         const sourceSlide = slides[action.payload.index];
         if (!sourceSlide) {
           return;
@@ -158,6 +172,7 @@ const presentationGenerationSlice = createSlice({
           ...slide,
           index: idx,
         }));
+        state.presentationData.n_slides = state.presentationData.slides.length;
       }
     },
     movePresentationSlide: (
@@ -269,6 +284,10 @@ const presentationGenerationSlice = createSlice({
 
     addNewSlide: (state, action: PayloadAction<{ slideData: any; index: number }>) => {
       if (state.presentationData?.slides) {
+        if (state.presentationData.slides.length >= MAX_NUMBER_OF_SLIDES) {
+          return;
+        }
+
         // Insert the new slide at the specified index + 1 (after current slide)
         state.presentationData.slides.splice(action.payload.index + 1, 0, action.payload.slideData);
 
@@ -279,6 +298,7 @@ const presentationGenerationSlice = createSlice({
             index: idx,
           })
         );
+        state.presentationData.n_slides = state.presentationData.slides.length;
       }
     },
 

--- a/servers/nextjs/utils/presentationLimits.ts
+++ b/servers/nextjs/utils/presentationLimits.ts
@@ -1,0 +1,58 @@
+export const MAX_NUMBER_OF_SLIDES = 50;
+export const MAX_OUTLINE_CONTENT_WORDS = 500;
+
+const WORD_PATTERN = /\S+/g;
+
+export function countOutlineWords(value: string): number {
+  return value.match(WORD_PATTERN)?.length ?? 0;
+}
+
+export function trimTextToWordLimit(
+  value: string,
+  maxWords = MAX_OUTLINE_CONTENT_WORDS
+): string {
+  if (maxWords <= 0) return "";
+
+  const matches = Array.from((value || "").matchAll(WORD_PATTERN));
+  if (matches.length <= maxWords) return value;
+
+  const lastMatch = matches[maxWords - 1];
+  const endIndex = (lastMatch.index ?? 0) + lastMatch[0].length;
+  return value.slice(0, endIndex).trimEnd();
+}
+
+export function limitOutlines<T extends { content?: unknown }>(
+  outlines: T[] | null | undefined
+): { content: string }[] {
+  if (!Array.isArray(outlines)) return [];
+
+  return outlines.slice(0, MAX_NUMBER_OF_SLIDES).map((outline) => ({
+    ...outline,
+    content: trimTextToWordLimit(
+      typeof outline?.content === "string"
+        ? outline.content
+        : String(outline?.content ?? "")
+    ),
+  }));
+}
+
+export function clampSlideCountValue(value: string): string {
+  const digitsOnly = value.replace(/\D+/g, "");
+  if (!digitsOnly) return "";
+
+  const normalized = digitsOnly.replace(/^0+/, "");
+  if (!normalized) return "";
+
+  return String(Math.min(Number(normalized), MAX_NUMBER_OF_SLIDES));
+}
+
+export function parseLimitedSlideCount(
+  value: string | null | undefined
+): number | null {
+  if (!value || !/^\d+$/.test(value)) return null;
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+
+  return Math.min(parsed, MAX_NUMBER_OF_SLIDES);
+}


### PR DESCRIPTION
This pull request introduces comprehensive validation and enforcement of limits for the number of slides and outline content length throughout the presentation generation and editing workflow. The changes ensure that both user and AI-generated outlines and slides adhere to the maximum allowed limits, preventing excessive input and improving robustness. Additionally, error handling and user feedback have been enhanced, and integration tests have been added to verify these constraints.

**Validation and Enforcement of Slide and Outline Limits**

* Added checks in multiple endpoints (`outlines.py`, `presentation.py`) to ensure the number of slides/outlines does not exceed `MAX_NUMBER_OF_SLIDES`, returning clear HTTP 400 errors when violated. [[1]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R1380-R1384) [[2]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R1721-R1730) [[3]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R1740-R1744) [[4]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R1803-R1811) [[5]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R1858-R1862) [[6]](diffhunk://#diff-cd84161668d7cc95ecfb91f226dcd2f8efd68964307addd09689eccf644f887fL210-R217) [[7]](diffhunk://#diff-885e42999fb00473a8d49541f9b2e8b8d4d79788443b98685adc540c2bfba180R468-R476) [[8]](diffhunk://#diff-885e42999fb00473a8d49541f9b2e8b8d4d79788443b98685adc540c2bfba180R648-R654) [[9]](diffhunk://#diff-885e42999fb00473a8d49541f9b2e8b8d4d79788443b98685adc540c2bfba180R803-R810)
* Enforced slide and outline content word limits (`MAX_OUTLINE_CONTENT_WORDS`) in the `SlideOutlineModel` using Pydantic validators and normalization utilities, ensuring outline content is trimmed as needed. [[1]](diffhunk://#diff-f280caecf0105e31b6730f87a07c1fd252e461e0628a6b318f347ae34049d488L2-R24) [[2]](diffhunk://#diff-885e42999fb00473a8d49541f9b2e8b8d4d79788443b98685adc540c2bfba180R32) [[3]](diffhunk://#diff-885e42999fb00473a8d49541f9b2e8b8d4d79788443b98685adc540c2bfba180L2579-R2603)
* Updated chat-related schemas, tool descriptions, and prompts to reflect and communicate these limits to both users and AI assistants. [[1]](diffhunk://#diff-e575225ff8b26e9617d268df1f589913ef6e599c557b15d6be908480502aa09cL37-R39) [[2]](diffhunk://#diff-e575225ff8b26e9617d268df1f589913ef6e599c557b15d6be908480502aa09cL52-R54) [[3]](diffhunk://#diff-951801b0dc9f8d4f9e63d6f5a08c47bb0b46b7997005641a3deefe640b6585d2R80-R81) [[4]](diffhunk://#diff-951801b0dc9f8d4f9e63d6f5a08c47bb0b46b7997005641a3deefe640b6585d2R91) [[5]](diffhunk://#diff-c80248bc9d9d830381f14f1c669e311a33dd0631433b2feecc53a3a9457dc32dR1-R10) [[6]](diffhunk://#diff-c80248bc9d9d830381f14f1c669e311a33dd0631433b2feecc53a3a9457dc32dR86-R87)

**Utilities and Constants**

* Centralized `MAX_NUMBER_OF_SLIDES` and `MAX_OUTLINE_CONTENT_WORDS` in `constants.presentation`, and imported them where needed for consistent enforcement. [[1]](diffhunk://#diff-cd84161668d7cc95ecfb91f226dcd2f8efd68964307addd09689eccf644f887fR11) [[2]](diffhunk://#diff-ba0d11e0f52b1e4c1eb524bb23effa61d437e9c0d7a9d435c221330bec82de33R5) [[3]](diffhunk://#diff-885e42999fb00473a8d49541f9b2e8b8d4d79788443b98685adc540c2bfba180R12) [[4]](diffhunk://#diff-951801b0dc9f8d4f9e63d6f5a08c47bb0b46b7997005641a3deefe640b6585d2R9) [[5]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R76) [[6]](diffhunk://#diff-cd84161668d7cc95ecfb91f226dcd2f8efd68964307addd09689eccf644f887fR31)

**Testing**

* Added integration tests to verify that exceeding the maximum number of outlines or slides results in appropriate errors, ensuring reliability of the new validations.

These changes significantly improve the reliability and user experience of the presentation generation system by preventing excessive input and providing clear feedback.