### PR TITLE
feat: fix the ai assitant on small screens

### DIFF
--- a/servers/nextjs/app/(presentation-generator)/presentation/components/PresentationPage.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/PresentationPage.tsx
@@ -9,6 +9,7 @@ import React, {
 import { useDispatch, useSelector } from "react-redux";
 import { v4 as uuidv4 } from "uuid";
 import { RootState } from "@/store/store";
+import { cn } from "@/lib/utils";
 import "../../utils/prism-languages";
 import { Skeleton } from "@/components/ui/skeleton";
 import { OverlayLoader } from "@/components/ui/overlay-loader";
@@ -18,7 +19,7 @@ import SlideContent from "./SlideContent";
 import { Button } from "@/components/ui/button";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { trackEvent, MixpanelEvent } from "@/utils/mixpanel";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, Sparkles, X } from "lucide-react";
 import {
   usePresentationStreaming,
   usePresentationData,
@@ -160,8 +161,11 @@ const PresentationPage: React.FC<PresentationPageProps> = ({
   const [templatePromptSlideIds, setTemplatePromptSlideIds] = useState<
     Set<string>
   >(() => new Set());
+  const [isMobileAssistantOpen, setIsMobileAssistantOpen] = useState(false);
   const [error, setError] = useState(false);
   const slidesScrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const mobileAssistantTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const mobileAssistantCloseRef = useRef<HTMLButtonElement | null>(null);
   const templateV2EditorLoadedKeyRef = useRef<string | null>(null);
   const router = useRouter();
   const shouldPreloadTemplateV2Presentation =
@@ -175,6 +179,41 @@ const PresentationPage: React.FC<PresentationPageProps> = ({
     hasTemplateV2Layouts(presentationData?.layout) ||
     hasTemplateV2Slides(presentationData?.slides);
   const editingDisabled = isStreaming === true;
+
+  const closeMobileAssistant = useCallback(() => {
+    setIsMobileAssistantOpen(false);
+    window.requestAnimationFrame(() => {
+      mobileAssistantTriggerRef.current?.focus();
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isMobileAssistantOpen) return;
+    mobileAssistantCloseRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeMobileAssistant();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeMobileAssistant, isMobileAssistantOpen]);
+
+  useEffect(() => {
+    const desktopQuery = window.matchMedia("(min-width: 1280px)");
+    const closeDrawerOnDesktop = () => {
+      if (desktopQuery.matches) {
+        setIsMobileAssistantOpen(false);
+      }
+    };
+
+    closeDrawerOnDesktop();
+    desktopQuery.addEventListener("change", closeDrawerOnDesktop);
+    return () =>
+      desktopQuery.removeEventListener("change", closeDrawerOnDesktop);
+  }, []);
 
   // Auto-save functionality.
   // Pause while the chat assistant is mutating the deck: the assistant edits
@@ -692,19 +731,73 @@ const PresentationPage: React.FC<PresentationPageProps> = ({
               </div>
             </div>
           </div>
-          <div className="hidden h-full w-[375px] shrink-0 self-start sticky top-0 xl:block">
-            <PresentationActions
-              presentationId={presentation_id}
-              variant={isTemplateV2Presentation ? "template-v2" : "presentation"}
-              currentSlide={selectedSlide}
-              presentationData={presentationData}
-              onPresentationChanged={handlePresentationChanged}
-              onChatSendingStateChange={handleChatSendingStateChange}
-              onChatMutationStateChange={handleChatMutationStateChange}
-              onFollowModeChange={setIsFollowModeEnabled}
-              onAgentSlideFocus={handleAgentSlideFocus}
-              editingDisabled={editingDisabled}
-            />
+          <button
+            ref={mobileAssistantTriggerRef}
+            type="button"
+            aria-controls="presentation-mobile-assistant"
+            aria-expanded={isMobileAssistantOpen}
+            onClick={() => setIsMobileAssistantOpen(true)}
+            className="fixed bottom-5 right-5 z-40 inline-flex h-11 items-center gap-2 rounded-full border border-white/70 px-4 text-sm font-semibold text-[#101323] shadow-[0_8px_24px_rgba(74,58,155,0.24)] transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7A5AF8] focus-visible:ring-offset-2 xl:hidden"
+            style={{
+              background:
+                "linear-gradient(270deg, #D5CAFC 2.4%, #E3D2EB 27.88%, #F4DCD3 69.23%, #FDE4C2 100%)",
+            }}
+          >
+            <Sparkles className="h-4 w-4 text-[#7A5AF8]" aria-hidden="true" />
+            AI Assistant
+          </button>
+
+          <button
+            type="button"
+            aria-label="Close AI Assistant"
+            onClick={closeMobileAssistant}
+            className={cn(
+              "inset-0 z-[60] bg-black/35 xl:hidden",
+              isMobileAssistantOpen ? "fixed" : "hidden"
+            )}
+          />
+
+          <div
+            id="presentation-mobile-assistant"
+            role={isMobileAssistantOpen ? "dialog" : undefined}
+            aria-label={isMobileAssistantOpen ? "AI Assistant" : undefined}
+            aria-modal={isMobileAssistantOpen ? true : undefined}
+            className={cn(
+              "h-screen w-[calc(100vw-16px)] max-w-[375px] shrink-0 flex-col bg-white shadow-[-12px_0_32px_rgba(16,24,40,0.18)] xl:static xl:z-auto xl:flex xl:h-full xl:w-[375px] xl:max-w-none xl:self-start xl:shadow-none",
+              isMobileAssistantOpen
+                ? "fixed inset-y-0 right-0 z-[70] flex"
+                : "hidden"
+            )}
+          >
+            <div className="flex h-14 shrink-0 items-center justify-between border-b border-[#EDEEEF] px-4 xl:hidden">
+              <div className="flex items-center gap-2 text-sm font-semibold text-[#101323]">
+                <Sparkles className="h-4 w-4 text-[#7A5AF8]" aria-hidden="true" />
+                AI Assistant
+              </div>
+              <button
+                ref={mobileAssistantCloseRef}
+                type="button"
+                aria-label="Close AI Assistant"
+                onClick={closeMobileAssistant}
+                className="flex h-8 w-8 items-center justify-center rounded-full text-[#667085] transition hover:bg-[#F6F6F9] hover:text-[#101323] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7A5AF8]"
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1">
+              <PresentationActions
+                presentationId={presentation_id}
+                variant={isTemplateV2Presentation ? "template-v2" : "presentation"}
+                currentSlide={selectedSlide}
+                presentationData={presentationData}
+                onPresentationChanged={handlePresentationChanged}
+                onChatSendingStateChange={handleChatSendingStateChange}
+                onChatMutationStateChange={handleChatMutationStateChange}
+                onFollowModeChange={setIsFollowModeEnabled}
+                onAgentSlideFocus={handleAgentSlideFocus}
+                editingDisabled={editingDisabled}
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This pull request adds a mobile-friendly AI Assistant drawer to the `PresentationPage` component, improving accessibility and usability on smaller screens. It introduces new UI elements and keyboard accessibility features, ensuring the assistant is easily accessible and can be closed with the Escape key or when resizing to desktop. The main changes are grouped below:

**Mobile AI Assistant Drawer Implementation:**

* Added state, refs, and event handlers to manage the open/close behavior of a mobile AI Assistant drawer, including focus management and Escape key handling for accessibility (`isMobileAssistantOpen`, `mobileAssistantTriggerRef`, `mobileAssistantCloseRef`, `closeMobileAssistant`, and related `useEffect` hooks). [[1]](diffhunk://#diff-965d9af6f87648bcd801461e932ff72df3778bcdd97fd6fd2c6ca6951235420eR164-R168) [[2]](diffhunk://#diff-965d9af6f87648bcd801461e932ff72df3778bcdd97fd6fd2c6ca6951235420eR183-R217)
* Implemented a floating "AI Assistant" button (with `Sparkles` icon) that opens the drawer on mobile, and an overlay that closes the drawer when clicked. The drawer includes a header with a close button (`X` icon), and the assistant UI is rendered inside.
* Ensured the drawer closes automatically when switching to desktop layout (≥1280px width).

**UI and Accessibility Enhancements:**

* Updated imports to include new icons (`Sparkles`, `X`) and utility functions (`cn`), and used them in the new UI elements. [[1]](diffhunk://#diff-965d9af6f87648bcd801461e932ff72df3778bcdd97fd6fd2c6ca6951235420eR12) [[2]](diffhunk://#diff-965d9af6f87648bcd801461e932ff72df3778bcdd97fd6fd2c6ca6951235420eL21-R22)
* Improved accessibility by using appropriate ARIA attributes and focus management for the assistant drawer and its controls.

These changes significantly enhance the mobile user experience for the AI Assistant in presentations.