### PR TITLE
fix: make app_data permission fixups best-effort on startup

### DIFF
--- a/start.js
+++ b/start.js
@@ -65,9 +65,24 @@ const appDataStaticDirectories = [
   "pptx-to-json",
 ].map((name) => join(appDataDirectory, name));
 
+// Volumes mounted by the host (e.g. a Kubernetes/OpenShift PVC owned by an
+// arbitrary non-root UID) may already have sufficient permissions without
+// letting this process chmod them. Treat chmod as best-effort so a restricted
+// environment doesn't crash the whole process on startup.
+const chmodBestEffort = (path, mode) => {
+  try {
+    chmodSync(path, mode);
+  } catch (error) {
+    if (error && (error.code === "EPERM" || error.code === "EACCES")) {
+      return;
+    }
+    throw error;
+  }
+};
+
 const ensureReadableDirectory = (dirPath) => {
   mkdirSync(dirPath, { recursive: true, mode: appDataDirectoryMode });
-  chmodSync(dirPath, appDataDirectoryMode);
+  chmodBestEffort(dirPath, appDataDirectoryMode);
 };
 
 const ensureReadableExportFiles = (dirPath) => {
@@ -75,10 +90,10 @@ const ensureReadableExportFiles = (dirPath) => {
     const entryPath = join(dirPath, entry.name);
 
     if (entry.isDirectory()) {
-      chmodSync(entryPath, appDataDirectoryMode);
+      chmodBestEffort(entryPath, appDataDirectoryMode);
       ensureReadableExportFiles(entryPath);
     } else if (entry.isFile()) {
-      chmodSync(entryPath, 0o644);
+      chmodBestEffort(entryPath, 0o644);
     }
   }
 };
@@ -118,7 +133,7 @@ const copyUserConfigBackup = () => {
   try {
     if (readJsonConfig(userConfigPath)) {
       copyFileSync(userConfigPath, userConfigBackupPath);
-      chmodSync(userConfigBackupPath, 0o644);
+      chmodBestEffort(userConfigBackupPath, 0o644);
     }
   } catch (error) {
     console.warn("Failed to update user config backup:", error);
@@ -140,10 +155,6 @@ const writeUserConfig = (config) => {
 
   try {
     renameSync(tempPath, userConfigPath);
-    chmodSync(userConfigPath, 0o644);
-    if (!existsSync(userConfigBackupPath)) {
-      copyUserConfigBackup();
-    }
   } catch (error) {
     try {
       unlinkSync(tempPath);
@@ -151,6 +162,11 @@ const writeUserConfig = (config) => {
       // Best-effort cleanup.
     }
     throw error;
+  }
+
+  chmodBestEffort(userConfigPath, 0o644);
+  if (!existsSync(userConfigBackupPath)) {
+    copyUserConfigBackup();
   }
 };
 


### PR DESCRIPTION
Fixes #671

chmodSync on app_data directories/files was unguarded, so running as a
non-root UID with no chmod rights on the mounted volume (e.g. OpenShift
arbitrary UID) crashed the process with EPERM before the servers even
started. Also fixes writeUserConfig treating a chmod failure after a
successful rename as a write failure.