### PR TITLE
feat(codex): add GPT-5.6 support

### DIFF
--- a/servers/fastapi/constants/llm.py
+++ b/servers/fastapi/constants/llm.py
@@ -15,9 +15,13 @@ DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-20250514"
 DEFAULT_LITELLM_MODEL = "gpt-4.1"
 DEFAULT_LMSTUDIO_MODEL = "openai/gpt-oss-20b"
 SUPPORTED_CODEX_MODELS = {
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.3-codex-spark",
 }
-DEFAULT_CODEX_MODEL = "gpt-5.5"
+DEFAULT_CODEX_MODEL = "gpt-5.6"

--- a/servers/fastapi/tests/unit/test_codex_models.py
+++ b/servers/fastapi/tests/unit/test_codex_models.py
@@ -1,19 +1,26 @@
+import pytest
+
 from constants.llm import DEFAULT_CODEX_MODEL, SUPPORTED_CODEX_MODELS
 from enums.llm_provider import LLMProvider
 from utils import llm_provider
 
 
-def test_codex_supported_model_is_preserved(monkeypatch):
+@pytest.mark.parametrize(
+    "model",
+    ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
+)
+def test_codex_gpt_5_6_model_is_preserved(monkeypatch, model):
     monkeypatch.setattr(llm_provider, "get_llm_provider", lambda: LLMProvider.CODEX)
-    monkeypatch.setattr(llm_provider, "get_codex_model_env", lambda: "gpt-5.4-mini")
+    monkeypatch.setattr(llm_provider, "get_codex_model_env", lambda: model)
 
-    assert llm_provider.get_model() == "gpt-5.4-mini"
+    assert model in SUPPORTED_CODEX_MODELS
+    assert llm_provider.get_model() == model
 
 
-def test_codex_deprecated_model_falls_back_to_default(monkeypatch):
+def test_codex_deprecated_model_falls_back_to_latest_default(monkeypatch):
     monkeypatch.setattr(llm_provider, "get_llm_provider", lambda: LLMProvider.CODEX)
     monkeypatch.setattr(llm_provider, "get_codex_model_env", lambda: "gpt-5.2")
 
-    assert DEFAULT_CODEX_MODEL == "gpt-5.5"
+    assert DEFAULT_CODEX_MODEL == "gpt-5.6"
     assert "gpt-5.2" not in SUPPORTED_CODEX_MODELS
     assert llm_provider.get_model() == DEFAULT_CODEX_MODEL

--- a/servers/nextjs/tests/codex-models.test.mjs
+++ b/servers/nextjs/tests/codex-models.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+
+import { build } from "esbuild";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function loadCodexModels() {
+  const outDir = await mkdtemp(path.join(tmpdir(), "codex-models-test-"));
+  const outfile = path.join(outDir, "codex-models.mjs");
+
+  await build({
+    entryPoints: [path.join(projectRoot, "utils", "codexModels.ts")],
+    outfile,
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    logLevel: "silent",
+  });
+
+  return import(pathToFileURL(outfile).href);
+}
+
+const codexModelsPromise = loadCodexModels();
+
+test("lists GPT-5.6 as the default supported Codex model", async () => {
+  const { CODEX_MODELS, DEFAULT_CODEX_MODEL, isSupportedCodexModel } = await codexModelsPromise;
+
+  assert.equal(DEFAULT_CODEX_MODEL, "gpt-5.6");
+  assert.deepEqual(CODEX_MODELS.slice(0, 4), [
+    { id: "gpt-5.6", name: "GPT-5.6" },
+    { id: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+    { id: "gpt-5.6-terra", name: "GPT-5.6 Terra" },
+    { id: "gpt-5.6-luna", name: "GPT-5.6 Luna" },
+  ]);
+  assert.equal(isSupportedCodexModel("gpt-5.6-sol"), true);
+  assert.equal(isSupportedCodexModel("gpt-5.6-terra"), true);
+  assert.equal(isSupportedCodexModel("gpt-5.6-luna"), true);
+  assert.equal(isSupportedCodexModel("gpt-5.2"), false);
+});

--- a/servers/nextjs/utils/codexModels.ts
+++ b/servers/nextjs/utils/codexModels.ts
@@ -4,13 +4,17 @@ export interface CodexModel {
 }
 
 export const CODEX_MODELS: CodexModel[] = [
+  { id: "gpt-5.6", name: "GPT-5.6" },
+  { id: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+  { id: "gpt-5.6-terra", name: "GPT-5.6 Terra" },
+  { id: "gpt-5.6-luna", name: "GPT-5.6 Luna" },
   { id: "gpt-5.5", name: "GPT-5.5" },
   { id: "gpt-5.4", name: "GPT-5.4" },
   { id: "gpt-5.4-mini", name: "GPT-5.4 mini" },
   { id: "gpt-5.3-codex-spark", name: "GPT-5.3 Codex Spark (Pro preview)" },
 ];
 
-export const DEFAULT_CODEX_MODEL = "gpt-5.5";
+export const DEFAULT_CODEX_MODEL = "gpt-5.6";
 
 const CODEX_MODEL_IDS = new Set(CODEX_MODELS.map((model) => model.id));
 


### PR DESCRIPTION
## Summary

- add the GPT-5.6 family to the ChatGPT/Codex model selector and FastAPI allowlist: `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`
- keep `gpt-5.6` as the default Codex model and preserve fallback behavior for unsupported IDs
- cover all GPT-5.6 model IDs in frontend and backend regression tests

## Verification

- `uv run pytest tests/unit -q` — 452 passed
- `npm test` — 47 passed
- `npm run build` — passed
- `npm run lint` — passed with 101 pre-existing warnings and no errors
- `git diff --check` — passed

## AI disclosure

Implementation was AI-assisted, manually reviewed, and independently diff-reviewed before submission.

Closes #764