### PR TITLE
Add POST /presentation/{id}/export to export an existing presentation

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/presentation.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/presentation.py
@@ -1437,6 +1437,45 @@ async def duplicate_presentation(
     )
 
 
+@PRESENTATION_ROUTER.post("/{id}/export", response_model=PresentationPathAndEditPath)
+async def export_existing_presentation(
+    id: uuid.UUID,
+    request_http: Request,
+    export_as: Annotated[Literal["pptx", "pdf"], Body(embed=True)] = "pptx",
+    sql_session: AsyncSession = Depends(get_async_session),
+):
+    """Export a presentation that already exists.
+
+    Until now export could only happen as a side effect of the endpoint that
+    created a presentation (`/generate`, `/edit`, `/derive`). If that request
+    was interrupted — a reverse proxy closing a long-running connection, a
+    client disconnect, a browser tab closing — the presentation itself was
+    still generated and stored, but the exported file could no longer be
+    reached through the API at all. The work was done and paid for, and the
+    only way back to it was generating the whole thing again.
+
+    This exposes the same `export_presentation` helper those endpoints already
+    call, keyed on an existing presentation id, so an interrupted export can be
+    retried without regenerating. It also makes the self-hosted v1 API
+    consistent with the hosted v3 API, which offers `POST /presentation/export`.
+    """
+    presentation = await sql_session.get(PresentationModel, id)
+    if not presentation:
+        raise HTTPException(404, "Presentation not found")
+
+    presentation_and_path = await export_presentation(
+        presentation.id,
+        presentation.title or str(uuid.uuid4()),
+        export_as,
+        cookie_header=_build_export_cookie_header(request_http),
+    )
+
+    return PresentationPathAndEditPath(
+        **presentation_and_path.model_dump(),
+        edit_path=f"/presentation?id={presentation.id}",
+    )
+
+
 @PRESENTATION_ROUTER.post("/create", response_model=PresentationModel)
 async def create_presentation(
     content: Annotated[str, Body()],

--- a/servers/fastapi/tests/integration/test_presentation_generation_flow.py
+++ b/servers/fastapi/tests/integration/test_presentation_generation_flow.py
@@ -1082,3 +1082,63 @@ def test_derive_presentation_hydrates_template_slide_ui():
     assert new_presentation.version == PresentationVersion.V2_STANDARD
     assert new_slide.presentation == new_presentation.id
     assert title_element["runs"][0]["text"] == "Derived headline"
+
+
+def test_export_existing_presentation_returns_path_without_regenerating():
+    """A presentation that already exists can be exported on its own.
+
+    Regression cover for the gap this endpoint closes: export used to happen
+    only as a side effect of /generate, /edit and /derive, so an interrupted
+    request left a stored presentation whose file could never be retrieved.
+    """
+    presentation_id = uuid.uuid4()
+    presentation = PresentationModel(
+        id=presentation_id,
+        version=PresentationVersion.V2_STANDARD,
+        content="deck",
+        n_slides=1,
+        language="English",
+        layout=_template_layout_payload(),
+        tone="default",
+        verbosity="standard",
+        instructions=None,
+        title="Existing deck",
+    )
+    session = FakeAsyncSession(get_results={presentation_id: presentation})
+
+    with patch.object(
+        presentation_endpoint,
+        "export_presentation",
+        new=_fake_export_presentation,
+    ):
+        response = _run(
+            presentation_endpoint.export_existing_presentation(
+                id=presentation_id,
+                request_http=FakeRequest(),
+                export_as="pptx",
+                sql_session=session,
+            )
+        )
+
+    assert response.presentation_id == presentation_id
+    assert response.path == "/tmp/generated/deck.pptx"
+    assert response.edit_path == f"/presentation?id={presentation_id}"
+    # Nothing may be mutated or re-created — this only exports what exists.
+    assert session.added == []
+    assert session.commit_count == 0
+
+
+def test_export_existing_presentation_404s_for_unknown_id():
+    session = FakeAsyncSession(get_results={})
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(
+            presentation_endpoint.export_existing_presentation(
+                id=uuid.uuid4(),
+                request_http=FakeRequest(),
+                export_as="pptx",
+                sql_session=session,
+            )
+        )
+
+    assert exc_info.value.status_code == 404


### PR DESCRIPTION
Export currently only happens as a side effect of the endpoint that creates
a presentation (/generate, /edit, /derive). If that request is interrupted
— a reverse proxy closing a long-running connection, a client disconnect, a
browser tab closing — the presentation itself is still generated and stored,
but the exported file can no longer be reached through the API at all. The
work is done and paid for, and the only way back to it is regenerating from
scratch.

This is most visible on long generations behind a proxy with a request-
duration limit: the deck completes server-side and is visible in the UI,
while the caller receives a gateway error and has no way to retrieve it.

The change exposes the same utils.export_utils.export_presentation helper
those endpoints already call, keyed on an existing presentation id, so an
interrupted export can be retried without regenerating. It follows the
conventions of its neighbours (load, 404 if missing, no separate ownership
check — matching GET /{id}, DELETE /{id} and POST /{id}/duplicate) and
returns the existing PresentationPathAndEditPath shape.

It also brings the self-hosted v1 API in line with the hosted v3 API, which
already offers POST /presentation/export.

Tests cover the happy path — asserting nothing is mutated or re-created,
only exported — and a 404 for an unknown id. Full suite passes: 718 passed.