### PR TITLE
Normalize content image fills and bump Electron beta version

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presenton",
-  "version": "0.9.2-beta",
+  "version": "0.9.3-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presenton",
-      "version": "0.9.2-beta",
+      "version": "0.9.3-beta",
       "hasInstallScript": true,
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.2",

--- a/electron/version.json
+++ b/electron/version.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.9.2-beta",
+  "version": "0.9.3-beta",
   "message": "Presenton Desktop electron-v0.8.9-beta\n\nA polished 0.8.9-beta release with lots of improvements across the Electron app.\n\nWhat's New\n\n• Faster, more reliable exports with Chromium export support\n• Better image editing with stock search and OpenAI-compatible generation\n• Improved AI model support, including LiteLLM, Azure, Vertex, and ComfyUI seeds\n• Cleaner editing workflows, markdown rendering, and slide management\n• Updated templates, Chart.js migration, and multilingual UI improvements\n• Stability fixes for packaging, onboarding, layouts, fonts, and exports\n\nInstallation\nDownload Link: https://presenton.ai/download\nLove the app? Star us on GitHub → github.com/presenton/presenton",
   "downloads": {
-    "linux": "https://github.com/presenton/presenton/releases/download/electron-v0.9.2-beta/Presenton-0.9.2-beta.deb",
-    "mac": "https://github.com/presenton/presenton/releases/download/electron-v0.9.2-beta/Presenton-0.9.2-beta.dmg",
-    "windows": "https://github.com/presenton/presenton/releases/download/electron-v0.9.2-beta/Presenton-0.9.2-beta.exe"
+    "linux": "https://github.com/presenton/presenton/releases/download/electron-v0.9.3-beta/Presenton-0.9.3-beta.deb",
+    "mac": "https://github.com/presenton/presenton/releases/download/electron-v0.9.3-beta/Presenton-0.9.3-beta.dmg",
+    "windows": "https://github.com/presenton/presenton/releases/download/electron-v0.9.3-beta/Presenton-0.9.3-beta.exe"
   }
 }

--- a/servers/fastapi/services/chat/slide_ui_helpers.py
+++ b/servers/fastapi/services/chat/slide_ui_helpers.py
@@ -383,7 +383,7 @@ def _normalize_generated_image_fit(
     element: dict[str, Any],
     asset_url: str | None,
 ) -> None:
-    if element.get("is_icon") is True or element.get("fit") != "fill":
+    if element.get("is_icon") is True or element.get("fit") == "cover":
         return
     if _has_image_clip_path(element):
         return

--- a/servers/fastapi/templates/v2/generation.py
+++ b/servers/fastapi/templates/v2/generation.py
@@ -34,6 +34,7 @@ from templates.v2.models.layouts import (
     SlideLayouts,
 )
 from templates.v2.models.elements import Image as SlideImageElement
+from templates.v2.models.elements import ImageFit
 from templates.v2.tools import PREVIEW_SLIDE_TOOL_NAME, PreviewSlideTool
 from utils.asset_directory_utils import resolve_image_path_to_filesystem
 from utils.llm_config import get_llm_config
@@ -984,6 +985,8 @@ def _replace_content_image_url_in_element(element: Any) -> None:
             if element.is_icon
             else CONTENT_IMAGE_PLACEHOLDER_URL
         )
+        if not element.is_icon and element.fit != ImageFit.COVER:
+            element.fit = ImageFit.COVER
 
     child = getattr(element, "child", None)
     if child is not None:

--- a/servers/fastapi/tests/unit/test_presentation_template_v2_ui.py
+++ b/servers/fastapi/tests/unit/test_presentation_template_v2_ui.py
@@ -865,6 +865,43 @@ def test_chat_template_image_content_stores_prompt():
     assert image["fit"] == "cover"
     assert image["prompt"] == "Analytics dashboard"
 
