### PR TITLE
feat(editor): add editable blank slide placeholders

### DIFF
--- a/docs/planning/2026-07-20-blank-slide-placeholders-design.md
+++ b/docs/planning/2026-07-20-blank-slide-placeholders-design.md
@@ -1,0 +1,63 @@
+# Editable Blank-Slide Placeholders Design
+
+**Issue:** #766
+**Status:** Approved for implementation
+
+## Goal
+
+Make a newly created Template V2 blank slide feel like a Google Slides starter slide: users start with editable title and subtitle text boxes instead of an empty canvas. The AI Assistant can treat that text as an editable brief, rewriting it, expanding it, and applying an appropriate design to the same slide.
+
+## Scope
+
+### Included
+
+- Add title and subtitle `text` elements to the Template V2 blank-slide factory.
+- Preserve the white background and the existing blank-slide layout ID.
+- Use the existing Template V2 editor model so placeholders are selectable, editable, movable, restylable, and deletable.
+- Make the blank-slide AI instruction explicitly permit rewriting title/subtitle copy, expanding content, and applying a layout/design to the existing target slide.
+- Add Node regression tests for the factory output and the AI instruction.
+
+### Excluded
+
+- Migrating existing slides.
+- Changing the Legacy/V1 blank-slide renderer, which does not use the Template V2 editable text-element model.
+- Adding a separate “completely empty” menu option; that is a later UX extension.
+- Changing server-side generation contracts.
+
+## Data model
+
+`BLANK_TEMPLATE_V2_LAYOUT` will retain its white decorative background and add two normal `text` elements in its top-level `elements` list:
+
+| Element | Text | Geometry | Style |
+| --- | --- | --- | --- |
+| Title | `Title` | x 120, y 180, 1040×100 | centered, 48px, bold, dark text |
+| Subtitle | `Subtitle` | x 180, y 310, 920×64 | centered, 24px, regular, muted text |
+
+The exact strings intentionally read as neutral editable starter copy. They are stored in both `text` and `runs` to match the existing Template V2 text contract.
+
+## AI behavior
+
+A prompt submitted from a blank-slide overlay continues to update the selected slide and must not add another slide. Its instruction additionally tells the assistant to:
+
+1. treat the title/subtitle as a brief rather than immutable content;
+2. improve or rewrite their wording when appropriate;
+3. expand the brief into presentation-ready content; and
+4. apply an appropriate visual design/layout to that same slide.
+
+## Acceptance cases
+
+| Case | Expected result |
+| --- | --- |
+| New Template V2 blank slide | Contains the white background plus editable `Title` and `Subtitle` text elements. |
+| New Legacy/V1 blank slide | Remains unchanged and empty. |
+| User edits title/subtitle | Existing Template V2 editor persists direct edits without custom code. |
+| AI prompt from blank slide | Targets the existing slide, permits copy rewrite/content expansion/design application, and says not to add another slide. |
+| Existing deck | Unchanged; only newly created V2 blank slides receive placeholders. |
+
+## Test plan
+
+1. Write a focused Node test that imports the shared blank-slide factory and expects the two editable text placeholders only for Template V2.
+2. Run it while the factory is still empty and verify the expected assertion failure.
+3. Implement the minimal factory change, rerun the focused test, and run the full Next.js test suite.
+4. Extract the blank-slide AI instruction to a small pure shared helper, write a failing test for its rewrite/design semantics, then integrate it in `Chat.tsx`.
+5. Run `npm test`, `npm run build`, `npm run lint`, and `git diff --check`.

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presenton",
-  "version": "0.9.0-beta",
+  "version": "0.9.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presenton",
-      "version": "0.9.0-beta",
+      "version": "0.9.1-beta",
       "hasInstallScript": true,
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.2",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "presenton",
   "productName": "Presenton Open Source",
