### PR TITLE
Improve JSON-to-HTML rendering for text shadows and lines

### DIFF
--- a/servers/nextjs/lib/template-v2-json-to-html.ts
+++ b/servers/nextjs/lib/template-v2-json-to-html.ts
@@ -502,11 +502,14 @@ function renderText(item: JsonRecord, mode: RenderMode): string {
     })
     .join("");
 
-  return `<div style="${frameStyle(item, mode)}${transformStyle(item)}${fontStyle(font)}display:flex;align-items:${verticalAlign(
+  return `<div style="${frameStyle(item, mode)}${transformStyle(item)}${fontStyle(font, {
+    includeLineHeight: false,
+  })}${textShadowStyle(item)}display:flex;align-items:${verticalAlign(
     vertical
-  )};justify-content:${horizontalAlign(horizontal)};line-height:${cssNumber(
-    readNumber(font.lineHeight ?? font.line_height) ?? 1.1
-  )};${textOverflowStyle()}text-align:${textAlign(horizontal)};"><span style="display:block;width:100%">${runHtml}</span></div>`;
+  )};justify-content:${horizontalAlign(horizontal)};${lineHeightStyle(
+    font,
+    1.1
+  )}${textOverflowStyle()}text-align:${textAlign(horizontal)};"><span style="display:block;width:100%">${runHtml}</span></div>`;
 }
 
 function renderTextList(item: JsonRecord, mode: RenderMode): string {
@@ -690,15 +693,39 @@ function renderLine(item: JsonRecord, mode: RenderMode): string {
     readNumber(stroke.opacity)
   );
   const width = Math.max(0, readNumber(stroke.width) ?? 1);
+  const deltaX = box.width ?? 0;
+  const deltaY = box.height ?? 0;
+  const left = box.x + Math.min(0, deltaX);
+  const top = box.y + Math.min(0, deltaY);
+  const frameWidth = Math.max(Math.abs(deltaX), width, 1);
+  const frameHeight = Math.max(Math.abs(deltaY), width, 1);
+  const x1 = deltaX < 0 ? frameWidth : 0;
+  const y1 = deltaY < 0 ? frameHeight : 0;
+  const x2 = deltaX < 0 ? 0 : Math.abs(deltaX);
+  const y2 = deltaY < 0 ? 0 : Math.abs(deltaY);
+  const frame =
+    mode === "absolute"
+      ? `box-sizing:border-box;min-height:0;min-width:0;position:absolute;left:${cssNumber(
+        left
+      )}px;top:${cssNumber(top)}px;width:${cssNumber(
+        frameWidth
+      )}px;height:${cssNumber(frameHeight)}px;`
+      : `box-sizing:border-box;min-height:0;min-width:0;position:relative;width:${cssNumber(
+        frameWidth
+      )}px;height:${cssNumber(frameHeight)}px;`;
   const dash = readArray(stroke.dash)
     .map(readNumber)
     .filter((value): value is number => value != null)
     .join(" ");
-  return `<div style="${frameStyle(item, mode)}${transformStyle(item)}overflow:visible"><svg width="100%" height="100%" viewBox="0 0 ${cssNumber(
-    box.width ?? 1
-  )} ${cssNumber(box.height ?? 1)}" preserveAspectRatio="none" style="display:block;overflow:visible"><line x1="0" y1="0" x2="${cssNumber(
-    box.width ?? 1
-  )}" y2="${cssNumber(box.height ?? 1)}" stroke="${escapeAttribute(
+  return `<div style="${frame}${transformStyle(
+    item
+  )}overflow:visible"><svg width="100%" height="100%" viewBox="0 0 ${cssNumber(
+    frameWidth
+  )} ${cssNumber(frameHeight)}" preserveAspectRatio="none" style="display:block;overflow:visible"><line x1="${cssNumber(
+    x1
+  )}" y1="${cssNumber(y1)}" x2="${cssNumber(x2)}" y2="${cssNumber(
+    y2
+  )}" stroke="${escapeAttribute(
     color
   )}" stroke-width="${cssNumber(width)}"${dash ? ` stroke-dasharray="${dash}"` : ""}/></svg></div>`;
 }
