### PR TITLE
Fix repository metadata and Cypress CI

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presenton",
-  "version": "0.9.4-beta",
+  "version": "0.9.5-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presenton",
-      "version": "0.9.4-beta",
+      "version": "0.9.5-beta",
       "hasInstallScript": true,
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presenton",
-  "version": "0.9.4-beta",
+  "version": "0.9.5-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presenton",
-      "version": "0.9.4-beta",
+      "version": "0.9.5-beta",
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.2",
         "sharp": "^0.34.5"

--- a/servers/nextjs/components/ui/dialog.cy.tsx
+++ b/servers/nextjs/components/ui/dialog.cy.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+import "@/app/globals.css";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+describe("DialogContent", () => {
+  it("stays centered when another Tailwind runtime defines translate", () => {
+    cy.viewport(1920, 1080);
+
+    cy.document().then((document) => {
+      const style = document.createElement("style");
+      style.textContent = `
+        [data-cy="dialog-content"] {
+          translate: -50% -50%;
+        }
+      `;
+      document.head.appendChild(style);
+    });
+
+    cy.mount(
+      <Dialog open>
+        <DialogContent data-cy="dialog-content">
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>Dialog positioning regression test.</DialogDescription>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    cy.get('[data-cy="dialog-content"]')
+      .should("be.visible")
+      .and("have.css", "translate", "none")
+      .then(($dialog) => {
+        const bounds = $dialog[0].getBoundingClientRect();
+
+        expect(bounds.left).to.be.greaterThan(-1);
+        expect(bounds.top).to.be.greaterThan(-1);
+        expect(bounds.right).to.be.lessThan(1921);
+        expect(bounds.bottom).to.be.lessThan(1081);
+        expect(bounds.left + bounds.width / 2).to.be.closeTo(960, 3);
+        expect(bounds.top + bounds.height / 2).to.be.closeTo(540, 3);
+      });
+  });
+});


### PR DESCRIPTION
## Summary
- align root and Electron lockfile versions with `0.9.5-beta` package metadata
- add a Cypress component regression test for dialog centering under conflicting Tailwind translate styles
- restore the Cypress CI job to a meaningful passing suite

## Validation
- `npm test` (repository root)
- `npm test` (servers/nextjs)
- `npm run lint` (servers/nextjs; existing warnings only)
- `npm run build` (servers/nextjs)
- `npx cypress run --component --browser electron`