### PR TITLE
fix(security): remove committed MCP token

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,12 +1,19 @@
 {
-	"servers": {
-		"presentonmcp": {
-			"url": "https://api.presenton.ai/mcp",
-			"type": "http",
-			"headers": {
-				"Authorization": "Bearer sk-presenton-374409c928ff0cd6c622152f1791eacd023d95b8"
-			}
-		}
-	},
-	"inputs": []
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "presenton-api-key",
+      "description": "Presenton MCP API key",
+      "password": true
+    }
+  ],
+  "servers": {
+    "presentonmcp": {
+      "url": "https://api.presenton.ai/mcp",
+      "type": "http",
+      "headers": {
+        "Authorization": "Bearer ${input:presenton-api-key}"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Open-source AI presentation generator",
   "scripts": {
-    "test": "npm run test:template-converter && node --test scripts/package-metadata.test.mjs",
+    "test": "npm run test:template-converter && node --test scripts/package-metadata.test.mjs scripts/mcp-config.test.mjs",
     "convert:template": "node scripts/convert-template.mjs",
     "convert:presentation-template": "node scripts/convert-presentation-template.mjs",
     "test:template-converter": "node --test scripts/convert-template.test.mjs scripts/convert-presentation-template.test.mjs",

--- a/scripts/mcp-config.test.mjs
+++ b/scripts/mcp-config.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const configPath = path.join(repoRoot, ".vscode", "mcp.json");
+
+test("workspace Presenton MCP configuration prompts for its API key", async () => {
+  const raw = await readFile(configPath, "utf8");
+  const config = JSON.parse(raw);
+  const server = config.servers?.presentonmcp;
+  const apiKeyInput = config.inputs?.find(
+    (input) => input?.id === "presenton-api-key",
+  );
+
+  assert.ok(server);
+  assert.equal(server.type, "http");
+  assert.equal(server.url, "https://api.presenton.ai/mcp");
+  assert.equal(
+    server.headers?.Authorization,
+    "Bearer ${input:presenton-api-key}",
+  );
+  assert.deepEqual(apiKeyInput, {
+    type: "promptString",
+    id: "presenton-api-key",
+    description: "Presenton MCP API key",
+    password: true,
+  });
+  assert.doesNotMatch(raw, /sk-presenton-/);
+});


### PR DESCRIPTION
## Summary

- replace the workspace MCP configuration's committed bearer credential with a VS Code password-masked input prompt
- retain the HTTP endpoint, server definition, and Authorization-header behavior
- add a repository test that rejects the credential prefix in the workspace MCP configuration

## Security note

The exposed credential must be revoked and reissued outside this repository. This PR prevents future working-tree exposure but cannot erase copied clones or historical Git objects.

## Verification

- `node --test scripts/mcp-config.test.mjs`
- JSON validation for `.vscode/mcp.json`
- confirmed no credential prefix remains in `.vscode/mcp.json`
- `git diff --check`

`npm test` remains blocked on the pre-existing package-version metadata mismatch in `main`; tracked separately in #770.

Closes #769