-  "version": "0.9.0-beta",
+  "version": "0.9.1-beta",
   "exportVersion": "v0.4.2",
   "exportChromiumBuildId": "149.0.7827.196",
   "exportMacChromiumBuildIds": {

--- a/electron/version.json
+++ b/electron/version.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.9.0-beta",
+  "version": "0.9.1-beta",
   "message": "Presenton Desktop electron-v0.8.9-beta\n\nA polished 0.8.9-beta release with lots of improvements across the Electron app.\n\nWhat's New\n\n• Faster, more reliable exports with Chromium export support\n• Better image editing with stock search and OpenAI-compatible generation\n• Improved AI model support, including LiteLLM, Azure, Vertex, and ComfyUI seeds\n• Cleaner editing workflows, markdown rendering, and slide management\n• Updated templates, Chart.js migration, and multilingual UI improvements\n• Stability fixes for packaging, onboarding, layouts, fonts, and exports\n\nInstallation\nDownload Link: https://presenton.ai/download\nLove the app? Star us on GitHub → github.com/presenton/presenton",
   "downloads": {
-    "linux": "https://github.com/presenton/presenton/releases/download/electron-v0.9.0-beta/Presenton-0.9.0-beta.deb",
-    "mac": "https://github.com/presenton/presenton/releases/download/electron-v0.9.0-beta/Presenton-0.9.0-beta.dmg",
-    "windows": "https://github.com/presenton/presenton/releases/download/electron-v0.9.0-beta/Presenton-0.9.0-beta.exe"
+    "linux": "https://github.com/presenton/presenton/releases/download/electron-v0.9.1-beta/Presenton-0.9.1-beta.deb",
+    "mac": "https://github.com/presenton/presenton/releases/download/electron-v0.9.1-beta/Presenton-0.9.1-beta.dmg",
+    "windows": "https://github.com/presenton/presenton/releases/download/electron-v0.9.1-beta/Presenton-0.9.1-beta.exe"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presenton",
-  "version": "0.9.0-beta",
+  "version": "0.9.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presenton",
-      "version": "0.9.0-beta",
+      "version": "0.9.1-beta",
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.2",
         "sharp": "^0.34.5"

--- a/scripts/package-metadata.test.mjs
+++ b/scripts/package-metadata.test.mjs
@@ -13,21 +13,38 @@ async function readJson(relativePath) {
   return JSON.parse(await readFile(path.join(repoRoot, relativePath), "utf8"));
 }
 
-test("application versions stay aligned", async () => {
-  const [rootPackage, rootLock, electronPackage, electronLock] =
-    await Promise.all([
-      readJson("package.json"),
-      readJson("package-lock.json"),
-      readJson("electron/package.json"),
-      readJson("electron/package-lock.json"),
-    ]);
+test("application versions and desktop update metadata stay aligned", async () => {
+  const [
+    rootPackage,
+    rootLock,
+    electronPackage,
+    electronLock,
+    electronVersion,
+  ] = await Promise.all([
+    readJson("package.json"),
+    readJson("package-lock.json"),
+    readJson("electron/package.json"),
+    readJson("electron/package-lock.json"),
+    readJson("electron/version.json"),
+  ]);
 
-  assert.equal(rootPackage.version, "0.9.0-beta");
+  assert.match(rootPackage.version, /^\d+\.\d+\.\d+-beta$/);
   assert.equal(electronPackage.version, rootPackage.version);
   assert.equal(rootLock.version, rootPackage.version);
   assert.equal(rootLock.packages[""].version, rootPackage.version);
   assert.equal(electronLock.version, electronPackage.version);
   assert.equal(electronLock.packages[""].version, electronPackage.version);
+  assert.equal(electronVersion.version, electronPackage.version);
+  for (const [platform, extension] of Object.entries({
+    linux: "deb",
+    mac: "dmg",
+    windows: "exe",
+  })) {
+    assert.equal(
+      electronVersion.downloads[platform],
+      `https://github.com/presenton/presenton/releases/download/electron-v${electronPackage.version}/Presenton-${electronPackage.version}.${extension}`,
+    );
+  }
 });
 
 test("Docker and Electron use the same pinned presentation export", async () => {

--- a/servers/nextjs/app/(presentation-generator)/_shared/blank-slide-ai-instruction.ts
+++ b/servers/nextjs/app/(presentation-generator)/_shared/blank-slide-ai-instruction.ts
@@ -1,0 +1,26 @@
+type BlankSlideAiInstructionOptions = {
+  slideIndex?: number | null;
+  layoutId?: string | null;
+  promptKind?: "blank" | "layout";
+};
+
+export function createBlankSlideAiInstruction({
+  slideIndex,
+  layoutId,
+  promptKind = "blank",
+}: BlankSlideAiInstructionOptions): string {
+  const target =
+    typeof slideIndex === "number"
+      ? `slide ${slideIndex + 1}`
+      : "the current blank slide";
+  const layoutReference =
+    typeof layoutId === "string" && layoutId.trim()
+      ? ` (layout id: ${layoutId.trim()})`
+      : "";
+
+  if (promptKind === "layout") {
+    return `Fill the existing selected ${target} using its selected layout${layoutReference} as the layout reference. Preserve the layout structure and update this slide; do not add another slide.`;
+  }
+
+  return `Transform the existing selected ${target} into a presentation-ready slide. Treat its Title and Subtitle placeholders as an editable brief: improve or rewrite their copy when appropriate, expand the brief into useful content, and apply an appropriate visual design or layout. Update this slide; do not add another slide.`;
+}

--- a/servers/nextjs/app/(presentation-generator)/_shared/blank-slide.ts
+++ b/servers/nextjs/app/(presentation-generator)/_shared/blank-slide.ts
@@ -19,6 +19,37 @@ export const BLANK_TEMPLATE_V2_LAYOUT = {
       fill: { color: "#FFFFFF" },
       decorative: true,
     },
+    {
+      type: "text",
+      name: "Title placeholder",
+      position: { x: 120, y: 180 },
+      size: { width: 1040, height: 100 },
+      text: "Title",
+      runs: [{ text: "Title" }],
+      font: {
+        family: "Arial",
+        size: 48,
+        color: "#191919",
+        bold: true,
+        line_height: 1.1,
+      },
+      alignment: { horizontal: "center", vertical: "middle" },
+    },
+    {
+      type: "text",
+      name: "Subtitle placeholder",
+      position: { x: 180, y: 310 },
+      size: { width: 920, height: 64 },
+      text: "Subtitle",
+      runs: [{ text: "Subtitle" }],
+      font: {
+        family: "Arial",
+        size: 24,
+        color: "#667085",
+        line_height: 1.25,
+      },
+      alignment: { horizontal: "center", vertical: "middle" },
+    },
   ],
 };
 

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/Chat.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/Chat.tsx
@@ -37,6 +37,7 @@ import {
   PRESENTON_BLANK_SLIDE_PROMPT_EVENT,
   type BlankSlidePromptEventDetail,
 } from "../../_shared/blank-slide-prompt-event";
+import { createBlankSlideAiInstruction } from "../../_shared/blank-slide-ai-instruction";
 import type {
   ChatAttachment,
   ChatConversationSummary,
@@ -2470,18 +2471,11 @@ const Chat = ({
       const prompt = typeof detail?.prompt === "string" ? detail.prompt.trim() : "";
       if (!prompt) return;
 
-      const target =
-        typeof detail.slideIndex === "number"
-          ? `slide ${detail.slideIndex + 1}`
-          : "the current blank slide";
-      const layoutReference =
-        typeof detail.layoutId === "string" && detail.layoutId.trim()
-          ? ` (layout id: ${detail.layoutId.trim()})`
-          : "";
-      const instruction =
-        detail.promptKind === "layout"
-          ? `Fill the existing selected ${target} using its selected layout${layoutReference} as the layout reference. Preserve the layout structure and update this slide; do not add another slide.`
-          : `Create content on the existing selected ${target}. Update this slide; do not add another slide.`;
+      const instruction = createBlankSlideAiInstruction({
+        slideIndex: detail.slideIndex,
+        layoutId: detail.layoutId,
+        promptKind: detail.promptKind,
+      });
       if (typeof detail.slideIndex === "number") {
         setHiddenOverlaySlideReference(detail.slideIndex);
       }

--- a/servers/nextjs/tests/blank-slide-ai-instruction.test.mjs
+++ b/servers/nextjs/tests/blank-slide-ai-instruction.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+
+import { build } from "esbuild";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function loadBlankSlideAiInstruction() {
+  const outDir = await mkdtemp(path.join(tmpdir(), "blank-slide-ai-test-"));
+  const outfile = path.join(outDir, "blank-slide-ai-instruction.mjs");
+
+  await build({
+    entryPoints: [
+      path.join(
+        projectRoot,
+        "app",
+        "(presentation-generator)",
+        "_shared",
+        "blank-slide-ai-instruction.ts",
+      ),
+    ],
+    outfile,
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    logLevel: "silent",
+  });
+
+  return import(pathToFileURL(outfile).href);
+}
+
+test("blank-slide AI instruction permits rewriting placeholder copy and applying a design", async () => {
+  const { createBlankSlideAiInstruction } = await loadBlankSlideAiInstruction();
+  const instruction = createBlankSlideAiInstruction({
+    slideIndex: 2,
+    layoutId: "template-v2:__blank_slide__",
+  });
+
+  assert.match(instruction, /slide 3/);
+  assert.match(instruction, /Title and Subtitle/i);
+  assert.match(instruction, /rewrite/i);
+  assert.match(instruction, /expand/i);
+  assert.match(instruction, /design|layout/i);
+  assert.match(instruction, /do not add another slide/i);
+});
+
+test("layout-slide AI instruction preserves the selected layout", async () => {
+  const { createBlankSlideAiInstruction } = await loadBlankSlideAiInstruction();
+  const instruction = createBlankSlideAiInstruction({
+    slideIndex: 0,
+    layoutId: "template-v2:two-column",
+    promptKind: "layout",
+  });
+
+  assert.match(instruction, /slide 1/);
+  assert.match(instruction, /two-column/);
+  assert.match(instruction, /Preserve the layout structure/i);
+  assert.match(instruction, /do not add another slide/i);
+});

--- a/servers/nextjs/tests/blank-slide-placeholders.test.mjs
+++ b/servers/nextjs/tests/blank-slide-placeholders.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+
+import { build } from "esbuild";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function loadBlankSlideFactory() {
+  const outDir = await mkdtemp(path.join(tmpdir(), "blank-slide-test-"));
+  const outfile = path.join(outDir, "blank-slide.mjs");
+
+  await build({
+    entryPoints: [
+      path.join(
+        projectRoot,
+        "app",
+        "(presentation-generator)",
+        "_shared",
+        "blank-slide.ts",
+      ),
+    ],
+    outfile,
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    logLevel: "silent",
+  });
+
+  return import(pathToFileURL(outfile).href);
+}
+
+const blankSlideFactoryPromise = loadBlankSlideFactory();
+
+test("creates editable title and subtitle placeholders for a Template V2 blank slide", async () => {
+  const { createBlankPresentationSlide } = await blankSlideFactoryPromise;
+  const slide = createBlankPresentationSlide({
+    id: "blank-v2",
+    isTemplateV2: true,
+    templateId: "template-v2",
+  });
+
+  const textElements = slide.ui.elements.filter((element) => element.type === "text");
+
+  assert.deepEqual(
+    textElements.map((element) => ({
+      text: element.text,
+      runs: element.runs,
+      position: element.position,
+      size: element.size,
+    })),
+    [
+      {
+        text: "Title",
+        runs: [{ text: "Title" }],
+        position: { x: 120, y: 180 },
+        size: { width: 1040, height: 100 },
+      },
+      {
+        text: "Subtitle",
+        runs: [{ text: "Subtitle" }],
+        position: { x: 180, y: 310 },
+        size: { width: 920, height: 64 },
+      },
+    ],
+  );
+});
+
+test("keeps Legacy/V1 blank slides unchanged", async () => {
+  const { createBlankPresentationSlide } = await blankSlideFactoryPromise;
+  const slide = createBlankPresentationSlide({ id: "blank-v1", templateId: "general" });
+
+  assert.equal(slide.ui, undefined);
+  assert.deepEqual(slide.content, {});
+});


### PR DESCRIPTION
## Summary

- start new Template V2 blank slides with editable Google Slides-style title and subtitle placeholders
- let the AI Assistant rewrite the draft copy, expand the slide content, and apply design to the current slide without adding another slide
- align package, Electron, lockfile, and desktop update-manifest versions so repository tooling can run on this PR

## Verification

- `node --test tests/blank-slide-placeholders.test.mjs tests/blank-slide-ai-instruction.test.mjs`
- Next.js `npm test` (51 passing)
- Next.js production build
- Next.js lint (0 errors; existing warnings only)
- `node --test scripts/package-metadata.test.mjs`
- root `npm test`
- root and Electron `npm ci --ignore-scripts --dry-run`
- `git diff --check`

Closes #766