### PR TITLE
Add llmai reasoning metrics to Smart HTML generation

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/presentation.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/presentation.py
@@ -92,7 +92,7 @@ from utils.process_slides import (
     process_slide_and_fetch_assets,
 )
 from utils.icon_weights import DEFAULT_ICON_TYPE, extract_icon_type_from_settings
-from utils.llm_utils import message_content_to_text
+from utils.llm_utils import TextGenerationMetrics, message_content_to_text
 from utils.sse import safe_sse_stream
 from api.v1.auth.config import SESSION_COOKIE_NAME
 from utils.web_search import get_selected_web_search_provider, get_web_search_route
@@ -1740,7 +1740,7 @@ async def _stream_smart_presentation(
             )
         ).to_string()
         streamed_slides: dict[int, SlideModel] = {}
-        slide_events: asyncio.Queue[SlideModel] = asyncio.Queue()
+        generation_events: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
 
         async def emit_slide(index: int, slide: dict[str, str]) -> None:
             if index < 0 or index >= slide_count:
@@ -1761,7 +1761,10 @@ async def _stream_smart_presentation(
                 streamed_slide.content = {"title": slide["title"]}
                 streamed_slide.html_content = slide["html"]
                 streamed_slide.speaker_note = ""
-            await slide_events.put(streamed_slide)
+            await generation_events.put(("slide", streamed_slide))
+
+        async def emit_metrics(metrics: TextGenerationMetrics) -> None:
+            await generation_events.put(("metrics", metrics))
 
         generation_task = asyncio.create_task(
             generate_smart_presentation(
@@ -1777,17 +1780,32 @@ async def _stream_smart_presentation(
                 community_design_context=community_context,
                 fonts=presentation.fonts,
                 on_slide=emit_slide,
+                on_metrics=emit_metrics,
             )
         )
 
         try:
-            while not generation_task.done() or not slide_events.empty():
+            while not generation_task.done() or not generation_events.empty():
                 try:
-                    streamed_slide = await asyncio.wait_for(
-                        slide_events.get(), timeout=0.1
+                    event_type, event_value = await asyncio.wait_for(
+                        generation_events.get(), timeout=0.1
                     )
                 except asyncio.TimeoutError:
                     continue
+                if event_type == "metrics":
+                    metrics = event_value
+                    if not isinstance(metrics, TextGenerationMetrics):
+                        raise TypeError("Invalid Smart generation metrics event")
+                    yield SSEResponse(
+                        event="response",
+                        data=json.dumps(
+                            {"type": "generation_metrics", **metrics.to_dict()}
+                        ),
+                    ).to_string()
+                    continue
+                streamed_slide = event_value
+                if not isinstance(streamed_slide, SlideModel):
+                    raise TypeError("Invalid Smart slide event")
                 yield SSEResponse(
                     event="response",
                     data=json.dumps(

--- a/servers/fastapi/pyproject.toml
+++ b/servers/fastapi/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pillow>=12.2.0",
     "psycopg[binary]>=3.2.0",
     "sqlmodel>=0.0.24",
-    "llmai==0.2.8",
+    "llmai==0.3.7",
     "jsonschema>=4.26.0",
     "python-pptx>=1.0.2",
     "fonttools>=4.55.0",

--- a/servers/fastapi/tests/unit/test_llm_config_web_search.py
+++ b/servers/fastapi/tests/unit/test_llm_config_web_search.py
@@ -1,4 +1,4 @@
-from llmai import DeepSeekClientConfig
+from llmai import AzureOpenAIClientConfig, DeepSeekClientConfig
 from llmai.shared import OpenAIApiType, OpenAIClientConfig
 
 from utils.llm_config import get_extra_body, get_llm_config
@@ -13,6 +13,21 @@ def test_openai_uses_responses_api_only_for_native_web_search(monkeypatch):
 
     assert regular_config.api_type == OpenAIApiType.COMPLETIONS
     assert search_config.api_type == OpenAIApiType.RESPONSES
+
+
+def test_azure_uses_responses_api(monkeypatch):
+    monkeypatch.setenv("LLM", "azure")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-10-21")
+    monkeypatch.setenv(
+        "AZURE_OPENAI_ENDPOINT",
+        "https://test-resource.openai.azure.com",
+    )
+
+    config = get_llm_config()
+
+    assert isinstance(config, AzureOpenAIClientConfig)
+    assert config.api_type == OpenAIApiType.RESPONSES
 
 
 def test_deepseek_provider_uses_deepseek_client_config(monkeypatch):

--- a/servers/fastapi/tests/unit/test_smart_presentation_generation.py
+++ b/servers/fastapi/tests/unit/test_smart_presentation_generation.py
@@ -1,8 +1,11 @@
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
+from llmai.shared import ReasoningConfig, ReasoningEffortValue, UserMessage
 
+from enums.llm_provider import LLMProvider
 from services.community_presentations import (
     CommunityPresentationReference,
     build_community_design_context,
@@ -13,7 +16,9 @@ from services.community_presentations import (
 from utils.llm_calls.generate_smart_presentation import (
     SMART_DECK_SYSTEM_PROMPT,
     SmartSlideStreamParser,
+    _stream_deck_response,
     get_smart_messages,
+    get_smart_reasoning_config,
     normalize_smart_deck,
     normalize_smart_slide_html,
     parse_smart_presentation_html,
@@ -123,6 +128,99 @@ def test_smart_retry_prompt_includes_layout_validation_feedback():
     prompt = str(messages[1].content)
     assert "prior response failed validation" in prompt
     assert "Slide content uses overflow-y-auto" in prompt
+
+
+def test_smart_reasoning_uses_low_effort_for_openai(monkeypatch):
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.disable_thinking",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.get_llm_provider",
+        lambda: LLMProvider.OPENAI,
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.llmai.supports_thinking",
+        lambda model, provider=None: True,
+    )
+
+    reasoning, supports_thinking = get_smart_reasoning_config("gpt-5")
+
+    assert supports_thinking is True
+    assert reasoning is not None
+    assert reasoning.enabled is True
+    assert reasoning.effort == ReasoningEffortValue.LOW
+
+
+def test_smart_reasoning_respects_disable_thinking(monkeypatch):
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.disable_thinking",
+        lambda: True,
+    )
+
+    reasoning, supports_thinking = get_smart_reasoning_config("gpt-5")
+
+    assert reasoning is None
+    assert supports_thinking is False
+
+
+def test_smart_stream_separates_thinking_and_reports_exact_usage(monkeypatch):
+    reasoning = ReasoningConfig(enabled=True)
+    captured_kwargs = {}
+
+    async def fake_stream_generate_events(_client, **kwargs):
+        captured_kwargs.update(kwargs)
+        yield SimpleNamespace(type="thinking", chunk="private planning")
+        yield SimpleNamespace(type="content", chunk="visible deck")
+        yield SimpleNamespace(
+            type="completion",
+            content=None,
+            usage=SimpleNamespace(
+                input_tokens=12,
+                output_tokens=8,
+                total_tokens=20,
+                reasoning=SimpleNamespace(
+                    billed_tokens=5,
+                    billed_estimated=False,
+                ),
+            ),
+            duration_seconds=2.0,
+        )
+
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.stream_generate_events",
+        fake_stream_generate_events,
+    )
+    monkeypatch.setattr("utils.llm_utils.get_extra_body", lambda **_kwargs: None)
+    content_chunks = []
+    thinking_chunks = []
+
+    async def on_chunk(chunk):
+        content_chunks.append(chunk)
+
+    async def on_thinking_chunk(chunk):
+        thinking_chunks.append(chunk)
+
+    response, metrics = asyncio.run(
+        _stream_deck_response(
+            object(),
+            "thinking-model",
+            [UserMessage(content="Build a deck")],
+            on_chunk,
+            reasoning=reasoning,
+            on_thinking_chunk=on_thinking_chunk,
+        )
+    )
+
+    assert response == "visible deck"
+    assert content_chunks == ["visible deck"]
+    assert thinking_chunks == ["private planning"]
+    assert captured_kwargs["reasoning"] is reasoning
+    assert metrics.input_tokens == 12
+    assert metrics.output_tokens == 8
+    assert metrics.thinking_tokens == 5
+    assert metrics.thinking_tokens_estimated is False
+    assert metrics.supports_thinking is True
 
 
 def test_normalize_community_ids_preserves_order_and_deduplicates():

--- a/servers/fastapi/utils/llm_calls/generate_smart_presentation.py
+++ b/servers/fastapi/utils/llm_calls/generate_smart_presentation.py
@@ -1,34 +1,45 @@
 from __future__ import annotations
 
+import asyncio
 import html as html_module
 import json
 import re
+import time
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, Optional
 
+import llmai
 from fastapi import HTTPException
 from llmai import get_client
 from llmai.shared import (
     Message,
+    ReasoningConfig,
+    ReasoningEffortValue,
     ResponseStreamCompletionChunk,
+    ResponseStreamThinkingChunk,
     SystemMessage,
     UserMessage,
 )
 
 from utils.llm_client_error_handler import handle_llm_client_exceptions
-from utils.llm_config import get_llm_config
-from utils.llm_provider import get_model
-from utils.smart_slide_layout import inspect_smart_slide_layout
+from utils.llm_config import disable_thinking, get_llm_config
+from utils.llm_provider import get_llm_provider, get_model
 from utils.llm_utils import (
+    TextGenerationMetrics,
+    build_text_generation_metrics,
+    estimate_message_tokens,
+    estimate_text_tokens,
+    estimate_thinking_tokens,
     extract_text,
     get_generate_kwargs,
     stream_generate_events,
 )
-
+from utils.smart_slide_layout import inspect_smart_slide_layout
 
 DEFAULT_SMART_SLIDE_COUNT = 8
 MAX_SMART_SLIDE_COUNT = 20
 SMART_GENERATION_MAX_ATTEMPTS = 8
+SMART_GENERATION_METRICS_INTERVAL_SECONDS = 5.0
 SMART_TITLE_MAX_VISIBLE_CHARACTERS = 800
 SMART_TITLE_MAX_VISIBLE_WORDS = 80
 SMART_VISUAL_MAX_VISIBLE_CHARACTERS = 1400
@@ -38,6 +49,7 @@ SMART_TEXT_MAX_VISIBLE_WORDS = 190
 SMART_TOC_MAX_VISIBLE_CHARACTERS = 1900
 SMART_TOC_MAX_VISIBLE_WORDS = 220
 SmartSlideCallback = Callable[[int, dict[str, str]], Awaitable[None]]
+SmartMetricsCallback = Callable[[TextGenerationMetrics], Awaitable[None]]
 
 SMART_DECK_SYSTEM_PROMPT = (
     "You are an expert presentation designer and frontend engineer. Return the "
@@ -614,26 +626,84 @@ async def _stream_deck_response(
     model: str,
     messages: Sequence[Message],
     on_chunk: Callable[[str], Awaitable[None]],
-) -> str:
+    *,
+    reasoning: ReasoningConfig | None = None,
+    on_thinking_chunk: Callable[[str], Awaitable[None]] | None = None,
+    model_supports_thinking: bool = False,
+) -> tuple[str, TextGenerationMetrics]:
     chunks: list[str] = []
-    completion_content: Any = None
+    thinking_chunks: list[str] = []
+    completion: Any = None
+    started_at = time.perf_counter()
     async for event in stream_generate_events(
         client,
-        **get_generate_kwargs(model=model, messages=messages, stream=True),
+        **get_generate_kwargs(
+            model=model,
+            messages=messages,
+            reasoning=reasoning,
+            stream=True,
+        ),
     ):
-        if isinstance(event, ResponseStreamCompletionChunk):
-            completion_content = event.content
+        if (
+            isinstance(event, ResponseStreamCompletionChunk)
+            or getattr(event, "type", None) == "completion"
+        ):
+            completion = event
+        elif (
+            isinstance(event, ResponseStreamThinkingChunk)
+            or getattr(event, "type", None) == "thinking"
+        ):
+            chunk = getattr(event, "chunk", None)
+            if isinstance(chunk, str) and chunk:
+                thinking_chunks.append(chunk)
+                if on_thinking_chunk is not None:
+                    await on_thinking_chunk(chunk)
         elif getattr(event, "type", None) == "content":
             chunk = getattr(event, "chunk", None)
             if isinstance(chunk, str):
                 chunks.append(chunk)
                 await on_chunk(chunk)
-    response = extract_text(completion_content) or "".join(chunks)
+    response = extract_text(getattr(completion, "content", None)) or "".join(chunks)
     if not chunks and response:
         await on_chunk(response)
     if not response:
         raise HTTPException(status_code=400, detail="LLM did not return any content")
-    return response
+    metrics = build_text_generation_metrics(
+        model=model,
+        messages=messages,
+        content=response,
+        streamed_thinking="".join(thinking_chunks),
+        completion=completion,
+        started_at=started_at,
+        model_supports_thinking=model_supports_thinking,
+    )
+    return response, metrics
+
+
+def get_smart_reasoning_config(model: str) -> tuple[ReasoningConfig | None, bool]:
+    """Enable reasoning only when llmai knows the selected model supports it."""
+    if disable_thinking():
+        return None, False
+
+    provider = get_llm_provider().value
+    try:
+        supports_thinking = llmai.supports_thinking(model, provider=provider) is True
+    except Exception:
+        supports_thinking = False
+    if not supports_thinking:
+        return None, False
+
+    return (
+        ReasoningConfig(
+            enabled=True,
+            effort=(
+                ReasoningEffortValue.LOW
+                if provider in {"openai", "azure"}
+                else None
+            ),
+        ),
+        True,
+    )
 
 
 async def generate_smart_presentation(
@@ -650,9 +720,11 @@ async def generate_smart_presentation(
     community_design_context: str = "",
     fonts: Optional[dict[str, str]] = None,
     on_slide: SmartSlideCallback | None = None,
+    on_metrics: SmartMetricsCallback | None = None,
 ) -> dict[str, Any]:
-    client = get_client(config=get_llm_config())
+    client = get_client(config=get_llm_config(use_openai_responses_api=True))
     model = get_model()
+    reasoning, configured_thinking_support = get_smart_reasoning_config(model)
     accepted_slides: list[dict[str, str]] = []
     title = ""
     last_exception: Exception | None = None
@@ -676,8 +748,15 @@ async def generate_smart_presentation(
         )
         parser = SmartSlideStreamParser()
         attempt_slides: list[dict[str, str]] = []
+        streamed_response = ""
+        streamed_thinking = ""
+        model_supports_thinking = configured_thinking_support
+        attempt_started_at = time.perf_counter()
+        estimated_input_tokens = estimate_message_tokens(messages)
 
         async def handle_chunk(chunk: str) -> None:
+            nonlocal streamed_response
+            streamed_response += chunk
             for slide in parser.feed(chunk):
                 index = len(accepted_slides) + len(attempt_slides)
                 if index >= n_slides:
@@ -695,8 +774,59 @@ async def generate_smart_presentation(
                 if on_slide is not None:
                     await on_slide(index, slide)
 
+        async def handle_thinking_chunk(chunk: str) -> None:
+            nonlocal streamed_thinking, model_supports_thinking
+            streamed_thinking += chunk
+            model_supports_thinking = True
+
+        async def emit_estimated_metrics_periodically() -> None:
+            while True:
+                await asyncio.sleep(SMART_GENERATION_METRICS_INTERVAL_SECONDS)
+                duration = max(time.perf_counter() - attempt_started_at, 1e-9)
+                output_tokens = estimate_text_tokens(streamed_response)
+                thinking_tokens = (
+                    estimate_thinking_tokens(streamed_thinking)
+                    if streamed_thinking
+                    else (0 if model_supports_thinking else None)
+                )
+                if on_metrics is not None:
+                    await on_metrics(
+                        TextGenerationMetrics(
+                            model=model,
+                            input_tokens=estimated_input_tokens,
+                            output_tokens=output_tokens,
+                            total_tokens=estimated_input_tokens + output_tokens,
+                            tokens_per_second=output_tokens / duration,
+                            duration_seconds=duration,
+                            estimated=True,
+                            thinking_tokens=thinking_tokens,
+                            thinking_tokens_estimated=model_supports_thinking,
+                            supports_thinking=model_supports_thinking,
+                        )
+                    )
+
+        metrics_task = (
+            asyncio.create_task(emit_estimated_metrics_periodically())
+            if on_metrics is not None
+            else None
+        )
         try:
-            response = await _stream_deck_response(client, model, messages, handle_chunk)
+            try:
+                response, metrics = await _stream_deck_response(
+                    client,
+                    model,
+                    messages,
+                    handle_chunk,
+                    reasoning=reasoning,
+                    on_thinking_chunk=handle_thinking_chunk,
+                    model_supports_thinking=model_supports_thinking,
+                )
+            finally:
+                if metrics_task is not None:
+                    metrics_task.cancel()
+                    await asyncio.gather(metrics_task, return_exceptions=True)
+            if on_metrics is not None:
+                await on_metrics(metrics)
             parsed_title, parsed_slides = parse_smart_presentation_html(
                 response,
                 expected_slide_count=n_slides - len(accepted_slides),
@@ -711,8 +841,11 @@ async def generate_smart_presentation(
                 )
             title = title or parsed_title
             accepted_slides.extend(attempt_slides)
-            return {"title": title, "slides": accepted_slides}
+            return {"title": title, "slides": accepted_slides, "metrics": metrics}
         except Exception as exc:
+            if metrics_task is not None and not metrics_task.done():
+                metrics_task.cancel()
+                await asyncio.gather(metrics_task, return_exceptions=True)
             last_exception = exc
             retry_error = (
                 str(exc.detail)

--- a/servers/fastapi/utils/llm_config.py
+++ b/servers/fastapi/utils/llm_config.py
@@ -243,6 +243,7 @@ def get_llm_config(*, use_openai_responses_api: bool = False) -> ClientConfig:
                 )
 
             return AzureOpenAIClientConfig(
+                api_type=OpenAIApiType.RESPONSES,
                 api_key=api_key,
                 api_version=api_version,
                 endpoint=endpoint or None,

--- a/servers/fastapi/utils/llm_utils.py
+++ b/servers/fastapi/utils/llm_utils.py
@@ -1,8 +1,11 @@
 import asyncio
 import json
 import logging
+import math
 import threading
+import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Sequence
+from dataclasses import dataclass
 from typing import Any, Optional
 
 import dirtyjson
@@ -10,6 +13,7 @@ from fastapi import HTTPException
 from llmai.shared import (
     LLMTool,
     Message,
+    ReasoningConfig,
     ResponseFormat,
     ResponseStreamCompletionChunk,
     UserMessage,
@@ -19,11 +23,38 @@ from llmai.shared import (
 from utils.llm_config import get_extra_body
 from utils.schema_utils import get_schema_validation_errors
 
-
 LOGGER = logging.getLogger(__name__)
 CLIENT_DISCONNECT_POLL_SECONDS = 0.1
 DisconnectChecker = Callable[[], Awaitable[bool]]
 TextChunkCallback = Callable[[str], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class TextGenerationMetrics:
+    model: str
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    tokens_per_second: float
+    duration_seconds: float
+    estimated: bool
+    thinking_tokens: Optional[int] = None
+    thinking_tokens_estimated: bool = False
+    supports_thinking: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model": self.model,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens,
+            "tokens_per_second": round(self.tokens_per_second, 2),
+            "duration_seconds": round(self.duration_seconds, 3),
+            "estimated": self.estimated,
+            "thinking_tokens": self.thinking_tokens,
+            "thinking_tokens_estimated": self.thinking_tokens_estimated,
+            "supports_thinking": self.supports_thinking,
+        }
 
 
 async def _raise_if_client_disconnected(
@@ -76,6 +107,7 @@ def get_generate_kwargs(
     max_tokens: Optional[int] = None,
     tools: Optional[list[LLMTool]] = None,
     response_format: Optional[ResponseFormat] = None,
+    reasoning: Optional[ReasoningConfig] = None,
     stream: bool = False,
 ) -> dict[str, Any]:
     kwargs: dict[str, Any] = {
@@ -89,12 +121,141 @@ def get_generate_kwargs(
         kwargs["tools"] = tools
     if response_format is not None:
         kwargs["response_format"] = response_format
+    if reasoning is not None:
+        kwargs["reasoning"] = reasoning
 
     extra_body = get_extra_body(uses_tool_choice=bool(tools or response_format))
     if extra_body:
         kwargs["extra_body"] = extra_body
 
     return kwargs
+
+
+def estimate_text_tokens(value: str) -> int:
+    """Return a stable approximation when a provider omits token usage."""
+    return max(1, round(len(value) / 4)) if value else 0
+
+
+def estimate_thinking_tokens(value: str) -> int:
+    """Match llmai's visible-reasoning estimate for streamed thinking chunks."""
+    return math.ceil(len(value.encode("utf-8")) / 4) if value else 0
+
+
+def estimate_message_tokens(messages: Sequence[Message]) -> int:
+    return sum(
+        estimate_text_tokens(extract_text(getattr(message, "content", None)) or "")
+        for message in messages
+    )
+
+
+def _usage_token_value(usage: Any, *names: str) -> Optional[int]:
+    for name in names:
+        value = usage.get(name) if isinstance(usage, dict) else getattr(usage, name, None)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return None
+
+
+def _usage_thinking_tokens(usage: Any) -> tuple[Optional[int], bool]:
+    """Return llmai's best thinking count and whether that count is estimated."""
+    if usage is None:
+        return None, False
+
+    reasoning = (
+        usage.get("reasoning")
+        if isinstance(usage, dict)
+        else getattr(usage, "reasoning", None)
+    )
+    billed_tokens = _usage_token_value(reasoning, "billed_tokens")
+    if billed_tokens is not None:
+        billed_estimated = (
+            reasoning.get("billed_estimated", False)
+            if isinstance(reasoning, dict)
+            else getattr(reasoning, "billed_estimated", False)
+        )
+        return billed_tokens, bool(billed_estimated)
+
+    visible_tokens = _usage_token_value(reasoning, "visible_tokens")
+    if visible_tokens is not None:
+        return visible_tokens, True
+
+    return _usage_token_value(usage, "thinking_tokens", "reasoning_tokens"), False
+
+
+def build_text_generation_metrics(
+    *,
+    model: str,
+    messages: Sequence[Message],
+    content: str,
+    streamed_thinking: str,
+    completion: Any,
+    started_at: float,
+    model_supports_thinking: bool = False,
+) -> TextGenerationMetrics:
+    usage = getattr(completion, "usage", None) if completion is not None else None
+    exact_input_tokens = _usage_token_value(usage, "input_tokens", "prompt_tokens")
+    exact_output_tokens = _usage_token_value(
+        usage, "output_tokens", "completion_tokens"
+    )
+    input_tokens = (
+        exact_input_tokens
+        if exact_input_tokens is not None
+        else estimate_message_tokens(messages)
+    )
+    output_tokens = (
+        exact_output_tokens
+        if exact_output_tokens is not None
+        else estimate_text_tokens(content)
+    )
+    thinking_tokens, thinking_tokens_estimated = _usage_thinking_tokens(usage)
+    if thinking_tokens is None and streamed_thinking:
+        thinking_tokens = estimate_thinking_tokens(streamed_thinking)
+        thinking_tokens_estimated = True
+
+    supports_thinking = bool(
+        model_supports_thinking
+        or thinking_tokens is not None
+        or streamed_thinking
+    )
+    if (
+        supports_thinking
+        and exact_output_tokens is not None
+        and (thinking_tokens is None or thinking_tokens_estimated)
+    ):
+        inferred_thinking_tokens = max(
+            0,
+            exact_output_tokens - estimate_text_tokens(content),
+        )
+        if thinking_tokens is None or inferred_thinking_tokens > thinking_tokens:
+            thinking_tokens = inferred_thinking_tokens
+            thinking_tokens_estimated = True
+    if supports_thinking and thinking_tokens is None:
+        thinking_tokens = 0
+        thinking_tokens_estimated = True
+
+    duration_seconds = (
+        getattr(completion, "duration_seconds", None)
+        if completion is not None
+        else None
+    )
+    if not isinstance(duration_seconds, (int, float)) or duration_seconds <= 0:
+        duration_seconds = max(time.perf_counter() - started_at, 1e-9)
+    total_tokens = _usage_token_value(usage, "total_tokens")
+    if total_tokens is None:
+        total_tokens = input_tokens + output_tokens
+
+    return TextGenerationMetrics(
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        tokens_per_second=output_tokens / duration_seconds,
+        duration_seconds=duration_seconds,
+        estimated=exact_input_tokens is None or exact_output_tokens is None,
+        thinking_tokens=thinking_tokens,
+        thinking_tokens_estimated=thinking_tokens_estimated,
+        supports_thinking=supports_thinking,
+    )
 
 
 def structured_validation_feedback_user_message(

--- a/servers/fastapi/uv.lock
+++ b/servers/fastapi/uv.lock
@@ -1352,17 +1352,18 @@ wheels = [
 
 [[package]]
 name = "llmai"
-version = "0.2.8"
+version = "0.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "boto3" },
     { name = "google-genai" },
+    { name = "httpx" },
     { name = "openai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/57/a6f0d0a7db99f3263ecba66d7494eddf8ac5d702f0baaf4b90cfd0bb193e/llmai-0.2.8.tar.gz", hash = "sha256:6247e919d2ca413159dc292cea6d0fa542a1a2d74d98262fb312959c66b6a695", size = 55149, upload-time = "2026-06-23T12:06:51.752Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/0b/5332ee7d5735409e2ac61a0c7beb541c3c2013dfeff86e12f2e9921339ff/llmai-0.3.7.tar.gz", hash = "sha256:4697b2ca2b336cae1fc698116217d814370741e771f09a427464364fed449164", size = 428953, upload-time = "2026-08-01T12:57:02.013Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/c0/867e2440265bfb7675eca82b15ed673bb503a227b7cabe26d3d856595f59/llmai-0.2.8-py3-none-any.whl", hash = "sha256:547f45502843dec80a23d10921cf0c6d1ecb9c0fc2cd7870f07cc021234a9189", size = 71203, upload-time = "2026-06-23T12:06:50.491Z" },
+    { url = "https://files.pythonhosted.org/packages/29/85/62d302f1d51cb5f25ce619f5d6aef62d02bccfbae47c9ee7da0c200a125a/llmai-0.3.7-py3-none-any.whl", hash = "sha256:8909fabab520e1925d8b47a0cd88ad495cada23edbb87c7a88a96f05191b173a", size = 443064, upload-time = "2026-08-01T12:57:00.21Z" },
 ]
 
 [[package]]
@@ -1885,7 +1886,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.28.0" },
     { name = "greenlet", specifier = ">=3.0.3" },
     { name = "jsonschema", specifier = ">=4.26.0" },
-    { name = "llmai", specifier = "==0.2.8" },
+    { name = "llmai", specifier = "==0.3.7" },
     { name = "mem0ai", extras = ["nlp"], specifier = ">=0.1.115" },
     { name = "nltk", specifier = ">=3.9.1" },
     { name = "openai", specifier = ">=1.98.0" },


### PR DESCRIPTION
## Summary
- upgrade llmai from 0.2.8 to 0.3.7
- enable capability-aware reasoning for direct Smart HTML generation while respecting DISABLE_THINKING
- separate streamed thinking chunks from slide HTML and report live/final token metrics over SSE
- use the Responses API for OpenAI and Azure Smart generation
- add regression coverage for reasoning configuration and thinking-token usage

## Validation
- 565 backend unit tests passed
- uv lock check passed
- git diff check passed

## UI impact
No frontend changes are required. Existing clients safely ignore the new generation_metrics SSE payload unless they choose to display it.