### PR TITLE
updated: fixed the streaming SSE stopping issue

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/outlines.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/outlines.py
@@ -4,7 +4,7 @@ import logging
 import traceback
 import uuid
 import dirtyjson
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -83,7 +83,9 @@ async def update_outline(
 
 @OUTLINES_ROUTER.get("/stream/{id}")
 async def stream_outlines(
-    id: uuid.UUID, sql_session: AsyncSession = Depends(get_async_session)
+    id: uuid.UUID,
+    request: Request,
+    sql_session: AsyncSession = Depends(get_async_session),
 ):
     presentation = await sql_session.get(PresentationModel, id)
 
@@ -108,6 +110,9 @@ async def stream_outlines(
     temp_dir = TEMP_FILE_SERVICE.create_temp_dir()
 
     async def inner():
+        if await request.is_disconnected():
+            return
+
         yield SSEStatusResponse(
             status="Preparing your presentation outline"
         ).to_string()
@@ -174,6 +179,7 @@ async def stream_outlines(
             presentation.web_search,
             presentation.include_table_of_contents,
             emit_statuses=True,
+            disconnect_checker=request.is_disconnected,
         ):
             # Give control to the event loop
             await asyncio.sleep(0)

--- a/servers/fastapi/api/v1/ppt/endpoints/presentation.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/presentation.py
@@ -1915,9 +1915,23 @@ async def generate_presentation_handler(
     presentation_id: uuid.UUID,
     async_status: Optional[AsyncTaskModel],
     export_cookie_header: Optional[str] = None,
+    request_http: Optional[Request] = None,
     sql_session: AsyncSession = Depends(get_async_session),
 ):
     try:
+        disconnect_checker = (
+            request_http.is_disconnected if request_http is not None else None
+        )
+
+        async def raise_if_client_disconnected() -> None:
+            if disconnect_checker and await disconnect_checker():
+                logger.info(
+                    "[presentation.generate] client disconnected presentation_id=%s",
+                    presentation_id,
+                )
+                raise asyncio.CancelledError
+
+        await raise_if_client_disconnected()
         using_slides_markdown = False
         language_to_use = (request.language or "").strip() or None
         additional_context = ""
@@ -2004,6 +2018,7 @@ async def generate_presentation_handler(
                 request.include_title_slide,
                 request.web_search,
                 request.include_table_of_contents,
+                disconnect_checker=disconnect_checker,
             ):
 
                 if isinstance(chunk, HTTPException):
@@ -2106,6 +2121,7 @@ async def generate_presentation_handler(
                     instructions=request.instructions,
                     using_slides_markdown=using_slides_markdown,
                     source_content=request.content,
+                    disconnect_checker=disconnect_checker,
                 )
             )
 
@@ -2189,6 +2205,7 @@ async def generate_presentation_handler(
         # Schedule slide content generation and asset fetching in batches of 10
         batch_size = 10
         for start in range(0, len(slide_layouts), batch_size):
+            await raise_if_client_disconnected()
             end = min(start + batch_size, len(slide_layouts))
 
             print(f"Generating slides from {start} to {end}")
@@ -2202,6 +2219,7 @@ async def generate_presentation_handler(
                     request.tone.value,
                     request.verbosity.value,
                     request.instructions,
+                    disconnect_checker=disconnect_checker,
                 )
                 for i in range(start, end)
             ]
@@ -2366,6 +2384,7 @@ async def generate_presentation_sync(
             presentation_id,
             None,
             export_cookie_header=_build_export_cookie_header(request_http),
+            request_http=request_http,
             sql_session=sql_session,
         )
     except HTTPException:

--- a/servers/fastapi/tests/test_presentation_generation_api.py
+++ b/servers/fastapi/tests/test_presentation_generation_api.py
@@ -64,6 +64,7 @@ class TestPresentationGenerationAPI:
             path="/tmp/exports/test.pdf",
             edit_path="/presentation?id=test",
         )
