### PR TITLE
fix: avoid overwriting existing Downloads files on export

### DIFF
--- a/electron/app/ipc/export_handlers.ts
+++ b/electron/app/ipc/export_handlers.ts
@@ -23,6 +23,9 @@ import {
   resolveLaunchableExportChromiumPath,
 } from "../utils/export-chromium";
 import { resolveExportSpawnTarget } from "../utils/export-msix-runtime";
+import {
+  moveExportToDownloads,
+} from "../utils/unique-download-path";
 
 type BinaryFormat = "elf" | "mach-o" | "pe" | "unknown";
 type RuntimeCandidate = {
@@ -152,8 +155,11 @@ export function setupExportHandlers() {
         return { success: false, message: "Export finished but output file was not found." };
       }
 
-      const destinationPath = path.join(getDownloadsDir(), path.basename(exportFilePath));
-      await moveFile(exportFilePath, destinationPath);
+      const destinationPath = await moveExportToDownloads(
+        exportFilePath,
+        getDownloadsDir(),
+        path.basename(exportFilePath),
+      );
       showFileDownloadedDialogInBackground(destinationPath);
       addMainBreadcrumb("export", "electron.ipc_export.finish", {
         id,
@@ -561,14 +567,3 @@ function resolveExportedFilePath(responseData: any): string | null {
   return null;
 }
 
-async function moveFile(sourcePath: string, destinationPath: string) {
-  try {
-    await fs.promises.rename(sourcePath, destinationPath);
-  } catch (error: any) {
-    if (error?.code !== "EXDEV") {
-      throw error;
-    }
-    await fs.promises.copyFile(sourcePath, destinationPath);
-    await fs.promises.unlink(sourcePath);
-  }
-}

--- a/electron/app/utils/unique-download-path.ts
+++ b/electron/app/utils/unique-download-path.ts
@@ -1,0 +1,78 @@
+import fs from "fs";
+import path from "path";
+
+export function buildCandidateDownloadPath(
+  directory: string,
+  fileName: string,
+  attempt: number,
+): string {
+  if (attempt <= 0) {
+    return path.join(directory, fileName);
+  }
+
+  const extension = path.extname(fileName);
+  const stem = path.basename(fileName, extension);
+  return path.join(directory, `${stem} (${attempt})${extension}`);
+}
+
+export async function allocateUniqueDownloadPath(
+  directory: string,
+  fileName: string,
+  maxAttempts: number = 10_000,
+): Promise<string> {
+  const safeName = path.basename(fileName);
+  if (!safeName || safeName === "." || safeName === "..") {
+    throw new Error("Invalid export file name");
+  }
+
+  await fs.promises.mkdir(directory, { recursive: true });
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const candidate = buildCandidateDownloadPath(directory, safeName, attempt);
+    try {
+      const handle = await fs.promises.open(candidate, "wx");
+      await handle.close();
+      return candidate;
+    } catch (error: any) {
+      if (error?.code === "EEXIST") {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new Error(`Unable to allocate a unique download path for ${safeName}`);
+}
+
+async function removeQuietly(filePath: string): Promise<void> {
+  try {
+    await fs.promises.unlink(filePath);
+  } catch {
+    // Best-effort cleanup for reserved or partial destinations.
+  }
+}
+
+/**
+ * Move `sourcePath` into Downloads without clobbering an existing file.
+ * Reserves a unique destination with O_EXCL, then replaces that placeholder
+ * with the export contents (copy+unlink so Windows and POSIX behave the same).
+ */
+export async function moveExportToDownloads(
+  sourcePath: string,
+  downloadsDirectory: string,
+  preferredFileName: string,
+): Promise<string> {
+  const destinationPath = await allocateUniqueDownloadPath(
+    downloadsDirectory,
+    preferredFileName,
+  );
+
+  try {
+    await fs.promises.copyFile(sourcePath, destinationPath);
+    await fs.promises.unlink(sourcePath);
+    return destinationPath;
+  } catch (error) {
+    await removeQuietly(destinationPath);
+    throw error;
+  }
+}

--- a/electron/package.json
+++ b/electron/package.json
@@ -40,6 +40,7 @@
     "build:ts": "node -e \"fs.rmSync('app_dist',{recursive:true,force:true})\" && tsc",
     "check:main-no-undef": "node scripts/check-main-no-undef.cjs",
     "lint:main": "npm run build:ts && npm run check:main-no-undef",
+    "test:unique-download-path": "node --test tests/unique-download-path.test.mjs",
     "build:css": "tailwindcss -i ./resources/ui/assets/css/tailwind.import.css -o ./resources/ui/assets/css/tailwind.css --watch",
     "build:vectorstore": "echo 'Using prebuilt shared icons vectorstore index'",
     "build:export-runtime": "node scripts/sync-export-runtime.cjs",

--- a/electron/tests/unique-download-path.test.mjs
+++ b/electron/tests/unique-download-path.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { after, before } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+
+const electronRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const require = createRequire(path.join(electronRoot, "package.json"));
+
+let tempDirectory;
+let uniqueDownloadPath;
+
+before(async () => {
+  tempDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "presenton-unique-download-"),
+  );
+  const outfile = path.join(tempDirectory, "unique-download-path.mjs");
+
+  let build;
+  try {
+    ({ build } = require("esbuild"));
+  } catch {
+    const nextEsbuild = path.resolve(
+      electronRoot,
+      "../servers/nextjs/node_modules/esbuild",
+    );
+    ({ build } = createRequire(path.join(nextEsbuild, "package.json"))(
+      nextEsbuild,
+    ));
+  }
+
+  await build({
+    entryPoints: [
+      path.join(electronRoot, "app/utils/unique-download-path.ts"),
+    ],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile,
+    logLevel: "silent",
+  });
+
+  uniqueDownloadPath = await import(pathToFileURL(outfile).href);
+});
+
+after(async () => {
+  if (tempDirectory) {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+});
+
+test("builds numbered candidates for collisions", () => {
+  assert.equal(
+    uniqueDownloadPath.buildCandidateDownloadPath("/tmp", "deck.pdf", 0),
+    path.join("/tmp", "deck.pdf"),
+  );
+  assert.equal(
+    uniqueDownloadPath.buildCandidateDownloadPath("/tmp", "deck.pdf", 1),
+    path.join("/tmp", "deck (1).pdf"),
+  );
+  assert.equal(
+    uniqueDownloadPath.buildCandidateDownloadPath("/tmp", "deck.pdf", 2),
+    path.join("/tmp", "deck (2).pdf"),
+  );
+});
+
+test("moves export beside an existing same-named file without overwrite", async () => {
+  const downloads = path.join(tempDirectory, "Downloads");
+  const existing = path.join(downloads, "Quarterly Review.pdf");
+  const source = path.join(tempDirectory, "export-output.pdf");
+
+  await writeFile(source, "new-export-bytes", "utf8");
+  await mkdir(downloads, { recursive: true });
+  await writeFile(existing, "original-bytes", "utf8");
+
+  const destination = await uniqueDownloadPath.moveExportToDownloads(
+    source,
+    downloads,
+    "Quarterly Review.pdf",
+  );
+
+  assert.equal(destination, path.join(downloads, "Quarterly Review (1).pdf"));
+  assert.equal(await readFile(existing, "utf8"), "original-bytes");
+  assert.equal(await readFile(destination, "utf8"), "new-export-bytes");
+});
+
+test("uses the original name when the destination is free", async () => {
+  const downloads = path.join(tempDirectory, "Downloads-free");
+  const source = path.join(tempDirectory, "fresh-export.pdf");
+  await writeFile(source, "fresh", "utf8");
+
+  const destination = await uniqueDownloadPath.moveExportToDownloads(
+    source,
+    downloads,
+    "fresh.pdf",
+  );
+
+  assert.equal(destination, path.join(downloads, "fresh.pdf"));
+  assert.equal(await readFile(destination, "utf8"), "fresh");
+});


### PR DESCRIPTION
## Summary
- Desktop exports always moved output to `Downloads/<basename>`, which silently replaced an existing same-named file on macOS/Linux (`rename` / `copyFile` overwrite).
- Reserve a unique destination (`presentation (1).pdf`, etc.) with exclusive create before writing the export contents.
- Added Node tests proving the original file is preserved and the new export lands on a numbered name.

## Test plan
- [x] `node --test tests/unique-download-path.test.mjs` (3 passed)
- [x] Place `~/Downloads/deck.pdf` with known content, export another deck named `deck` as PDF, confirm original remains and new file is `deck (1).pdf`
- [x] Export when no collision exists → still uses the original basename