### PR TITLE
Fix/v2 template overflow and image relevance

### DIFF
--- a/servers/fastapi/services/image_generation_service.py
+++ b/servers/fastapi/services/image_generation_service.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import json
 import os
+import re
 import secrets
 from weakref import WeakKeyDictionary
 
@@ -43,11 +44,31 @@ from utils.image_generation_error import normalize_image_generation_error
 import uuid
 
 
+# Candidates fetched per slide before picking the best match (was: blind top-1).
+STOCK_IMAGE_CANDIDATE_POOL_SIZE = 6
+
 COMFYUI_MAX_SEED = 0xFFFFFFFFFFFFFFFF
 COMFYUI_SEED_SOURCE_VALUE_KEYS = {"value", "int", "integer", "number"}
 _IMAGE_GENERATION_LOCKS: WeakKeyDictionary[
     asyncio.AbstractEventLoop, asyncio.Lock
 ] = WeakKeyDictionary()
+
+
+def _rank_stock_candidates_by_relevance(
+    prompt: str, candidates: list[tuple[str, str]]
+) -> list[str]:
+    """Sorts candidates by word overlap between prompt and description (Pexels `alt` /
+    Pixabay `tags`); ties keep the provider's original order."""
+    prompt_words = set(re.findall(r"[a-z0-9]+", prompt.lower()))
+    if not prompt_words or len(candidates) <= 1:
+        return [url for url, _ in candidates]
+
+    def score(pair: tuple[str, str]) -> int:
+        description_words = set(re.findall(r"[a-z0-9]+", pair[1].lower()))
+        return len(prompt_words & description_words)
+
+    ranked = sorted(enumerate(candidates), key=lambda item: (-score(item[1]), item[0]))
+    return [url for _, (url, _description) in ranked]
 
 
 def _get_image_generation_lock() -> asyncio.Lock:
@@ -147,7 +168,13 @@ class ImageGenerationService:
 
     async def _call_image_provider(self, image_prompt: str) -> str:
         if self.is_stock_provider_selected():
