### PR TITLE
fix: cap font uploads and clean up failed font writes

### DIFF
--- a/servers/fastapi/templates/fonts_and_slides_preview.py
+++ b/servers/fastapi/templates/fonts_and_slides_preview.py
@@ -46,6 +46,8 @@ from utils.font_uploads import (
     get_font_upload_url,
     get_font_uploads_for_names_by_variant,
     persist_font_file,
+    read_upload_with_size_limit,
+    safe_font_filename,
 )
 
 
@@ -1719,10 +1721,12 @@ async def _save_uploaded_fonts_to_temp(
     for i, (font_file, original_name) in enumerate(
         zip(font_files, original_font_names)
     ):
-        font_filename = getattr(font_file, "filename", f"font_{i}")
+        font_filename = safe_font_filename(
+            getattr(font_file, "filename", None) or f"font_{i}.ttf"
+        )
         font_path = os.path.join(temp_dir, font_filename)
 
-        font_content = await font_file.read()
+        font_content = await read_upload_with_size_limit(font_file)
         await asyncio.to_thread(_write_bytes_to_path, font_path, font_content)
 
         saved_fonts.append((font_path, original_name))

--- a/servers/fastapi/tests/test_pptx_font_utils.py
+++ b/servers/fastapi/tests/test_pptx_font_utils.py
@@ -35,8 +35,12 @@ class DummyUploadFile:
         self._content = content
         self.size = len(content) if size is _SIZE_UNSET else size
 
-    async def read(self) -> bytes:
-        return self._content
+    async def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            data, self._content = self._content, b""
+            return data
+        data, self._content = self._content[:size], self._content[size:]
+        return data
 
 
 async def _run_sync_in_test(func, *args, **kwargs):

--- a/servers/fastapi/tests/unit/test_font_upload_limits.py
+++ b/servers/fastapi/tests/unit/test_font_upload_limits.py
@@ -1,0 +1,119 @@
+import asyncio
+import io
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from utils import font_uploads
+
+
+@pytest.fixture
+def fonts_dir(tmp_path, monkeypatch):
+    directory = tmp_path / "fonts"
+    directory.mkdir()
+    monkeypatch.setattr(font_uploads, "get_fonts_directory", lambda: str(directory))
+    return directory
+
+
+def test_raise_if_font_upload_too_large_rejects_over_limit():
+    with pytest.raises(HTTPException) as exc:
+        font_uploads.raise_if_font_upload_too_large(
+            font_uploads.MAX_FONT_UPLOAD_BYTES + 1
+        )
+    assert exc.value.status_code == 413
+
+
+def test_raise_if_font_upload_too_large_allows_at_limit():
+    font_uploads.raise_if_font_upload_too_large(font_uploads.MAX_FONT_UPLOAD_BYTES)
+    font_uploads.raise_if_font_upload_too_large(None)
+
+
+def test_read_upload_with_size_limit_streams_and_enforces_cap(monkeypatch):
+    monkeypatch.setattr(font_uploads, "MAX_FONT_UPLOAD_BYTES", 64)
+    oversized = b"a" * 65
+    upload = UploadFile(filename="big.ttf", file=io.BytesIO(oversized))
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(font_uploads.read_upload_with_size_limit(upload))
+
+    assert exc.value.status_code == 413
+
+
+def test_persist_upload_file_rejects_oversized_without_writing(fonts_dir, monkeypatch):
+    monkeypatch.setattr(font_uploads, "MAX_FONT_UPLOAD_BYTES", 32)
+    oversized = b"x" * 64
+    upload = UploadFile(
+        filename="HugeFont.ttf",
+        file=io.BytesIO(oversized),
+        size=len(oversized),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(font_uploads.persist_upload_file(upload))
+
+    assert exc.value.status_code == 413
+    assert list(fonts_dir.iterdir()) == []
+
+
+def test_persist_upload_file_removes_orphan_after_invalid_font(fonts_dir):
+    upload = UploadFile(
+        filename="Broken.ttf",
+        file=io.BytesIO(b"not-a-real-font"),
+        size=14,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(font_uploads.persist_upload_file(upload))
+
+    assert exc.value.status_code == 400
+    assert list(fonts_dir.iterdir()) == []
+
+
+def test_persist_upload_file_keeps_valid_font_and_persists(fonts_dir):
+    repo_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+    )
+    source = os.path.join(
+        repo_root, "templates", "momentum", "static", "Lato Regular.ttf"
+    )
+    if not os.path.isfile(source):
+        pytest.skip("No sample TTF available in workspace")
+
+    with open(source, "rb") as handle:
+        payload = handle.read()
+
+    upload = UploadFile(
+        filename="Lato Regular.ttf",
+        file=io.BytesIO(payload),
+        size=len(payload),
+    )
+
+    fake_upload = MagicMock()
+    fake_upload.id = "font-id"
+    fake_session = MagicMock()
+    fake_session.add = MagicMock()
+    fake_session.commit = AsyncMock()
+    fake_session.refresh = AsyncMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(
+        font_uploads,
+        "_build_font_upload_from_path",
+        return_value=fake_upload,
+    ), patch.object(
+        font_uploads,
+        "async_session_maker",
+        return_value=fake_session,
+    ):
+        font_upload, dest_path = asyncio.run(
+            font_uploads.persist_upload_file(upload)
+        )
+
+    assert font_upload is fake_upload
+    assert os.path.isfile(dest_path)
+    assert dest_path.startswith(str(fonts_dir))
+    assert os.path.getsize(dest_path) == len(payload)
+    fake_session.add.assert_called_once_with(fake_upload)

--- a/servers/fastapi/tests/unit/test_font_upload_limits.py
+++ b/servers/fastapi/tests/unit/test_font_upload_limits.py
@@ -94,6 +94,7 @@ def test_persist_upload_file_keeps_valid_font_and_persists(fonts_dir):
     fake_upload.id = "font-id"
     fake_session = MagicMock()
     fake_session.add = MagicMock()
+    fake_session.flush = AsyncMock()
     fake_session.commit = AsyncMock()
     fake_session.refresh = AsyncMock()
     fake_session.__aenter__ = AsyncMock(return_value=fake_session)
@@ -117,3 +118,83 @@ def test_persist_upload_file_keeps_valid_font_and_persists(fonts_dir):
     assert dest_path.startswith(str(fonts_dir))
     assert os.path.getsize(dest_path) == len(payload)
     fake_session.add.assert_called_once_with(fake_upload)
+    assert [
+        name
+        for name, *_ in fake_session.method_calls
+        if name in {"flush", "refresh", "commit"}
+    ] == ["flush", "refresh", "commit"]
+
+
+def test_persist_upload_file_removes_file_when_refresh_fails_before_commit(fonts_dir):
+    upload = UploadFile(
+        filename="RefreshFail.ttf",
+        file=io.BytesIO(b"font-bytes"),
+        size=10,
+    )
+
+    fake_upload = MagicMock()
+    fake_session = MagicMock()
+    fake_session.add = MagicMock()
+    fake_session.flush = AsyncMock()
+    fake_session.refresh = AsyncMock(side_effect=RuntimeError("refresh failed"))
+    fake_session.commit = AsyncMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(
+        font_uploads,
+        "_build_font_upload_from_path",
+        return_value=fake_upload,
+    ), patch.object(
+        font_uploads,
+        "async_session_maker",
+        return_value=fake_session,
+    ):
+        with pytest.raises(RuntimeError, match="refresh failed"):
+            asyncio.run(font_uploads.persist_upload_file(upload))
+
+    fake_session.commit.assert_not_awaited()
+    assert list(fonts_dir.iterdir()) == []
+
+
+def test_save_uploaded_fonts_to_temp_rejects_oversized_before_write(
+    tmp_path, monkeypatch
+):
+    from templates import fonts_and_slides_preview
+
+    monkeypatch.setattr(font_uploads, "MAX_FONT_UPLOAD_BYTES", 32)
+    monkeypatch.setattr(
+        fonts_and_slides_preview.asyncio,
+        "to_thread",
+        lambda func, *a, **k: func(*a, **k),
+    )
+
+    class _Upload:
+        def __init__(self):
+            self.filename = "Huge.ttf"
+            self.size = 64
+            self._content = b"x" * 64
+
+        async def read(self, size: int = -1):
+            if size is None or size < 0:
+                data, self._content = self._content, b""
+                return data
+            data, self._content = self._content[:size], self._content[size:]
+            return data
+
+    class _Logger:
+        def info(self, *_args, **_kwargs):
+            return None
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            fonts_and_slides_preview._save_uploaded_fonts_to_temp(
+                [_Upload()],
+                ["Huge"],
+                str(tmp_path),
+                _Logger(),
+            )
+        )
+
+    assert exc.value.status_code == 413
+    assert list(tmp_path.iterdir()) == []

--- a/servers/fastapi/utils/font_uploads.py
+++ b/servers/fastapi/utils/font_uploads.py
@@ -31,6 +31,9 @@ ALLOWED_FONT_EXTENSIONS = {
     ".woff2",
 }
 
+# Keep in sync with the slide-editor client upload guard (10 MB).
+MAX_FONT_UPLOAD_BYTES = 10 * 1024 * 1024
+
 FONT_CONTENT_TYPES = {
     ".eot": "application/vnd.ms-fontobject",
     ".fntdata": "application/octet-stream",
@@ -123,6 +126,40 @@ def is_allowed_font_filename(filename: str) -> bool:
 def safe_font_filename(filename: str) -> str:
     name = os.path.basename(filename or "font")
     return name.replace("/", "_").replace("\\", "_")
+
+
+def raise_if_font_upload_too_large(size: Optional[int]) -> None:
+    if size is not None and size > MAX_FONT_UPLOAD_BYTES:
+        limit_mb = MAX_FONT_UPLOAD_BYTES // (1024 * 1024)
+        raise HTTPException(
+            status_code=413,
+            detail=f"Font file exceeded max upload size of {limit_mb} MB",
+        )
+
+
+def remove_font_file_quietly(path: str) -> None:
+    try:
+        if path and os.path.isfile(path):
+            os.remove(path)
+    except OSError:
+        pass
+
+
+async def read_upload_with_size_limit(font_file: UploadFile) -> bytes:
+    raise_if_font_upload_too_large(getattr(font_file, "size", None))
+
+    chunks: List[bytes] = []
+    total = 0
+    chunk_size = 64 * 1024
+    while True:
+        chunk = await font_file.read(chunk_size)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > MAX_FONT_UPLOAD_BYTES:
+            raise_if_font_upload_too_large(total)
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _font_upload_filesystem_path(font_upload: FontUpload) -> str:
@@ -270,18 +307,23 @@ async def persist_font_file(
 ) -> Tuple[FontUpload, str]:
     source_filename = safe_font_filename(filename or os.path.basename(src_path))
     extension = validate_font_filename(source_filename)
+    raise_if_font_upload_too_large(os.path.getsize(src_path))
     unique_filename = (
         f"{Path(source_filename).stem}_{uuid.uuid4().hex[:8]}{extension}"
     )
     dest_path = os.path.join(get_fonts_directory(), unique_filename)
-    await _copy_file(src_path, dest_path)
+    try:
+        await _copy_file(src_path, dest_path)
 
-    font_upload = _build_font_upload_from_path(dest_path, filename=unique_filename)
-    async with async_session_maker() as session:
-        session.add(font_upload)
-        await session.commit()
-        await session.refresh(font_upload)
-    return font_upload, dest_path
+        font_upload = _build_font_upload_from_path(dest_path, filename=unique_filename)
+        async with async_session_maker() as session:
+            session.add(font_upload)
+            await session.commit()
+            await session.refresh(font_upload)
+        return font_upload, dest_path
+    except Exception:
+        remove_font_file_quietly(dest_path)
+        raise
 
 
 async def persist_upload_file(font_file: UploadFile) -> Tuple[FontUpload, str]:
@@ -291,15 +333,20 @@ async def persist_upload_file(font_file: UploadFile) -> Tuple[FontUpload, str]:
     unique_filename = f"{Path(filename).stem}_{uuid.uuid4().hex[:8]}{extension}"
     dest_path = os.path.join(get_fonts_directory(), unique_filename)
 
-    with open(dest_path, "wb") as file:
-        file.write(await font_file.read())
+    try:
+        content = await read_upload_with_size_limit(font_file)
+        with open(dest_path, "wb") as file:
+            file.write(content)
 
-    font_upload = _build_font_upload_from_path(dest_path, filename=unique_filename)
-    async with async_session_maker() as session:
-        session.add(font_upload)
-        await session.commit()
-        await session.refresh(font_upload)
-    return font_upload, dest_path
+        font_upload = _build_font_upload_from_path(dest_path, filename=unique_filename)
+        async with async_session_maker() as session:
+            session.add(font_upload)
+            await session.commit()
+            await session.refresh(font_upload)
+        return font_upload, dest_path
+    except Exception:
+        remove_font_file_quietly(dest_path)
+        raise
 
 
 async def list_font_uploads() -> FontUploadsResponse:

--- a/servers/fastapi/utils/font_uploads.py
+++ b/servers/fastapi/utils/font_uploads.py
@@ -301,6 +301,23 @@ async def backfill_font_uploads_from_disk() -> None:
             await session.commit()
 
 
+async def _persist_built_font_upload(
+    font_upload: FontUpload,
+) -> FontUpload:
+    """
+    Commit a font upload row.
+
+    Flush and refresh before commit so a refresh failure cannot leave a
+    committed database row without a matching file on disk.
+    """
+    async with async_session_maker() as session:
+        session.add(font_upload)
+        await session.flush()
+        await session.refresh(font_upload)
+        await session.commit()
+    return font_upload
+
+
 async def persist_font_file(
     src_path: str,
     filename: Optional[str] = None,
@@ -312,17 +329,17 @@ async def persist_font_file(
         f"{Path(source_filename).stem}_{uuid.uuid4().hex[:8]}{extension}"
     )
     dest_path = os.path.join(get_fonts_directory(), unique_filename)
+    committed = False
     try:
         await _copy_file(src_path, dest_path)
 
         font_upload = _build_font_upload_from_path(dest_path, filename=unique_filename)
-        async with async_session_maker() as session:
-            session.add(font_upload)
-            await session.commit()
-            await session.refresh(font_upload)
+        font_upload = await _persist_built_font_upload(font_upload)
+        committed = True
         return font_upload, dest_path
     except Exception:
-        remove_font_file_quietly(dest_path)
+        if not committed:
+            remove_font_file_quietly(dest_path)
         raise
 
 
@@ -333,19 +350,19 @@ async def persist_upload_file(font_file: UploadFile) -> Tuple[FontUpload, str]:
     unique_filename = f"{Path(filename).stem}_{uuid.uuid4().hex[:8]}{extension}"
     dest_path = os.path.join(get_fonts_directory(), unique_filename)
 
+    committed = False
     try:
         content = await read_upload_with_size_limit(font_file)
         with open(dest_path, "wb") as file:
             file.write(content)
 
         font_upload = _build_font_upload_from_path(dest_path, filename=unique_filename)
-        async with async_session_maker() as session:
-            session.add(font_upload)
-            await session.commit()
-            await session.refresh(font_upload)
+        font_upload = await _persist_built_font_upload(font_upload)
+        committed = True
         return font_upload, dest_path
     except Exception:
-        remove_font_file_quietly(dest_path)
+        if not committed:
+            remove_font_file_quietly(dest_path)
         raise
 
 


### PR DESCRIPTION
## Summary
- Font upload persistence buffered the full request with no size limit and wrote to `fonts/` before validation, leaving orphan files when parsing failed.
- Enforce a 10MB limit (matching the slide-editor client) while streaming the upload, and remove partial files when validation or DB persistence fails.
- Added unit tests for oversize rejection, orphan cleanup, and successful persistence.

## Test plan
- [x] `uv run pytest -q tests/unit/test_font_upload_limits.py` (6 passed)
- [x] Upload a font larger than 10MB → 413 and no file under fonts/
- [x] Upload invalid `.ttf` bytes → 400 and fonts directory unchanged
- [ ] Upload a normal font → still succeeds and remains listed