@@ -1164,7 +1191,7 @@ function normalizeChartKindValue(value: string | null): string {
 }
 
 function chartKindFromValue(value: string | null): ChartKind {
-  const normalized = value?.toLowerCase().replace(/[\s-]+/g, "_") ?? "";
+  const normalized = normalizeChartKindValue(value);
   if (normalized === "bubble") return "bubble";
   if (normalized === "horizontal_bar" || normalized === "bar_horizontal") {
     return "horizontal_bar";
@@ -1726,21 +1753,29 @@ function boxStyle(item: JsonRecord): string {
   }
   const borderRadius = borderRadiusStyle(radius);
   if (borderRadius) style += `border-radius:${borderRadius};`;
-  const shadowOpacity = Object.keys(shadow).length
-    ? (readNumber(shadow.opacity) ?? 1)
-    : 0;
-  if (shadowOpacity > 0) {
-    style += `box-shadow:${cssNumber(
-      readNumber(shadow.offsetX ?? shadow.offset_x) ?? 0
-    )}px ${cssNumber(readNumber(shadow.offsetY ?? shadow.offset_y) ?? 0)}px ${cssNumber(
-      readNumber(shadow.blur) ?? 0
-    )}px ${escapeCssColor(
-      colorWithOpacity(readString(shadow.color) ?? "#000000", shadowOpacity)
-    )};`;
-  }
+  const shadowValue = shadowCssValue(shadow);
+  if (shadowValue) style += `box-shadow:${shadowValue};`;
   const opacity = readNumber(item.opacity);
   if (opacity != null) style += `opacity:${cssNumber(opacity)};`;
   return style;
+}
+
+function textShadowStyle(item: JsonRecord): string {
+  const shadowValue = shadowCssValue(readRecord(item.shadow));
+  return shadowValue ? `text-shadow:${shadowValue};` : "";
+}
+
+function shadowCssValue(shadow: JsonRecord): string {
+  const shadowOpacity = Object.keys(shadow).length
+    ? (readNumber(shadow.opacity) ?? 1)
+    : 0;
+  if (shadowOpacity <= 0) return "";
+
+  return `${cssNumber(readNumber(shadow.offsetX ?? shadow.offset_x) ?? 0)}px ${cssNumber(
+    readNumber(shadow.offsetY ?? shadow.offset_y) ?? 0
+  )}px ${cssNumber(readNumber(shadow.blur) ?? 0)}px ${escapeCssColor(
+    colorWithOpacity(readString(shadow.color) ?? "#000000", shadowOpacity)
+  )}`;
 }
 
 function transformStyle(item: JsonRecord): string {
@@ -1756,7 +1791,10 @@ function transformStyle(item: JsonRecord): string {
   return `transform:${transforms.join(" ")};transform-origin:center;`;
 }
 
-function fontStyle(fontValue: unknown): string {
+function fontStyle(
+  fontValue: unknown,
+  options: { includeLineHeight?: boolean } = {}
+): string {
   const font = readRecord(fontValue);
   let style = `color:${escapeCssColor(
     colorWithOpacity(readString(font.color) ?? "#111827", readNumber(font.opacity))
@@ -1765,13 +1803,23 @@ function fontStyle(fontValue: unknown): string {
   const size = readNumber(font.size);
   if (family) style += `font-family:${escapeCssFont(family)};`;
   if (size != null) style += `font-size:${cssNumber(size)}px;`;
-  if (readBoolean(font.italic)) style += "font-style:italic;";
-  if (readBoolean(font.bold)) style += "font-weight:700;";
-  const lineHeight = readNumber(font.lineHeight ?? font.line_height);
-  if (lineHeight != null) style += `line-height:${cssNumber(lineHeight)};`;
+  if (hasOwn(font, "italic")) {
+    style += readBoolean(font.italic) ? "font-style:italic;" : "font-style:normal;";
+  }
+  if (hasOwn(font, "bold")) {
+    style += readBoolean(font.bold) ? "font-weight:700;" : "font-weight:400;";
+  }
+  if (options.includeLineHeight !== false) style += lineHeightStyle(font);
   const letterSpacing = readNumber(font.letterSpacing ?? font.letter_spacing);
   if (letterSpacing != null) style += `letter-spacing:${cssNumber(letterSpacing)}px;`;
   return style;
+}
+
+function lineHeightStyle(font: JsonRecord, fallback?: number): string {
+  const lineHeight = readNumber(font.lineHeight ?? font.line_height) ?? fallback;
+  if (lineHeight == null) return "";
+
+  return `line-height:${cssNumber(lineHeight)};`;
 }
 
 function tableRows(item: JsonRecord): unknown[][] {
@@ -2087,6 +2135,10 @@ function readRecord(value: unknown): JsonRecord {
 function readRecordOrNull(value: unknown): JsonRecord | null {
   const record = readRecord(value);
   return Object.keys(record).length ? record : null;
+}
+
+function hasOwn(record: JsonRecord, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
 }
 
 function readArray(value: unknown): unknown[] {

--- a/servers/nextjs/tests/template-v2-json-to-html.test.mjs
+++ b/servers/nextjs/tests/template-v2-json-to-html.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+
+import { build } from "esbuild";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function resolveNextAlias(importPath) {
+  const basePath = path.join(projectRoot, importPath.slice(2));
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    `${basePath}.js`,
+    path.join(basePath, "index.ts"),
+    path.join(basePath, "index.tsx"),
+    path.join(basePath, "index.js"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? basePath;
+}
+
+async function loadRenderer() {
+  const outDir = await mkdtemp(path.join(tmpdir(), "template-v2-html-test-"));
+  const outfile = path.join(outDir, "renderer.mjs");
+
+  await build({
+    entryPoints: [path.join(projectRoot, "lib", "template-v2-json-to-html.ts")],
+    outfile,
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    sourcemap: false,
+    logLevel: "silent",
+    plugins: [
+      {
+        name: "next-alias",
+        setup(builder) {
+          builder.onResolve({ filter: /^@\// }, (args) => ({
+            path: resolveNextAlias(args.path),
+          }));
+        },
+      },
+    ],
+  });
+
+  return import(pathToFileURL(outfile).href);
+}
+
+const rendererPromise = loadRenderer();
+
+test("renders text shadows and explicit false run font overrides", async () => {
+  const { templateV2UiToHtml } = await rendererPromise;
+  const html = templateV2UiToHtml({
+    elements: [
+      {
+        type: "text",
+        position: { x: 12, y: 16 },
+        size: { width: 360, height: 96 },
+        text: "Headline",
+        runs: [{ text: "Headline", font: { bold: false, italic: false } }],
+        font: {
+          family: "Arial",
+          size: 28,
+          color: "#111111",
+          bold: true,
+          italic: true,
+          line_height: 1.2,
+        },
+        shadow: {
+          color: "#123456",
+          opacity: 0.5,
+          offsetX: 2,
+          offsetY: 3,
+          blur: 4,
+        },
+      },
+    ],
+  });
+
+  assert.ok(html);
+  assert.match(html, /text-shadow:2px 3px 4px rgba\(18,52,86,0\.5\);/);
+  assert.match(html, /font-style:normal;/);
+  assert.match(html, /font-weight:400;/);
+});
+
+test("uses the default text line-height when none is provided", async () => {
+  const { templateV2UiToHtml } = await rendererPromise;
+  const html = templateV2UiToHtml({
+    elements: [
+      {
+        type: "text",
+        position: { x: 0, y: 0 },
+        size: { width: 320, height: 80 },
+        text: "Default line height",
+        font: { family: "Arial", size: 20, color: "#111111" },
+      },
+    ],
+  });
+
+  assert.ok(html);
+  assert.match(html, /line-height:1\.1;/);
+});
+
+test("renders zero-height horizontal lines with a stroke-sized frame", async () => {
+  const { templateV2UiToHtml } = await rendererPromise;
+  const html = templateV2UiToHtml({
+    components: [
+      {
+        position: { x: 0, y: 0 },
+        size: { width: 689, height: 24 },
+        elements: [
+          {
+            type: "line",
+            position: { x: 0, y: 19.63 },
+            size: { width: 689, height: 0 },
+            stroke: { color: "#FFFFFF", width: 2.67 },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.ok(html);
+  assert.match(html, /height:2\.67px;/);
+  assert.match(html, /viewBox="0 0 689 2\.67"/);
+  assert.match(html, /stroke-width="2\.67"/);
+});
+
+test("normalizes camelCase chart kinds before rendering chart config", async () => {
+  const { templateV2UiToHtml } = await rendererPromise;
+  const html = templateV2UiToHtml({
+    elements: [
+      {
+        type: "chart",
+        chartType: "horizontalStackedBar",
+        position: { x: 0, y: 0 },
+        size: { width: 420, height: 260 },
+        categories: ["A", "B"],
+        series: [
+          { name: "North", values: [4, 6] },
+          { name: "South", values: [2, 8] },
+        ],
+      },
+    ],
+  });
+
+  assert.ok(html);
+  assert.match(html, /&quot;type&quot;:&quot;bar&quot;/);
+  assert.match(html, /&quot;indexAxis&quot;:&quot;y&quot;/);
+  assert.match(html, /&quot;stacked&quot;:true/);
+});


### PR DESCRIPTION
## Summary
- Render text shadows separately from box shadows and preserve explicit run-level font overrides
- Move text line-height handling into a dedicated helper with a default fallback
- Expand line rendering to handle zero-height and reversed segments with a proper SVG frame
- Normalize chart kind values through the shared chart-kind parser
- Add unit coverage for text shadow rendering, default line-height behavior, line sizing, and chart kind normalization

## Testing
- Added node:test coverage for the updated renderer behavior
- Not run (not requested)