-            return await self.image_gen_func(image_prompt)
+            # Best of a pool, not just the top hit — see _rank_stock_candidates_by_relevance.
+            results = await self.image_gen_func(
+                image_prompt, limit=STOCK_IMAGE_CANDIDATE_POOL_SIZE
+            )
+            if isinstance(results, list):
+                return results[0] if results else ""
+            return results
         return await self.image_gen_func(image_prompt, self.output_directory)
 
     async def generate_image_openai(
@@ -365,11 +392,12 @@ class ImageGenerationService:
 
             data = await response.json()
             photos = data.get("photos", [])
-            image_urls = [
-                photo.get("src", {}).get("large")
+            candidates = [
+                (photo.get("src", {}).get("large"), photo.get("alt") or "")
                 for photo in photos
                 if photo.get("src", {}).get("large")
             ]
+            image_urls = _rank_stock_candidates_by_relevance(prompt, candidates)
 
             if limit <= 1:
                 return image_urls[0] if image_urls else ""
@@ -419,9 +447,12 @@ class ImageGenerationService:
 
             data = await response.json()
             hits = data.get("hits", [])
-            image_urls = [
-                hit.get("largeImageURL") for hit in hits if hit.get("largeImageURL")
+            candidates = [
+                (hit.get("largeImageURL"), hit.get("tags") or "")
+                for hit in hits
+                if hit.get("largeImageURL")
             ]
+            image_urls = _rank_stock_candidates_by_relevance(prompt, candidates)
 
             if limit <= 1:
                 return image_urls[0] if image_urls else ""

--- a/servers/fastapi/templates/v2/schema.py
+++ b/servers/fastapi/templates/v2/schema.py
@@ -196,8 +196,11 @@ def _content_schema_for_element(element: dict[str, Any]) -> dict[str, Any]:
         )
 
     if element_type == "image":
-        key = "icon_query" if element.get("is_icon") is True else "image_prompt"
-        return _object_schema({key: {"type": "string"}})
+        is_icon = element.get("is_icon") is True
+        key = "icon_query" if is_icon else "image_prompt"
+        return _object_schema(
+            {key: {"type": "string", "description": _component_image_prompt_description(element)}}
+        )
 
     if element_type == "text-list":
         return _compact(
@@ -1027,4 +1030,10 @@ def _component_image_prompt_key(element: dict[str, Any]) -> str:
 def _component_image_prompt_description(element: dict[str, Any]) -> str:
     if element.get("is_icon") is True:
         return "Search query for the replacement icon."
-    return "Prompt for the replacement image."
+    # Pexels/Pixabay search barely matches non-English text — query must stay English.
+    return (
+        "Stock photo search query, ALWAYS IN ENGLISH regardless of the slide's "
+        "language. Describe a concrete, visual scene (subject, setting, action) — not "
+        "an abstract concept — e.g. 'engineer inspecting car engine block' rather than "
+        "'efficiency'."
+    )

--- a/servers/nextjs/lib/template-v2-json-to-html.ts
+++ b/servers/nextjs/lib/template-v2-json-to-html.ts
@@ -249,6 +249,7 @@ function renderSlideRoot(
   height: number,
   background: string
 ): string {
+  resolveOverflowLayout(records);
   const content = records.map((item) => renderItem(item, "absolute")).join("");
 
   return `<div class="relative overflow-hidden" data-template-v2-html-slide="true" style="box-sizing:border-box;position:relative;width:${cssNumber(
@@ -504,24 +505,108 @@ function renderText(item: JsonRecord, mode: RenderMode): string {
   const horizontal = readString(alignment.horizontal);
   const vertical = readString(alignment.vertical);
   const runs = normalizedRunsForHtml(item, font);
+  const scale = titleFitScale(item, font, runs);
+  const scaledFont = scale === 1 ? font : { ...font, size: (readNumber(font.size) ?? 0) * scale };
   const runHtml = runs
     .map((run) => {
       const runFont = { ...font, ...readRecord(run.font) };
+      if (scale !== 1) {
+        runFont.size = (readNumber(runFont.size) ?? readNumber(font.size) ?? 0) * scale;
+      }
       return `<span style="${fontStyle(runFont)}">${escapeHtml(
         readStringValue(run.text)
       )}</span>`;
     })
     .join("");
 
-  return `<div style="${frameStyle(item, mode)}${transformStyle(item)}${fontStyle(font, {
+  return `<div style="${frameStyle(item, mode)}${transformStyle(item)}${fontStyle(scaledFont, {
     includeLineHeight: false,
     includeTextDecoration: false,
   })}${textShadowStyle(item)}display:flex;align-items:${verticalAlign(
     vertical
   )};justify-content:${horizontalAlign(horizontal)};${lineHeightStyle(
-    font,
+    scaledFont,
     1.1
   )}${textOverflowStyle()}text-align:${textAlign(horizontal)};"><span style="display:block;width:100%">${runHtml}</span></div>`;
+}
+
+// Shrinks headline font if estimated line count won't fit the box height (no real text
+// measurement available server-side, so this is a glyph-width estimate). Floor: 60%.
+function titleFitScale(item: JsonRecord, font: JsonRecord, runs: JsonRecord[]): number {
+  const size = readNumber(font.size);
+  if (size == null || size < DISPLAY_HEADING_MIN_SIZE) return 1;
+
+  const box = readBox(item);
+  if (!box.width || !box.height) return 1;
+
+  const lineHeight = effectiveLineHeight(font, 1.1);
+  if (lineHeight == null) return 1;
+
+  const text = runs.map((run) => readStringValue(run.text)).join("");
+  if (!text) return 1;
+
+  let scale = 1;
+  for (let i = 0; i < 8; i++) {
+    const currentSize = size * scale;
+    const avgCharWidth = currentSize * 0.56;
+    const charsPerLine = Math.max(1, Math.floor(box.width / avgCharWidth));
+    const lines = Math.max(1, Math.ceil(text.length / charsPerLine));
+    const neededHeight = lines * currentSize * lineHeight;
+    if (neededHeight <= box.height || scale <= 0.6) break;
+    scale = Math.max(0.6, scale - 0.08);
+  }
+  return scale;
+}
+
+// Заголовок и элементы под ним (разделитель, подзаголовок, карточка) — независимые
+// прямоугольники со своими x/y от LLM, без общего flow-layout. titleFitScale уже
+// ужимает шрифт, чтобы влезть в СВОЮ рамку, но если рамка была выбрана в расчёте на
+// меньше строк, чем реально нужно, заголовок всё равно вылезает за неё и перекрывает
+// то, что стоит ниже (см. слайд с заголовком в 3 строки поверх декоративной полоски).
+// Сдвигаем всё, что стоит в том же столбце ниже заголовка, на величину переполнения.
+function resolveOverflowLayout(records: JsonRecord[]): void {
+  for (const item of records) {
+    if (readString(item.type) !== "text") continue;
+    const font = readRecord(item.font);
+    const size = readNumber(font.size);
+    if (size == null) continue;
+
+    const box = readBox(item);
+    if (!box.width || !box.height) continue;
+
+    const runs = normalizedRunsForHtml(item, font);
+    const text = runs.map((run) => readStringValue(run.text)).join("");
+    if (!text) continue;
+
+    // Заголовочный масштаб (>=36px) сам ужимается через titleFitScale — обычный
+    // текст абзаца не уменьшаем, просто меряем, сколько места ему реально нужно.
+    const scale = size >= DISPLAY_HEADING_MIN_SIZE ? titleFitScale(item, font, runs) : 1;
+    const currentSize = size * scale;
+    const lineHeight = effectiveLineHeight({ ...font, size: currentSize }, 1.1) ?? 1.1;
+    const avgCharWidth = currentSize * 0.56;
+    const charsPerLine = Math.max(1, Math.floor(box.width / avgCharWidth));
+    const lines = Math.max(1, Math.ceil(text.length / charsPerLine));
+    const neededHeight = lines * currentSize * lineHeight;
+
+    const overflow = neededHeight - box.height;
+    if (overflow <= 0) continue;
+
+    const bottom = box.y + box.height;
+    const left = box.x;
+    const right = box.x + box.width;
+
+    for (const other of records) {
+      if (other === item) continue;
+      const otherBox = readBox(other);
+      if (otherBox.y == null || otherBox.y < bottom - 1) continue;
+      const otherLeft = otherBox.x ?? 0;
+      const otherRight = otherLeft + (otherBox.width ?? 0);
+      if (otherRight <= left || otherLeft >= right) continue; // другой столбец — не трогаем
+
+      const position = readRecord(other.position);
+      other.position = { ...position, y: (readNumber(position.y) ?? otherBox.y) + overflow };
+    }
+  }
 }
 
 function renderMath(item: JsonRecord, mode: RenderMode): string {
@@ -825,12 +910,16 @@ function gridRowTemplate(
   rowGap: number
 ) {
   if (!rows) return "";
+
+  // Don't reserve empty rows when the model returned fewer items than `rows` expects.
+  const effectiveRows = renderedRows < rows ? renderedRows : Math.max(rows, renderedRows);
+
   if (explicitHeight == null) {
-    return `grid-template-rows:repeat(${Math.max(rows, renderedRows)},minmax(0,1fr));`;
+    return `grid-template-rows:repeat(${effectiveRows},minmax(0,1fr));`;
   }
 
   const rowHeight = Math.max(1, (explicitHeight - rowGap * (rows - 1)) / rows);
-  return `grid-template-rows:repeat(${Math.max(rows, renderedRows)},${cssNumber(rowHeight)}px);`;
+  return `grid-template-rows:repeat(${effectiveRows},${cssNumber(rowHeight)}px);`;
 }
 
 function readLayoutChildren(item: JsonRecord): unknown[] {
@@ -2232,10 +2321,22 @@ function textDecorationStyle(font: JsonRecord): string {
   return "";
 }
 
-function lineHeightStyle(font: JsonRecord, fallback?: number): string {
-  const lineHeight = readNumber(font.lineHeight ?? font.line_height) ?? fallback;
-  if (lineHeight == null) return "";
+// Tight line-height (e.g. 0.8) on headlines overlaps glyphs once text wraps to 2+ lines.
+const DISPLAY_HEADING_MIN_SIZE = 36;
 
+function effectiveLineHeight(font: JsonRecord, fallback?: number): number | null {
+  const lineHeight = readNumber(font.lineHeight ?? font.line_height) ?? fallback ?? null;
+  if (lineHeight == null) return null;
+  const size = readNumber(font.size);
+  if (size != null && size >= DISPLAY_HEADING_MIN_SIZE && lineHeight < 1.0) {
+    return 1.0;
+  }
+  return lineHeight;
+}
+
+function lineHeightStyle(font: JsonRecord, fallback?: number): string {
+  const lineHeight = effectiveLineHeight(font, fallback);
+  if (lineHeight == null) return "";
   return `line-height:${cssNumber(lineHeight)};`;
 }
 


### PR DESCRIPTION
Fix v2 template text overflow, empty grid rows, and stock image relevance

Three bugs found running Presenton in production (non-English audience,
budget OpenRouter model):

- template-v2-json-to-html.ts: headline line-height (0.8) overlapped its
  own wrapped lines; titleFitScale() now shrinks oversized headlines to fit
  their box (floor 60%), and a new resolveOverflowLayout() pass pushes
  sibling elements (dividers, cards) down when text still needs more room
  than its box reserved — v2 slides position every element independently
  by fixed x/y, so a 3-line title otherwise overlaps whatever sits below a
  1-2 line assumption. Also fixed: card grids reserving empty rows for
  fewer cards than the template declared.

- image_generation_service.py: stock image search took the first Pexels/
  Pixabay result regardless of relevance. Now requests a candidate pool and
  ranks by word-overlap between the query and each candidate's alt text/
  tags. Public get_image_from_pexels() contract unchanged.

- schema.py: explicit language/concreteness hint on image_prompt. Turned
  out redundant with an existing instruction elsewhere in the prompt chain;
  kept as harmless, doesn't measurably change output on cheaper models.

Verified against real generations: exported .pptx via the API, converted
with soffice/pdftoppm, inspected rendered slides visually and the raw pptx
XML (shape offsets) for the overlap case.

Known limitation: the overflow/reflow fix only reaches the Next.js editor
preview. The actual .pptx export renders through the separately-released
presenton-export binary, which ships no source — same-class bugs may still
reproduce in exported files. See companion issue.