### PR TITLE
Always stream structured generation so background tasks don't fail instantly

### DIFF
--- a/servers/fastapi/tests/unit/test_generate_web_search_query.py
+++ b/servers/fastapi/tests/unit/test_generate_web_search_query.py
@@ -1,5 +1,6 @@
 import asyncio
-from types import SimpleNamespace
+
+from llmai.shared import ResponseStreamCompletionChunk
 
 from utils.llm_calls.generate_web_search_query import generate_web_search_query
 
@@ -11,7 +12,7 @@ class FakeClient:
 
     def generate(self, **kwargs):
         self.calls.append(kwargs)
-        return SimpleNamespace(content=self.content)
+        return iter([ResponseStreamCompletionChunk(content=self.content)])
 
 
 def test_generate_web_search_query_returns_normalized_query(monkeypatch):

--- a/servers/fastapi/tests/unit/test_llm_utils_disconnect.py
+++ b/servers/fastapi/tests/unit/test_llm_utils_disconnect.py
@@ -1,7 +1,6 @@
 import asyncio
 import threading
 import time
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -13,11 +12,37 @@ from utils.llm_utils import generate_structured_with_schema_retries
 class RetryClient:
     def __init__(self):
         self.calls = []
-        self.responses = [None, {"result": "ok"}]
+        self.responses = [None, '{"result": "ok"}']
 
     def generate(self, **kwargs):
         self.calls.append(kwargs)
-        return SimpleNamespace(content=self.responses.pop(0))
+        response = self.responses.pop(0)
+
+        def events():
+            if response is not None:
+                yield ResponseStreamContentChunk(chunk=response)
+
+        return events()
+
+
+class NonStreamingRefusingClient:
+    """Mirrors the Anthropic SDK, which refuses a long non-streaming request."""
+
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, **kwargs):
+        self.calls.append(kwargs)
+        if not kwargs.get("stream"):
+            raise ValueError(
+                "Streaming is required for operations that may take longer "
+                "than 10 minutes."
+            )
+
+        def events():
+            yield ResponseStreamContentChunk(chunk='{"result": "ok"}')
+
+        return events()
 
 
 class StreamingClient:
@@ -41,7 +66,7 @@ class StreamingClient:
         return events()
 
 
-def test_regular_generation_keeps_existing_retry_behavior(monkeypatch):
+def test_background_generation_streams_and_keeps_retry_behavior(monkeypatch):
     monkeypatch.setenv("LLM", "ollama")
     client = RetryClient()
 
@@ -58,7 +83,25 @@ def test_regular_generation_keeps_existing_retry_behavior(monkeypatch):
 
     assert result == {"result": "ok"}
     assert len(client.calls) == 2
-    assert all(call["stream"] is False for call in client.calls)
+    assert all(call["stream"] is True for call in client.calls)
+
+
+def test_background_generation_never_issues_a_nonstreaming_request(monkeypatch):
+    monkeypatch.setenv("LLM", "ollama")
+    client = NonStreamingRefusingClient()
+
+    result = asyncio.run(
+        generate_structured_with_schema_retries(
+            client,
+            "test-model",
+            messages=[],
+            response_format=object(),
+            json_schema={},
+        )
+    )
+
+    assert result == {"result": "ok"}
+    assert len(client.calls) == 1
 
 
 def test_disconnect_cancels_generation_without_retrying(monkeypatch):

--- a/servers/fastapi/utils/llm_utils.py
+++ b/servers/fastapi/utils/llm_utils.py
@@ -71,10 +71,15 @@ async def _generate_structured_content(
     text_chunk_callback: Optional[TextChunkCallback] = None,
     **kwargs: Any,
 ) -> Optional[dict]:
-    if disconnect_checker is None and text_chunk_callback is None:
-        response = await asyncio.to_thread(client.generate, **kwargs)
-        return extract_structured_content(response.content)
-
+    # Always stream, even with nothing to stream *to*. Structured generation
+    # runs without an explicit max_tokens, so providers default to the model
+    # ceiling, and the Anthropic SDK refuses a non-streaming request whose
+    # estimated duration exceeds ten minutes -- it raises before sending
+    # anything, so the call fails in seconds rather than running long. That
+    # only bit callers with no disconnect checker and no chunk callback, i.e.
+    # background generation, which made it look provider- or size-specific.
+    # Streaming is what the SDK asks for here and is accepted identically by
+    # the other providers, so it is the single path.
     completion_content: Any = None
     streamed_text: list[str] = []
     async for event in stream_generate_events(


### PR DESCRIPTION
Structured generation took a non-streaming path whenever there was no disconnect checker and no chunk callback -- that is, whenever it ran in the background rather than behind a live request. Those calls pass no explicit max_tokens, so providers default to the model ceiling, and the Anthropic SDK refuses a non-streaming request whose estimated duration exceeds ten minutes:

    ValueError: Streaming is required for operations that may take longer
    than 10 minutes.

It raises before sending anything, so the call fails in about three seconds without reaching the provider. The failure then reaches the caller as a generic "please try again", which makes it look intermittent, size-related, or provider-related. It is none of those -- it is deterministic for any background structured generation on Anthropic, at any slide count, while the same work succeeds through an endpoint that supplies a disconnect checker.

/presentation/generate/async is the visible case: it reaches generate_presentation_structure without a disconnect checker, by design, since there is no connection to watch.

stream_generate_events already handles disconnect_checker=None (it skips the poll timeout and the disconnect check), and streaming is accepted identically by the other providers, so the non-streaming branch is removed rather than made conditional -- one path, and the one the SDK asks for.

Tests cover a background call refusing to be made non-streaming, and the existing retry and schema-validation behavior is asserted unchanged.