+    contained_image = {
+        "type": "image",
+        "decorative": False,
+        "name": "contained_image",
+        "data": "/old-contained-image.png",
+        "fit": "contain",
+        "is_icon": False,
+    }
+    PresentationChatMemoryLayer._set_template_element_value(
+        contained_image,
+        {
+            "image_prompt": "Product team planning",
+            "image_url": "/app_data/images/planning.png",
+        },
+    )
+
+    assert contained_image["data"] == "/app_data/images/planning.png"
+    assert contained_image["fit"] == "cover"
+
+    default_fit_image = {
+        "type": "image",
+        "decorative": False,
+        "name": "default_fit_image",
+        "data": "/old-default-image.png",
+        "is_icon": False,
+    }
+    PresentationChatMemoryLayer._set_template_element_value(
+        default_fit_image,
+        {
+            "image_prompt": "Customer success dashboard",
+            "image_url": "/app_data/images/customer-success.png",
+        },
+    )
+
+    assert default_fit_image["data"] == "/app_data/images/customer-success.png"
+    assert default_fit_image["fit"] == "cover"
+
     icon = {
         "type": "image",
         "decorative": False,
@@ -939,6 +976,14 @@ def test_apply_template_image_content_avoids_stretching_generated_photos():
                     {
                         "type": "image",
                         "decorative": False,
+                        "name": "contained_image",
+                        "data": "/static/images/replaceable_template_image.png",
+                        "fit": "contain",
+                        "is_icon": False,
+                    },
+                    {
+                        "type": "image",
+                        "decorative": False,
                         "name": "vector_image",
                         "data": "/static/images/replaceable_template_image.svg",
                         "fit": "fill",
@@ -965,6 +1010,9 @@ def test_apply_template_image_content_avoids_stretching_generated_photos():
                 "hero_image": {
                     "image_url": "/app_data/images/dashboard.png",
                 },
+                "contained_image": {
+                    "image_url": "/app_data/images/product.png",
+                },
                 "vector_image": {
                     "image_url": "/app_data/images/diagram.svg",
                 },
@@ -975,9 +1023,13 @@ def test_apply_template_image_content_avoids_stretching_generated_photos():
         },
     )
 
-    hero_image, vector_image, clipped_image = hydrated["components"][0]["elements"]
+    hero_image, contained_image, vector_image, clipped_image = hydrated["components"][
+        0
+    ]["elements"]
     assert hero_image["data"] == "/app_data/images/dashboard.png"
     assert hero_image["fit"] == "cover"
+    assert contained_image["data"] == "/app_data/images/product.png"
+    assert contained_image["fit"] == "cover"
     assert vector_image["data"] == "/app_data/images/diagram.svg"
     assert vector_image["fit"] == "fill"
     assert clipped_image["data"] == "/app_data/images/freeform.png"

--- a/servers/fastapi/tests/unit/test_templates_v2_generation.py
+++ b/servers/fastapi/tests/unit/test_templates_v2_generation.py
@@ -324,11 +324,13 @@ def test_generate_slide_layout_replaces_content_image_urls(monkeypatch):
 
     elements = result.model_dump(mode="json")["components"][0]["elements"]
     assert elements[0]["data"] == CONTENT_IMAGE_PLACEHOLDER_URL
+    assert elements[0]["fit"] == "cover"
     assert elements[0]["prompt"] == "Team reviewing dashboard"
     assert elements[1]["data"] == CONTENT_ICON_PLACEHOLDER_URL
     assert elements[1]["prompt"] == "growth chart"
     assert elements[2]["data"] == "/app_data/images/logo.png"
     assert elements[3]["children"][0]["data"] == CONTENT_IMAGE_PLACEHOLDER_URL
+    assert elements[3]["children"][0]["fit"] == "cover"
 
 
 def test_generate_slide_layout_passes_max_tokens_when_provided(monkeypatch):

--- a/servers/nextjs/next-env.d.ts
+++ b/servers/nextjs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next-build/dev/types/routes.d.ts";
+import "./.next-build/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- Force non-icon content images to use `cover` to prevent stretching.
- Preserve icons, SVGs, and clipped images without changing their fit behavior.
- Add regression coverage for contained and default-fit content images.
- Bump the Electron beta version from `0.9.2-beta` to `0.9.3-beta`.
- Update the Next.js generated route types reference.

## Testing

- Added and updated unit tests covering content image replacement and fit normalization.