### PR TITLE
fix(ci): align package metadata versions

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presenton",
-  "version": "0.9.0-beta",
+  "version": "0.9.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presenton",
-      "version": "0.9.0-beta",
+      "version": "0.9.1-beta",
       "hasInstallScript": true,
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.2",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "presenton",
   "productName": "Presenton Open Source",
-  "version": "0.9.0-beta",
+  "version": "0.9.1-beta",
   "exportVersion": "v0.4.2",
   "exportChromiumBuildId": "149.0.7827.196",
   "exportMacChromiumBuildIds": {

--- a/electron/version.json
+++ b/electron/version.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.9.0-beta",
+  "version": "0.9.1-beta",
   "message": "Presenton Desktop electron-v0.8.9-beta\n\nA polished 0.8.9-beta release with lots of improvements across the Electron app.\n\nWhat's New\n\n• Faster, more reliable exports with Chromium export support\n• Better image editing with stock search and OpenAI-compatible generation\n• Improved AI model support, including LiteLLM, Azure, Vertex, and ComfyUI seeds\n• Cleaner editing workflows, markdown rendering, and slide management\n• Updated templates, Chart.js migration, and multilingual UI improvements\n• Stability fixes for packaging, onboarding, layouts, fonts, and exports\n\nInstallation\nDownload Link: https://presenton.ai/download\nLove the app? Star us on GitHub → github.com/presenton/presenton",
   "downloads": {
-    "linux": "https://github.com/presenton/presenton/releases/download/electron-v0.9.0-beta/Presenton-0.9.0-beta.deb",
-    "mac": "https://github.com/presenton/presenton/releases/download/electron-v0.9.0-beta/Presenton-0.9.0-beta.dmg",
-    "windows": "https://github.com/presenton/presenton/releases/download/electron-v0.9.0-beta/Presenton-0.9.0-beta.exe"
+    "linux": "https://github.com/presenton/presenton/releases/download/electron-v0.9.1-beta/Presenton-0.9.1-beta.deb",
+    "mac": "https://github.com/presenton/presenton/releases/download/electron-v0.9.1-beta/Presenton-0.9.1-beta.dmg",
+    "windows": "https://github.com/presenton/presenton/releases/download/electron-v0.9.1-beta/Presenton-0.9.1-beta.exe"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presenton",
-  "version": "0.9.0-beta",
+  "version": "0.9.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presenton",
-      "version": "0.9.0-beta",
+      "version": "0.9.1-beta",
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.2",
         "sharp": "^0.34.5"

--- a/scripts/package-metadata.test.mjs
+++ b/scripts/package-metadata.test.mjs
@@ -13,21 +13,38 @@ async function readJson(relativePath) {
   return JSON.parse(await readFile(path.join(repoRoot, relativePath), "utf8"));
 }
 
-test("application versions stay aligned", async () => {
-  const [rootPackage, rootLock, electronPackage, electronLock] =
-    await Promise.all([
-      readJson("package.json"),
-      readJson("package-lock.json"),
-      readJson("electron/package.json"),
-      readJson("electron/package-lock.json"),
-    ]);
+test("application versions and desktop update metadata stay aligned", async () => {
+  const [
+    rootPackage,
+    rootLock,
+    electronPackage,
+    electronLock,
+    electronVersion,
+  ] = await Promise.all([
+    readJson("package.json"),
+    readJson("package-lock.json"),
+    readJson("electron/package.json"),
+    readJson("electron/package-lock.json"),
+    readJson("electron/version.json"),
+  ]);
 
-  assert.equal(rootPackage.version, "0.9.0-beta");
+  assert.match(rootPackage.version, /^\d+\.\d+\.\d+-beta$/);
   assert.equal(electronPackage.version, rootPackage.version);
   assert.equal(rootLock.version, rootPackage.version);
   assert.equal(rootLock.packages[""].version, rootPackage.version);
   assert.equal(electronLock.version, electronPackage.version);
   assert.equal(electronLock.packages[""].version, electronPackage.version);
+  assert.equal(electronVersion.version, electronPackage.version);
+  for (const [platform, extension] of Object.entries({
+    linux: "deb",
+    mac: "dmg",
+    windows: "exe",
+  })) {
+    assert.equal(
+      electronVersion.downloads[platform],
+      `https://github.com/presenton/presenton/releases/download/electron-v${electronPackage.version}/Presenton-${electronPackage.version}.${extension}`,
+    );
+  }
 });
 
 test("Docker and Electron use the same pinned presentation export", async () => {


### PR DESCRIPTION
## Summary

- align root and Electron package/lockfile metadata with the current root application version
- replace the brittle fixed-version assertion with beta-semver validation plus cross-file equality checks
- leave dependency resolutions and the presentation-export pin unchanged

## Verification

- `node --test scripts/package-metadata.test.mjs`
- `npm test`
- `npm ci --ignore-scripts --dry-run` at repository root
- `npm ci --ignore-scripts --dry-run` in `electron/`
- `git diff --check`

Closes #770