+        request_http = FakeRequest()
 
         with patch(
             "api.v1.ppt.endpoints.presentation.generate_presentation_handler",
@@ -71,7 +72,7 @@ class TestPresentationGenerationAPI:
         ) as mock_handler:
             response = asyncio.run(
                 generate_presentation_sync(
-                    request_http=FakeRequest(),
+                    request_http=request_http,
                     request=request,
                     sql_session=FakeAsyncSession(),
                 )
@@ -79,6 +80,7 @@ class TestPresentationGenerationAPI:
 
         assert response == response_payload
         mock_handler.assert_awaited_once()
+        assert mock_handler.await_args.kwargs["request_http"] is request_http
 
     def test_generate_presentation_export_as_pptx(self):
         request = GeneratePresentationRequest(

--- a/servers/fastapi/tests/unit/test_generate_presentation_outlines.py
+++ b/servers/fastapi/tests/unit/test_generate_presentation_outlines.py
@@ -109,6 +109,9 @@ def test_generate_ppt_outline_default_openai_uses_native_search_tool(monkeypatch
     captured_kwargs = {}
     captured_config_kwargs = {}
 
+    async def is_disconnected():
+        return False
+
     async def fake_stream_generate_events(_client, **kwargs):
         captured_kwargs.update(kwargs)
         yield content_event('{"slides": [{"content": "## Current facts"}]}')
@@ -139,12 +142,14 @@ def test_generate_ppt_outline_default_openai_uses_native_search_tool(monkeypatch
                 n_slides=1,
                 language="English",
                 web_search=True,
+                disconnect_checker=is_disconnected,
             )
         )
 
     assert captured_config_kwargs == {"use_openai_responses_api": True}
     assert len(captured_kwargs["tools"]) == 1
     assert isinstance(captured_kwargs["tools"][0], WebSearchTool)
+    assert captured_kwargs["disconnect_checker"] is is_disconnected
 
 
 def test_generate_ppt_outline_streams_json_chunks_and_keeps_schema_shape():

--- a/servers/fastapi/tests/unit/test_llm_utils_disconnect.py
+++ b/servers/fastapi/tests/unit/test_llm_utils_disconnect.py
@@ -1,0 +1,163 @@
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from llmai.shared import ResponseStreamCompletionChunk, ResponseStreamContentChunk
+
+from utils.llm_utils import generate_structured_with_schema_retries
+
+
+class RetryClient:
+    def __init__(self):
+        self.calls = []
+        self.responses = [None, {"result": "ok"}]
+
+    def generate(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(content=self.responses.pop(0))
+
+
+class StreamingClient:
+    def __init__(self):
+        self.calls = []
+        self.started = threading.Event()
+        self.closed = threading.Event()
+
+    def generate(self, **kwargs):
+        self.calls.append(kwargs)
+
+        def events():
+            try:
+                while True:
+                    self.started.set()
+                    time.sleep(0.01)
+                    yield ResponseStreamContentChunk(chunk='{"result":"pending"}')
+            finally:
+                self.closed.set()
+
+        return events()
+
+
+def test_regular_generation_keeps_existing_retry_behavior(monkeypatch):
+    monkeypatch.setenv("LLM", "ollama")
+    client = RetryClient()
+
+    with patch("utils.llm_utils.asyncio.sleep", new=AsyncMock()):
+        result = asyncio.run(
+            generate_structured_with_schema_retries(
+                client,
+                "test-model",
+                messages=[],
+                response_format=object(),
+                json_schema={},
+            )
+        )
+
+    assert result == {"result": "ok"}
+    assert len(client.calls) == 2
+    assert all(call["stream"] is False for call in client.calls)
+
+
+def test_disconnect_cancels_generation_without_retrying(monkeypatch):
+    monkeypatch.setenv("LLM", "ollama")
+    client = StreamingClient()
+
+    async def run():
+        async def is_disconnected():
+            return client.started.is_set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await generate_structured_with_schema_retries(
+                client,
+                "test-model",
+                messages=[],
+                response_format=object(),
+                json_schema={},
+                disconnect_checker=is_disconnected,
+            )
+
+        while not client.closed.is_set():
+            await asyncio.sleep(0.001)
+
+    asyncio.run(run())
+
+    assert len(client.calls) == 1
+    assert client.calls[0]["stream"] is True
+
+
+def test_connected_request_uses_stream_completion_content(monkeypatch):
+    monkeypatch.setenv("LLM", "ollama")
+
+    class CompletedClient:
+        def __init__(self):
+            self.calls = []
+
+        def generate(self, **kwargs):
+            self.calls.append(kwargs)
+            return iter(
+                [
+                    ResponseStreamCompletionChunk(
+                        content={"result": "complete"}
+                    )
+                ]
+            )
+
+    client = CompletedClient()
+
+    async def run():
+        async def is_disconnected():
+            return False
+
+        return await generate_structured_with_schema_retries(
+            client,
+            "test-model",
+            messages=[],
+            response_format=object(),
+            json_schema={},
+            disconnect_checker=is_disconnected,
+        )
+
+    assert asyncio.run(run()) == {"result": "complete"}
+    assert client.calls[0]["stream"] is True
+
+
+def test_connected_request_keeps_schema_validation_retries(monkeypatch):
+    monkeypatch.setenv("LLM", "ollama")
+
+    class ValidationRetryClient:
+        def __init__(self):
+            self.calls = []
+            self.responses = [{"wrong": "value"}, {"result": "fixed"}]
+
+        def generate(self, **kwargs):
+            self.calls.append(kwargs)
+            return iter(
+                [ResponseStreamCompletionChunk(content=self.responses.pop(0))]
+            )
+
+    client = ValidationRetryClient()
+
+    async def run():
+        async def is_disconnected():
+            return False
+
+        return await generate_structured_with_schema_retries(
+            client,
+            "test-model",
+            messages=[],
+            response_format=object(),
+            json_schema={
+                "type": "object",
+                "properties": {"result": {"type": "string"}},
+                "required": ["result"],
+            },
+            validate_schema=True,
+            disconnect_checker=is_disconnected,
+        )
+
+    assert asyncio.run(run()) == {"result": "fixed"}
+    assert len(client.calls) == 2
+    assert all(call["stream"] is True for call in client.calls)

--- a/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
+++ b/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
@@ -21,6 +21,7 @@ from utils.llm_client_error_handler import handle_llm_client_exceptions
 from utils.llm_config import get_llm_config
 from utils.llm_provider import get_model
 from utils.llm_utils import (
+    DisconnectChecker,
     get_generate_kwargs,
     serialize_structured_content,
     stream_generate_events,
@@ -250,6 +251,7 @@ async def generate_ppt_outline(
     web_search: bool = False,
     include_table_of_contents: bool = False,
     emit_statuses: bool = False,
+    disconnect_checker: Optional[DisconnectChecker] = None,
 ):
     model = get_model()
     response_model = (
@@ -309,6 +311,7 @@ async def generate_ppt_outline(
                 model,
                 content,
                 instructions,
+                disconnect_checker=disconnect_checker,
             )
             if generated_query:
                 search_query = generated_query
@@ -358,6 +361,7 @@ async def generate_ppt_outline(
         emitted_content = False
         async for event in stream_generate_events(
             client,
+            disconnect_checker=disconnect_checker,
             **get_generate_kwargs(
                 model=model,
                 messages=get_messages(

--- a/servers/fastapi/utils/llm_calls/generate_presentation_structure.py
+++ b/servers/fastapi/utils/llm_calls/generate_presentation_structure.py
@@ -6,7 +6,7 @@ from models.presentation_layout import PresentationLayoutModel
 from models.presentation_outline_model import PresentationOutlineModel
 from utils.llm_config import get_llm_config
 from utils.llm_client_error_handler import handle_llm_client_exceptions
-from utils.llm_utils import generate_structured_with_schema_retries
+from utils.llm_utils import DisconnectChecker, generate_structured_with_schema_retries
 from utils.llm_provider import get_model
 from utils.get_dynamic_models import get_presentation_structure_model_with_n_slides
 from utils.schema_utils import prepare_schema_for_validation
@@ -160,6 +160,7 @@ async def generate_presentation_structure(
     instructions: Optional[str] = None,
     using_slides_markdown: bool = False,
     source_content: Optional[str] = None,
+    disconnect_checker: Optional[DisconnectChecker] = None,
 ) -> PresentationStructureModel:
     client = get_client(config=get_llm_config())
     model = get_model()
@@ -203,6 +204,7 @@ async def generate_presentation_structure(
             json_schema=structure_schema,
             strict=False,
             validate_schema=True,
+            disconnect_checker=disconnect_checker,
         )
         return PresentationStructureModel(**content)
     except Exception as e:

--- a/servers/fastapi/utils/llm_calls/generate_slide_content.py
+++ b/servers/fastapi/utils/llm_calls/generate_slide_content.py
@@ -10,7 +10,7 @@ from models.presentation_outline_model import SlideOutlineModel
 from utils.llm_client_error_handler import handle_llm_client_exceptions
 from utils.llm_config import get_llm_config
 from utils.llm_provider import get_model
-from utils.llm_utils import generate_structured_with_schema_retries
+from utils.llm_utils import DisconnectChecker, generate_structured_with_schema_retries
 from utils.schema_utils import (
     add_field_in_schema,
     ensure_array_schemas_have_items,
@@ -214,6 +214,7 @@ async def get_slide_content_from_type_and_outline(
     tone: Optional[str] = None,
     verbosity: Optional[str] = None,
     instructions: Optional[str] = None,
+    disconnect_checker: Optional[DisconnectChecker] = None,
 ):
     response_schema = _prepare_response_schema(slide_layout.json_schema)
     if response_schema is None:
@@ -245,6 +246,7 @@ async def get_slide_content_from_type_and_outline(
             json_schema=response_schema,
             strict=False,
             validate_schema=True,
+            disconnect_checker=disconnect_checker,
         )
 
     except Exception as e:

--- a/servers/fastapi/utils/llm_calls/generate_web_search_query.py
+++ b/servers/fastapi/utils/llm_calls/generate_web_search_query.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 from llmai.shared import JSONSchemaResponse, SystemMessage, UserMessage
 
-from utils.llm_utils import generate_structured_with_schema_retries
+from utils.llm_utils import DisconnectChecker, generate_structured_with_schema_retries
 
 SEARCH_QUERY_GENERATION_PROMPT = """
 Generate a concise web search query that finds useful factual context for a presentation.
@@ -41,6 +41,7 @@ async def generate_web_search_query(
     model: str,
     content: str,
     instructions: Optional[str] = None,
+    disconnect_checker: Optional[DisconnectChecker] = None,
 ) -> Optional[str]:
     response_format = JSONSchemaResponse(
         name="web_search_query",
@@ -64,6 +65,7 @@ async def generate_web_search_query(
         json_schema=SEARCH_QUERY_RESPONSE_SCHEMA,
         strict=False,
         validate_schema=True,
+        disconnect_checker=disconnect_checker,
     )
     query = response.get("query")
     if not isinstance(query, str):

--- a/servers/fastapi/utils/llm_utils.py
+++ b/servers/fastapi/utils/llm_utils.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 import logging
-from collections.abc import AsyncGenerator, Sequence
+import threading
+from collections.abc import AsyncGenerator, Awaitable, Callable, Sequence
 from typing import Any, Optional
 
 import dirtyjson
@@ -10,6 +11,7 @@ from llmai.shared import (
     LLMTool,
     Message,
     ResponseFormat,
+    ResponseStreamCompletionChunk,
     UserMessage,
     normalize_content_parts,
 )
@@ -19,6 +21,45 @@ from utils.schema_utils import get_schema_validation_errors
 
 
 LOGGER = logging.getLogger(__name__)
+CLIENT_DISCONNECT_POLL_SECONDS = 0.1
+DisconnectChecker = Callable[[], Awaitable[bool]]
+
+
+async def _raise_if_client_disconnected(
+    disconnect_checker: Optional[DisconnectChecker],
+) -> None:
+    if disconnect_checker and await disconnect_checker():
+        raise asyncio.CancelledError
+
+
+async def _generate_structured_content(
+    client: Any,
+    *,
+    disconnect_checker: Optional[DisconnectChecker],
+    **kwargs: Any,
+) -> Optional[dict]:
+    if disconnect_checker is None:
+        response = await asyncio.to_thread(client.generate, **kwargs)
+        return extract_structured_content(response.content)
+
+    completion_content: Any = None
+    streamed_text: list[str] = []
+    async for event in stream_generate_events(
+        client,
+        disconnect_checker=disconnect_checker,
+        **{**kwargs, "stream": True},
+    ):
+        if isinstance(event, ResponseStreamCompletionChunk):
+            completion_content = event.content
+        elif getattr(event, "type", None) == "content":
+            chunk = getattr(event, "chunk", None)
+            if isinstance(chunk, str):
+                streamed_text.append(chunk)
+
+    content = extract_structured_content(completion_content)
+    if content is not None:
+        return content
+    return extract_structured_content("".join(streamed_text))
 
 
 def get_generate_kwargs(
@@ -92,6 +133,7 @@ async def generate_structured_with_schema_retries(
     strict: bool = False,
     validate_schema: bool = False,
     validate_schema_max_loop_count: int = 4,
+    disconnect_checker: Optional[DisconnectChecker] = None,
 ) -> dict:
     """
     Parse retries (inner loop) plus optional JSON Schema validation feedback loops (outer loop),
@@ -103,15 +145,16 @@ async def generate_structured_with_schema_retries(
     for validation_attempt in range(max_validation_loops):
         content: Optional[dict] = None
         for attempt in range(3):
-            response = await asyncio.to_thread(
-                client.generate,
+            await _raise_if_client_disconnected(disconnect_checker)
+            content = await _generate_structured_content(
+                client,
+                disconnect_checker=disconnect_checker,
                 **get_generate_kwargs(
                     model=model,
                     messages=working_messages,
                     response_format=response_format,
                 ),
             )
-            content = extract_structured_content(response.content)
             if content is not None:
                 break
             if attempt < 2:
@@ -222,28 +265,81 @@ def message_content_to_text(content: Sequence[Any] | str | None) -> Optional[str
     return joined or None
 
 
-async def stream_generate_events(client: Any, **kwargs) -> AsyncGenerator[Any, None]:
+async def stream_generate_events(
+    client: Any,
+    *,
+    disconnect_checker: Optional[DisconnectChecker] = None,
+    **kwargs,
+) -> AsyncGenerator[Any, None]:
     loop = asyncio.get_running_loop()
     queue: asyncio.Queue[Any] = asyncio.Queue()
     sentinel = object()
+    stop_requested = threading.Event()
+
+    def enqueue(item: Any) -> None:
+        try:
+            loop.call_soon_threadsafe(queue.put_nowait, item)
+        except RuntimeError:
+            pass
 
     def worker():
+        events = None
         try:
-            for event in client.generate(**kwargs):
-                loop.call_soon_threadsafe(queue.put_nowait, event)
+            events = iter(client.generate(**kwargs))
+            while not stop_requested.is_set():
+                try:
+                    event = next(events)
+                except StopIteration:
+                    break
+                if stop_requested.is_set():
+                    break
+                enqueue(event)
         except Exception as exc:
-            loop.call_soon_threadsafe(queue.put_nowait, exc)
+            if not stop_requested.is_set():
+                enqueue(exc)
         finally:
-            loop.call_soon_threadsafe(queue.put_nowait, sentinel)
+            if stop_requested.is_set() and events is not None:
+                close = getattr(events, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except Exception:
+                        LOGGER.debug(
+                            "Failed to close cancelled LLM stream",
+                            exc_info=True,
+                        )
+            enqueue(sentinel)
 
     worker_task = asyncio.create_task(asyncio.to_thread(worker))
+    completed = False
     try:
         while True:
-            item = await queue.get()
+            await _raise_if_client_disconnected(disconnect_checker)
+            try:
+                item = await asyncio.wait_for(
+                    queue.get(),
+                    timeout=(
+                        CLIENT_DISCONNECT_POLL_SECONDS
+                        if disconnect_checker
+                        else None
+                    ),
+                )
+            except asyncio.TimeoutError:
+                continue
             if item is sentinel:
+                completed = True
                 break
             if isinstance(item, Exception):
                 raise item
             yield item
+    except asyncio.CancelledError:
+        LOGGER.info("LLM stream cancelled because the client disconnected")
+        raise
     finally:
-        await worker_task
+        stop_requested.set()
+        if completed or worker_task.done():
+            await worker_task
+        else:
+            worker_task.add_done_callback(
+                lambda task: None if task.cancelled() else task.exception()
+            )


### PR DESCRIPTION
This pull request introduces robust client disconnect handling to the presentation generation and outline streaming endpoints, ensuring that long-running tasks are cancelled promptly if the client disconnects. It also propagates disconnect awareness throughout the LLM utility and orchestration layers, and adds comprehensive tests for these behaviors.

**Disconnect handling and propagation:**

* All relevant FastAPI endpoints (`stream_outlines`, `generate_presentation_handler`, and related sync wrappers) now check for client disconnects using the `Request.is_disconnected()` method and pass a `disconnect_checker` down to LLM utility functions. This allows for early cancellation of tasks when the client disconnects. [[1]](diffhunk://#diff-cd84161668d7cc95ecfb91f226dcd2f8efd68964307addd09689eccf644f887fL86-R88) [[2]](diffhunk://#diff-cd84161668d7cc95ecfb91f226dcd2f8efd68964307addd09689eccf644f887fR113-R115) [[3]](diffhunk://#diff-cd84161668d7cc95ecfb91f226dcd2f8efd68964307addd09689eccf644f887fR182) [[4]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R1918-R1934) [[5]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R2021) [[6]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R2124) [[7]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R2208) [[8]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R2222) [[9]](diffhunk://#diff-336a0f48820689436371bdc10deb27a883c3ce58d83e2b631785da4f3d1b7067R2387)

* The LLM orchestration layer (`generate_ppt_outline`, `generate_presentation_structure`, `get_slide_content_from_type_and_outline`, `generate_web_search_query`) and their utility wrappers now accept and propagate an optional `disconnect_checker` parameter, ensuring that all LLM calls can be cancelled if the client disconnects. [[1]](diffhunk://#diff-b9735d86dfb452d5a68928a368f4f9ecc2aba8739b3adaf35d9233691ed8bb11R24) [[2]](diffhunk://#diff-b9735d86dfb452d5a68928a368f4f9ecc2aba8739b3adaf35d9233691ed8bb11R254) [[3]](diffhunk://#diff-b9735d86dfb452d5a68928a368f4f9ecc2aba8739b3adaf35d9233691ed8bb11R314) [[4]](diffhunk://#diff-b9735d86dfb452d5a68928a368f4f9ecc2aba8739b3adaf35d9233691ed8bb11R364) [[5]](diffhunk://#diff-7737d929eb54756a1900075413dbc2e520978d455e8e8944382d16a92f427e84L9-R9) [[6]](diffhunk://#diff-7737d929eb54756a1900075413dbc2e520978d455e8e8944382d16a92f427e84R163) [[7]](diffhunk://#diff-7737d929eb54756a1900075413dbc2e520978d455e8e8944382d16a92f427e84R207) [[8]](diffhunk://#diff-86666bcb6a00b5f7c5abdfd278066cea6b8ccc7539549fb95fc29a79e2d5e0c3L13-R13) [[9]](diffhunk://#diff-86666bcb6a00b5f7c5abdfd278066cea6b8ccc7539549fb95fc29a79e2d5e0c3R217) [[10]](diffhunk://#diff-86666bcb6a00b5f7c5abdfd278066cea6b8ccc7539549fb95fc29a79e2d5e0c3R249) [[11]](diffhunk://#diff-bce1f8b940a47a7808c00c11bfea82552ef7b581cfd0a9c9016bd15593bec791L6-R6) [[12]](diffhunk://#diff-bce1f8b940a47a7808c00c11bfea82552ef7b581cfd0a9c9016bd15593bec791R44) [[13]](diffhunk://#diff-bce1f8b940a47a7808c00c11bfea82552ef7b581cfd0a9c9016bd15593bec791R68)

**Testing and validation:**

* New and updated tests verify that disconnect handling works as expected, including ensuring that generation is cancelled without retries on disconnect, and that the disconnect checker is passed through all layers. [[1]](diffhunk://#diff-030232af7843e063d57819679a8d8353a2609b17bef5f8966a6a4861758a7918R1-R163) [[2]](diffhunk://#diff-2e1b1eaf9c704e051c2989327144a793aa094cea6527ac4eba650c769b1c53b3R67-R83) [[3]](diffhunk://#diff-d5bf155328ca0b1d9bfe4c8a3423303372d83a30e84d3659b23d446c67bd4271R112-R114) [[4]](diffhunk://#diff-d5bf155328ca0b1d9bfe4c8a3423303372d83a30e84d3659b23d446c67bd4271R145-R152)

**Internal refactoring:**

* Minor imports and type annotations have been updated to support the new `disconnect_checker` parameter and improve type safety.

These changes improve reliability and resource management for long-running streaming and generation tasks by ensuring they are responsive to client disconnects.