### PR TITLE
upgrade: performance improvements

### DIFF
--- a/servers/nextjs/app/(presentation-generator)/components/PresentationRender.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/PresentationRender.tsx
@@ -18,6 +18,8 @@ const SlideScale = ({
   fixedSize = false,
   presentationLayout,
   renderIndex,
+  enableViewportCulling = false,
+  isSelected = false,
   showBlankPromptOverlay = false,
   onBlankPromptOverlayDismiss,
   showTemplatePromptOverlay = false,
@@ -34,6 +36,8 @@ const SlideScale = ({
   fixedSize?: boolean;
   presentationLayout?: unknown;
   renderIndex?: number;
+  enableViewportCulling?: boolean;
+  isSelected?: boolean;
   showBlankPromptOverlay?: boolean;
   onBlankPromptOverlayDismiss?: () => void;
   showTemplatePromptOverlay?: boolean;
@@ -128,6 +132,9 @@ const SlideScale = ({
               fonts={fonts}
               presentationLayout={presentationLayout}
               renderIndex={renderIndex}
+              displayScale={scale}
+              enableViewportCulling={enableViewportCulling}
+              isSelected={isSelected}
               showBlankPromptOverlay={showBlankPromptOverlay}
               onBlankPromptOverlayDismiss={onBlankPromptOverlayDismiss}
               showTemplatePromptOverlay={showTemplatePromptOverlay}

--- a/servers/nextjs/app/(presentation-generator)/components/V1ContentRender.tsx
+++ b/servers/nextjs/app/(presentation-generator)/components/V1ContentRender.tsx
@@ -157,6 +157,9 @@ export const V1ContentRender = ({
     isEditMode,
     fonts,
     renderIndex,
+    displayScale = 1,
+    enableViewportCulling = false,
+    isSelected = false,
     showBlankPromptOverlay = false,
     onBlankPromptOverlayDismiss,
     showTemplatePromptOverlay = false,
@@ -168,6 +171,9 @@ export const V1ContentRender = ({
     theme?: any,
     fonts?: unknown,
     renderIndex?: number,
+    displayScale?: number,
+    enableViewportCulling?: boolean,
+    isSelected?: boolean,
     showBlankPromptOverlay?: boolean,
     onBlankPromptOverlayDismiss?: () => void,
     showTemplatePromptOverlay?: boolean,
@@ -223,6 +229,9 @@ export const V1ContentRender = ({
                     slideIndex={safeSlide.index ?? 0}
                     renderIndex={renderIndex}
                     fonts={fonts}
+                    displayScale={displayScale}
+                    enableViewportCulling={enableViewportCulling}
+                    isSelected={isSelected}
                 />
                 {isEditMode &&
                     ((showBlankPromptOverlay && isBlankSlide) ||

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/PresentationPage.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/PresentationPage.tsx
@@ -664,9 +664,13 @@ const PresentationPage: React.FC<PresentationPageProps> = ({
                       presentationData.slides.map(
                         (slide: any, index: number) => (
                           <SlideContent
-                            key={`${slide.type}-${index}-${slide.index}`}
+                            key={
+                              slide.id ??
+                              `${slide.type ?? "slide"}-${slide.index ?? index}`
+                            }
                             slide={slide}
                             index={index}
+                            selected={selectedSlide === index}
                             presentationId={presentation_id}
                             onSlideAdded={handleEditorSlideNavigation}
                             theme={presentationData?.theme}

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/SidePanel.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/SidePanel.tsx
@@ -179,12 +179,18 @@ const SidePanel = ({
             collisionDetection={closestCenter}
             onDragEnd={handleDragEnd}
           >
-            <div className="overflow-y-auto w-full hide-scrollbar min-h-0 flex-1 space-y-3.5">
+            <div
+              data-slide-thumbnail-scroll-container="true"
+              className="overflow-y-auto w-full hide-scrollbar min-h-0 flex-1 space-y-3.5"
+            >
               {isStreaming ? (
                 presentationData &&
                 presentationData?.slides.map((slide: any, index: number) => (
                   <SlideThumbnailCard
-                    key={`${slide.id}-${index}`}
+                    key={
+                      slide.id ??
+                      `${slide.type ?? "slide"}-${slide.index ?? index}`
+                    }
                     slide={slide}
                     index={index}
                     selected={selectedSlide === index}
@@ -206,7 +212,10 @@ const SidePanel = ({
                     presentationData?.slides.map(
                       (slide: any, index: number) => (
                         <SortableSlide
-                          key={`${slide.id}-${index}`}
+                          key={
+                            slide.id ??
+                            `${slide.type ?? "slide"}-${slide.index ?? index}`
+                          }
                           slide={slide}
                           index={index}
                           selectedSlide={selectedSlide}

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/SlideContent.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/SlideContent.tsx
@@ -7,6 +7,7 @@ import SlideActionBar from "./SlideActionBar";
 interface SlideContentProps {
   slide: any;
   index: number;
+  selected?: boolean;
   presentationId: string;
   onSlideAdded?: (
     index: number,
@@ -29,6 +30,7 @@ interface SlideContentProps {
 const SlideContent = ({
   slide,
   index,
+  selected = false,
   presentationId,
   onSlideAdded,
   isChatEditing = false,
@@ -112,6 +114,8 @@ const SlideContent = ({
             theme={theme ?? null}
             fonts={fonts}
             renderIndex={index}
+            enableViewportCulling
+            isSelected={selected}
             showBlankPromptOverlay={showBlankPromptOverlay}
             onBlankPromptOverlayDismiss={onBlankPromptOverlayDismiss}
             showTemplatePromptOverlay={showTemplatePromptOverlay}
@@ -137,6 +141,7 @@ export default memo(
   (previous, next) =>
     previous.slide === next.slide &&
     previous.index === next.index &&
+    previous.selected === next.selected &&
     previous.presentationId === next.presentationId &&
     previous.onSlideAdded === next.onSlideAdded &&
     previous.isChatEditing === next.isChatEditing &&

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/SlideThumbnailCard.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/SlideThumbnailCard.tsx
@@ -1,5 +1,6 @@
-import React, { forwardRef, memo } from "react";
+import React, { forwardRef, memo, useCallback } from "react";
 import type { Slide } from "../../types/slide";
+import { useNearViewport } from "@/app/hooks/useNearViewport";
 import { V1ContentRender } from "../../components/V1ContentRender";
 import {
   shouldRenderTemplateV2HtmlPreview,
@@ -33,6 +34,23 @@ const SlideThumbnailCardComponent = forwardRef<
     },
     ref
   ) => {
+    const { isNearViewport, ref: setViewportRoot } =
+      useNearViewport<HTMLDivElement>({
+        forceActive: selected,
+        rootMargin: "72px 0px",
+        rootSelector: "[data-slide-thumbnail-scroll-container='true']",
+      });
+    const setRootRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        setViewportRoot(node);
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      },
+      [ref, setViewportRoot],
+    );
     const useTemplateV2HtmlPreview = shouldRenderTemplateV2HtmlPreview(
       slide,
       presentationVersion
@@ -40,7 +58,8 @@ const SlideThumbnailCardComponent = forwardRef<
 
     return (
       <div
-        ref={ref}
+        ref={setRootRef}
+        data-slide-thumbnail-active={isNearViewport ? "true" : "false"}
         style={{
           backgroundColor: "var(--card-color, #ffffff)",
           borderColor: selected ? "#5141e5" : "var(--stroke, #e5e7eb)",
@@ -59,7 +78,12 @@ const SlideThumbnailCardComponent = forwardRef<
           className="relative"
           style={{ height: `${720 * SCALE}px`, overflow: "hidden" }}
         >
-          {useTemplateV2HtmlPreview ? (
+          {!isNearViewport ? (
+            <div
+              className="absolute inset-0 rounded-[10px] bg-white"
+              aria-hidden="true"
+            />
+          ) : useTemplateV2HtmlPreview ? (
             <TemplateV2HtmlSlidePreview
               slide={slide}
               fonts={fonts}

--- a/servers/nextjs/app/hooks/useNearViewport.ts
+++ b/servers/nextjs/app/hooks/useNearViewport.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+type UseNearViewportOptions = {
+  enabled?: boolean;
+  forceActive?: boolean;
+  rootMargin?: string;
+  rootSelector?: string;
+};
+
+export function useNearViewport<T extends Element>({
+  enabled = true,
+  forceActive = false,
+  rootMargin = "0px",
+  rootSelector,
+}: UseNearViewportOptions = {}) {
+  const [element, setElement] = useState<T | null>(null);
+  const [isNearViewport, setIsNearViewport] = useState(
+    () => !enabled || forceActive,
+  );
+  const ref = useCallback((node: T | null) => setElement(node), []);
+
+  useEffect(() => {
+    if (!enabled || forceActive) {
+      setIsNearViewport(true);
+      return;
+    }
+    if (!element) return;
+    if (typeof IntersectionObserver === "undefined") {
+      setIsNearViewport(true);
+      return;
+    }
+
+    const candidateRoot = rootSelector
+      ? element.closest(rootSelector)
+      : null;
+    const root = candidateRoot instanceof Element ? candidateRoot : null;
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsNearViewport(entry?.isIntersecting === true),
+      { root, rootMargin },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [element, enabled, forceActive, rootMargin, rootSelector]);
+
+  return { isNearViewport, ref };
+}

--- a/servers/nextjs/components/slide-editor/surface/TemplateV2KonvaSlide.tsx
+++ b/servers/nextjs/components/slide-editor/surface/TemplateV2KonvaSlide.tsx
@@ -58,6 +58,7 @@ import {
 
 
 import { updateSlideUi } from "@/store/slices/presentationGeneration";
+import { useNearViewport } from "@/app/hooks/useNearViewport";
 import { resolveBackendAssetSource } from "@/utils/api";
 import { bucketFileSize, sanitizeAnalyticsError } from "@/utils/analytics";
 import { MixpanelEvent, trackEvent } from "@/utils/mixpanel";
@@ -189,17 +190,22 @@ function autoSizeInlineTextFrame(
   };
 }
 
-const EDITING_SCENE_DEVICE_OVERSAMPLE = 1.5;
-const MIN_EDITING_SCENE_PIXEL_RATIO = 3;
-const MAX_EDITING_SCENE_PIXEL_RATIO = 4;
+const MIN_EDITING_SCENE_PIXEL_RATIO = 1;
+const MAX_EDITING_SCENE_PIXEL_RATIO = 2;
 
-function syncEditingScenePixelRatio(layer: Konva.Layer | null) {
+function syncEditingScenePixelRatio(
+  layer: Konva.Layer | null,
+  displayScale: number,
+) {
   if (!layer || typeof window === "undefined") return;
+  const safeDisplayScale = Number.isFinite(displayScale)
+    ? Math.max(0, displayScale)
+    : 1;
   const pixelRatio = Math.min(
     MAX_EDITING_SCENE_PIXEL_RATIO,
     Math.max(
       MIN_EDITING_SCENE_PIXEL_RATIO,
-      (window.devicePixelRatio || 1) * EDITING_SCENE_DEVICE_OVERSAMPLE,
+      (window.devicePixelRatio || 1) * safeDisplayScale,
     ),
   );
   const canvas = layer.getCanvas();
@@ -234,6 +240,9 @@ type TemplateV2KonvaSlideProps = {
   slideIndex: number;
   renderIndex?: number;
   fonts?: unknown;
+  displayScale?: number;
+  enableViewportCulling?: boolean;
+  isSelected?: boolean;
 };
 
 function TemplateV2KonvaSlideComponent({
@@ -244,12 +253,16 @@ function TemplateV2KonvaSlideComponent({
   slideIndex,
   renderIndex,
   fonts,
+  displayScale = 1,
+  enableViewportCulling = false,
+  isSelected = false,
 }: TemplateV2KonvaSlideProps) {
   const dispatch = useDispatch();
   const surfaceId = useId();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null);
   const nodeRefs = useRef(new Map<string, Konva.Node>());
+  const backgroundLayerRef = useRef<Konva.Layer | null>(null);
   const contentLayerRef = useRef<Konva.Layer | null>(null);
   const imageUploadInputRef = useRef<HTMLInputElement | null>(null);
   const pendingImageUploadRef = useRef<ElementSelection | null>(null);
@@ -262,7 +275,21 @@ function TemplateV2KonvaSlideComponent({
   const templateFonts = useMemo(() => templateFontOptionsFromMap(fonts), [
     fonts,
   ]);
-  const fontLoadState = useFontLoadState(uiDraft, templateFonts);
+  const {
+    isNearViewport,
+    ref: setViewportRoot,
+  } = useNearViewport<HTMLDivElement>({
+    enabled: enableViewportCulling,
+    forceActive: isSelected,
+    rootMargin: "800px 0px",
+    rootSelector: "[data-presentation-slides-scroll-container='true']",
+  });
+  const isRenderActive = !enableViewportCulling || isNearViewport;
+  const fontLoadState = useFontLoadState(
+    uiDraft,
+    templateFonts,
+    isRenderActive,
+  );
   const currentUiRef = useRef<RawUi>(uiDraft);
   const [selection, setSelection] = useState<Selection>(null);
   const selectionRef = useRef<Selection>(selection);
@@ -300,7 +327,8 @@ function TemplateV2KonvaSlideComponent({
   const setRootNode = useCallback((node: HTMLDivElement | null) => {
     rootRef.current = node;
     setRootElement(node);
-  }, []);
+    setViewportRoot(node);
+  }, [setViewportRoot]);
 
   const components = useMemo(
     () => readArray(uiDraft.components).filter(isRecord) as RawComponent[],
@@ -541,18 +569,22 @@ function TemplateV2KonvaSlideComponent({
   }, [selection]);
 
   useEffect(() => {
-    if (!fontLoadState.ready) return;
+    if (!isRenderActive || !fontLoadState.ready) return;
     contentLayerRef.current?.batchDraw();
-  }, [fontLoadState.ready, fontLoadState.revision]);
+  }, [fontLoadState.ready, fontLoadState.revision, isRenderActive]);
 
   useEffect(() => {
-    if (!isEditMode || typeof window === "undefined") return;
-    const refreshPixelRatio = () =>
-      syncEditingScenePixelRatio(contentLayerRef.current);
+    if (!isEditMode || !isRenderActive || typeof window === "undefined") {
+      return;
+    }
+    const refreshPixelRatio = () => {
+      syncEditingScenePixelRatio(backgroundLayerRef.current, displayScale);
+      syncEditingScenePixelRatio(contentLayerRef.current, displayScale);
+    };
     refreshPixelRatio();
     window.addEventListener("resize", refreshPixelRatio);
     return () => window.removeEventListener("resize", refreshPixelRatio);
-  }, [isEditMode]);
+  }, [displayScale, isEditMode, isRenderActive]);
 
   useEffect(() => {
     selectedComponentIndexesRef.current = selectedComponentIndexes;
@@ -574,7 +606,13 @@ function TemplateV2KonvaSlideComponent({
   }, [clearInlineEdit, clearTableCellSelection, layout]);
 
   useEffect(() => {
-    if (!hasFloatingToolbar || typeof window === "undefined") return;
+    if (
+      !isRenderActive ||
+      !hasFloatingToolbar ||
+      typeof window === "undefined"
+    ) {
+      return;
+    }
     let frame = 0;
     const refreshToolbarPosition = () => {
       window.cancelAnimationFrame(frame);
@@ -588,7 +626,7 @@ function TemplateV2KonvaSlideComponent({
       window.cancelAnimationFrame(frame);
       window.removeEventListener("resize", refreshToolbarPosition);
     };
-  }, [hasFloatingToolbar]);
+  }, [hasFloatingToolbar, isRenderActive]);
 
   const isSurfaceActive = useCallback(
     () =>
@@ -629,7 +667,12 @@ function TemplateV2KonvaSlideComponent({
   }, [isEditMode, slideId, surfaceId, surfaceSlideIndex]);
 
   useEffect(() => {
-    if (!isEditMode || !isSurfaceActive() || typeof window === "undefined") {
+    if (
+      !isRenderActive ||
+      !isEditMode ||
+      !isSurfaceActive() ||
+      typeof window === "undefined"
+    ) {
       return;
     }
     window.dispatchEvent(
@@ -646,6 +689,7 @@ function TemplateV2KonvaSlideComponent({
     );
   }, [
     isEditMode,
+    isRenderActive,
     isSurfaceActive,
     selectedSurfaceTarget,
     slideId,
@@ -718,6 +762,7 @@ function TemplateV2KonvaSlideComponent({
   useEffect(() => {
     if (
       !isEditMode ||
+      !isRenderActive ||
       !hasDismissibleEditorUi ||
       typeof document === "undefined" ||
       typeof window === "undefined"
@@ -784,7 +829,12 @@ function TemplateV2KonvaSlideComponent({
       document.removeEventListener("scroll", handleScroll, true);
       window.removeEventListener("scroll", handleScroll, true);
     };
-  }, [clearEditorUiState, hasDismissibleEditorUi, isEditMode]);
+  }, [
+    clearEditorUiState,
+    hasDismissibleEditorUi,
+    isEditMode,
+    isRenderActive,
+  ]);
 
   const commitUi = useCallback(
     (nextUi: RawUi, pushHistory = true) => {
@@ -1534,7 +1584,9 @@ function TemplateV2KonvaSlideComponent({
   );
 
   useEffect(() => {
-    if (!isEditMode || typeof document === "undefined") return;
+    if (!isRenderActive || !isEditMode || typeof document === "undefined") {
+      return;
+    }
 
     const handleLayerShortcut = (event: KeyboardEvent) => {
       if (
@@ -1561,7 +1613,12 @@ function TemplateV2KonvaSlideComponent({
     document.addEventListener("keydown", handleLayerShortcut, true);
     return () =>
       document.removeEventListener("keydown", handleLayerShortcut, true);
-  }, [isEditMode, isSurfaceActive, reorderComponentLayerAtIndex]);
+  }, [
+    isEditMode,
+    isRenderActive,
+    isSurfaceActive,
+    reorderComponentLayerAtIndex,
+  ]);
 
   const targetComponentActions =
     useMemo<TemplateV2SelectionComponentActions | null>(() => {
@@ -1738,7 +1795,9 @@ function TemplateV2KonvaSlideComponent({
   );
 
   useEffect(() => {
-    if (!isEditMode || typeof window === "undefined") return;
+    if (!isRenderActive || !isEditMode || typeof window === "undefined") {
+      return;
+    }
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.defaultPrevented ||
@@ -1757,7 +1816,7 @@ function TemplateV2KonvaSlideComponent({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [deleteSelection, isEditMode, selection]);
+  }, [deleteSelection, isEditMode, isRenderActive, selection]);
 
   useEffect(() => {
     if (!isEditMode || typeof window === "undefined") return;
@@ -1795,7 +1854,9 @@ function TemplateV2KonvaSlideComponent({
   }, [commitUi, isEditMode, isSurfaceActive, slideId, surfaceSlideIndex]);
 
   useEffect(() => {
-    if (!isEditMode || typeof document === "undefined") return;
+    if (!isRenderActive || !isEditMode || typeof document === "undefined") {
+      return;
+    }
     const handlePointerDown = (event: PointerEvent) => {
       const root = rootRef.current;
       const targetNode = event.target instanceof Node ? event.target : null;
@@ -1827,11 +1888,14 @@ function TemplateV2KonvaSlideComponent({
     clearEditorUiState,
     clearSurface,
     isEditMode,
+    isRenderActive,
     isSurfaceActive,
   ]);
 
   useEffect(() => {
-    if (!isEditMode || typeof document === "undefined") return;
+    if (!isRenderActive || !isEditMode || typeof document === "undefined") {
+      return;
+    }
 
     const handleUndoRedoShortcut = (event: KeyboardEvent) => {
       if (
@@ -1864,7 +1928,7 @@ function TemplateV2KonvaSlideComponent({
     document.addEventListener("keydown", handleUndoRedoShortcut, true);
     return () =>
       document.removeEventListener("keydown", handleUndoRedoShortcut, true);
-  }, [isEditMode, isSurfaceActive, redo, undo]);
+  }, [isEditMode, isRenderActive, isSurfaceActive, redo, undo]);
 
   if (!uiDraft) {
     return (
@@ -1892,7 +1956,8 @@ function TemplateV2KonvaSlideComponent({
           onChange={handleImageUploadChange}
         />
       ) : null}
-      <Stage
+      {isRenderActive ? (
+        <Stage
         width={STAGE_WIDTH}
         height={STAGE_HEIGHT}
         onMouseDown={(event) => {
@@ -1912,7 +1977,7 @@ function TemplateV2KonvaSlideComponent({
           activateSurface();
         }}
       >
-        <Layer listening={false}>
+        <Layer ref={backgroundLayerRef} listening={false}>
           <Rect width={STAGE_WIDTH} height={STAGE_HEIGHT} fill={backgroundColor(uiDraft)} />
         </Layer>
         <Layer ref={contentLayerRef} listening={isEditMode}>
@@ -1977,7 +2042,8 @@ function TemplateV2KonvaSlideComponent({
             />
           ) : null}
         </Layer>
-      </Stage>
+        </Stage>
+      ) : null}
       <TemplateV2SelectionToolbar
         anchorBox={floatingToolbarAnchorBox}
         canUngroupComponent={canUngroupSelectedComponent}

--- a/servers/nextjs/components/slide-editor/surface/fontLoading.ts
+++ b/servers/nextjs/components/slide-editor/surface/fontLoading.ts
@@ -25,8 +25,12 @@ const EMPTY_TEMPLATE_FONTS: TemplateFontOption[] = [];
 export function useFontLoadState(
   ui: RawUi,
   templateFonts: TemplateFontOption[] = EMPTY_TEMPLATE_FONTS,
+  enabled = true,
 ) {
-  const fontSignature = useMemo(() => fontLoadSignatureForUi(ui), [ui]);
+  const fontSignature = useMemo(
+    () => (enabled ? fontLoadSignatureForUi(ui) : ""),
+    [enabled, ui],
+  );
   const [state, setState] = useState(() => ({
     revision: 0,
     ready: !fontSignature,


### PR DESCRIPTION
This pull request introduces viewport culling and rendering optimizations for slide components in the presentation generator. The main focus is on improving performance by only rendering slides and thumbnails when they are near the viewport, as well as ensuring that selected slides are always rendered. The changes include a new `useNearViewport` hook, updates to slide and thumbnail components to support culling, and adjustments to pixel ratio handling for more efficient rendering.

**Viewport culling & rendering optimizations:**

* Added a new `useNearViewport` React hook to detect when elements are near the viewport, with support for custom root containers and margins. This enables conditional rendering of slide components and thumbnails based on their visibility.
* Updated `SlideThumbnailCard` to use the `useNearViewport` hook, rendering a placeholder when the thumbnail is not near the viewport, and ensuring the selected slide is always rendered. [[1]](diffhunk://#diff-0cd79062e2922ce6e7792ba83dd6629f371618e33516b57f83da37008a3f1728R37-R62) [[2]](diffhunk://#diff-0cd79062e2922ce6e7792ba83dd6629f371618e33516b57f83da37008a3f1728L62-R86)
* Updated `TemplateV2KonvaSlide` to use viewport culling, only loading fonts and rendering content when the slide is near the viewport or selected. Also, adjusted effect dependencies and event listeners to respect the culling state. [[1]](diffhunk://#diff-20e5b01a6fd345af37fc38a16dba856d1326fb404ed3d3bfb9c535c779cbb757L265-R292) [[2]](diffhunk://#diff-20e5b01a6fd345af37fc38a16dba856d1326fb404ed3d3bfb9c535c779cbb757L544-R587) [[3]](diffhunk://#diff-20e5b01a6fd345af37fc38a16dba856d1326fb404ed3d3bfb9c535c779cbb757L577-R615) [[4]](diffhunk://#diff-20e5b01a6fd345af37fc38a16dba856d1326fb404ed3d3bfb9c535c779cbb757L591-R629) [[5]](diffhunk://#diff-20e5b01a6fd345af37fc38a16dba856d1326fb404ed3d3bfb9c535c779cbb757L632-R675)

**Component API & prop updates:**

* Added `enableViewportCulling` and `isSelected` props to `SlideScale`, `V1ContentRender`, and `TemplateV2KonvaSlide`, and ensured these props are passed through the component hierarchy. This allows parent components to control culling and selection behavior. [[1]](diffhunk://#diff-1c7a23763f5d456475bda8bbcfcb97d50779c8063ff592b3ac6070182af2c059R21-R22) [[2]](diffhunk://#diff-1c7a23763f5d456475bda8bbcfcb97d50779c8063ff592b3ac6070182af2c059R39-R40) [[3]](diffhunk://#diff-1c7a23763f5d456475bda8bbcfcb97d50779c8063ff592b3ac6070182af2c059R135-R137) [[4]](diffhunk://#diff-0f2561451296ca595b7031a95a64c34ae5289ca8bf68ec63b4a1e932c1c78a8fR160-R162) [[5]](diffhunk://#diff-0f2561451296ca595b7031a95a64c34ae5289ca8bf68ec63b4a1e932c1c78a8fR174-R176) [[6]](diffhunk://#diff-0f2561451296ca595b7031a95a64c34ae5289ca8bf68ec63b4a1e932c1c78a8fR232-R234) [[7]](diffhunk://#diff-20e5b01a6fd345af37fc38a16dba856d1326fb404ed3d3bfb9c535c779cbb757R243-R245) [[8]](diffhunk://#diff-20e5b01a6fd345af37fc38a16dba856d1326fb404ed3d3bfb9c535c779cbb757R256-R265)
* Updated `SlideContent` to accept a `selected` prop and forward it to child components, enabling correct rendering of the selected slide even when culling is active. [[1]](diffhunk://#diff-f7826ace91a55633bf376cb8ac5495785c6b18389486efb4b13f585c11a8cbaaR10) [[2]](diffhunk://#diff-f7826ace91a55633bf376cb8ac5495785c6b18389486efb4b13f585c11a8cbaaR33) [[3]](diffhunk://#diff-f7826ace91a55633bf376cb8ac5495785c6b18389486efb4b13f585c11a8cbaaR117-R118) [[4]](diffhunk://#diff-f7826ace91a55633bf376cb8ac5495785c6b18389486efb4b13f585c11a8cbaaR144)

**Key and selection handling improvements:**

* Improved key generation for slides and thumbnails to fallback to a stable string if an `id` is not present, reducing unnecessary React re-renders. [[1]](diffhunk://#diff-965d9af6f87648bcd801461e932ff72df3778bcdd97fd6fd2c6ca6951235420eL667-R673) [[2]](diffhunk://#diff-19969e699a08b631eb115e6143f0b1f20c5ef7601cff85f9b250e8913035bfebL182-R193) [[3]](diffhunk://#diff-19969e699a08b631eb115e6143f0b1f20c5ef7601cff85f9b250e8913035bfebL209-R218)
* Ensured that the selected slide is always rendered and not culled, even if it is outside the viewport. [[1]](diffhunk://#diff-0cd79062e2922ce6e7792ba83dd6629f371618e33516b57f83da37008a3f1728R37-R62) [[2]](diffhunk://#diff-20e5b01a6fd345af37fc38a16dba856d1326fb404ed3d3bfb9c535c779cbb757L265-R292)

**Rendering & pixel ratio adjustments:**

* Modified pixel ratio logic in `TemplateV2KonvaSlide` to use the `displayScale` prop, and reduced the minimum and maximum pixel ratios for better performance and resource usage.

These changes collectively improve the responsiveness and efficiency of the slide editor, especially for large presentations with many slides.