### PR TITLE
Report the presentation reference in async generation task data

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/presentation.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/presentation.py
@@ -157,11 +157,19 @@ def _blank_presentation_slide_ui() -> dict[str, Any]:
 def _presentation_task_progress_data(
     created_slides: int,
     remaining_slides: int,
-) -> dict[str, int]:
-    return {
+    presentation_id: Optional[uuid.UUID | str] = None,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
         "created_slides": max(created_slides, 0),
         "remaining_slides": max(remaining_slides, 0),
     }
+    # Carried from the moment the task is created, so a polling caller can
+    # identify the presentation even while it is still generating -- and,
+    # more importantly, after a task ends in error, when there is no
+    # response body to learn it from.
+    if presentation_id is not None:
+        data["presentation_id"] = str(presentation_id)
+    return data
 
 
 def _requested_slide_count(request: GeneratePresentationRequest) -> int:
@@ -2358,6 +2366,7 @@ async def generate_presentation_handler(
                 async_status.data = _presentation_task_progress_data(
                     created_slides=0,
                     remaining_slides=_requested_slide_count(request),
+                    presentation_id=presentation_id,
                 )
                 async_status.updated_at = datetime.now()
                 sql_session.add(async_status)
@@ -2592,6 +2601,7 @@ async def generate_presentation_handler(
             async_status.data = _presentation_task_progress_data(
                 created_slides=0,
                 remaining_slides=final_n_slides or 0,
+                presentation_id=presentation_id,
             )
             async_status.updated_at = datetime.now()
             sql_session.add(async_status)
@@ -2653,6 +2663,7 @@ async def generate_presentation_handler(
                 async_status.data = _presentation_task_progress_data(
                     created_slides=len(slides),
                     remaining_slides=total_slides_to_create - len(slides),
+                    presentation_id=presentation_id,
                 )
                 async_status.updated_at = datetime.now()
                 sql_session.add(async_status)
@@ -2686,6 +2697,7 @@ async def generate_presentation_handler(
             async_status.data = _presentation_task_progress_data(
                 created_slides=len(slides),
                 remaining_slides=0,
+                presentation_id=presentation_id,
             )
             async_status.updated_at = datetime.now()
             sql_session.add(async_status)
@@ -2733,10 +2745,20 @@ async def generate_presentation_handler(
         if async_status:
             async_status.message = "Presentation generation completed"
             async_status.status = AsyncTaskStatus.COMPLETED
-            async_status.data = _presentation_task_progress_data(
-                created_slides=len(slides),
-                remaining_slides=0,
-            )
+            async_status.data = {
+                **_presentation_task_progress_data(
+                    created_slides=len(slides),
+                    remaining_slides=0,
+                    presentation_id=presentation_id,
+                ),
+                # The same fields the synchronous endpoint returns in its
+                # response body. Without them a polling caller learns only
+                # that *a* task finished, with no way to reach the file it
+                # produced -- the result was previously reachable only by
+                # receiving the completion webhook.
+                "path": response.path,
+                "edit_path": response.edit_path,
+            }
             async_status.updated_at = datetime.now()
             sql_session.add(async_status)
             await sql_session.commit()
@@ -2821,6 +2843,7 @@ async def _run_generate_presentation_task(
         async_status.data = _presentation_task_progress_data(
             created_slides=0,
             remaining_slides=_requested_slide_count(request),
+            presentation_id=presentation_id,
         )
         async_status.updated_at = datetime.now()
         sql_session.add(async_status)
@@ -2852,6 +2875,7 @@ async def generate_presentation_async(
             data=_presentation_task_progress_data(
                 created_slides=0,
                 remaining_slides=_requested_slide_count(request),
+                presentation_id=presentation_id,
             ),
         )
         sql_session.add(async_status)

--- a/servers/fastapi/tests/integration/test_presentation_generation_flow.py
+++ b/servers/fastapi/tests/integration/test_presentation_generation_flow.py
@@ -9,11 +9,13 @@ from fastapi import HTTPException
 
 from api.v1.ppt.endpoints import presentation as presentation_endpoint
 from constants.presentation import MAX_NUMBER_OF_SLIDES
+from enums.async_task_status import AsyncTaskStatus
 from models.generate_presentation_request import GeneratePresentationRequest
 from models.presentation_and_path import PresentationAndPath
 from models.presentation_from_template import EditPresentationRequest, SlideContentUpdate
 from models.presentation_outline_model import SlideOutlineModel
 from models.presentation_structure_model import PresentationStructureModel
+from models.sql.async_task import AsyncTaskModel
 from models.sql.presentation import PresentationModel, PresentationVersion
 from models.sql.slide import SlideModel
 from models.sql.template_v2 import TemplateV2
@@ -162,6 +164,116 @@ def test_generate_presentation_handler_full_flow_uses_mocked_dependencies():
     assert all(slide.ui is not None for slide in session.added_all)
     assert get_slide_content.call_args_list[0].kwargs["slide_number"] == 1
     assert get_slide_content.call_args_list[1].kwargs["slide_number"] == 2
+
+
+def test_async_task_data_carries_presentation_ref_for_polling_callers():
+    request = GeneratePresentationRequest(
+        content="Create a two-slide deck about renewable energy.",
+        n_slides=2,
+        language="English",
+        export_as="pptx",
+        template="general",
+    )
+    presentation_id = uuid.uuid4()
+    template_id = "general"
+    template = TemplateV2(
+        id=template_id,
+        name="General",
+        layouts=_template_layout_payload(),
+        is_default=True,
+    )
+    session = FakeAsyncSession(get_results={template_id: template})
+    async_status = AsyncTaskModel(
+        type=presentation_endpoint.ASYNC_TASK_TYPE_PRESENTATION_GENERATE,
+        status=AsyncTaskStatus.PENDING,
+        message="Queued for generation",
+    )
+
+    async def fake_outline_stream(*_args, **_kwargs):
+        yield '{"slides":[{"content":"## Intro"},{"content":"## Action Plan"}]}'
+
+    with patch.object(
+        presentation_endpoint.MEM0_PRESENTATION_MEMORY_SERVICE,
+        "store_generation_context",
+        new=AsyncMock(),
+    ), patch.object(
+        presentation_endpoint.MEM0_PRESENTATION_MEMORY_SERVICE,
+        "store_generated_outlines",
+        new=AsyncMock(),
+    ), patch.object(
+        presentation_endpoint,
+        "generate_ppt_outline",
+        side_effect=fake_outline_stream,
+    ), patch.object(
+        presentation_endpoint,
+        "generate_presentation_structure",
+        new=AsyncMock(return_value=PresentationStructureModel(slides=[0, 1])),
+    ), patch.object(
+        presentation_endpoint,
+        "get_slide_content_from_type_and_outline",
+        new=AsyncMock(return_value={"title": "Intro", "points": ["A"]}),
+    ), patch.object(
+        presentation_endpoint,
+        "process_slide_and_fetch_assets",
+        new=AsyncMock(return_value=[]),
+    ), patch.object(
+        presentation_endpoint,
+        "get_images_directory",
+        return_value="/tmp",
+    ), patch.object(
+        presentation_endpoint,
+        "ImageGenerationService",
+        return_value=Mock(),
+    ), patch.object(
+        presentation_endpoint,
+        "export_presentation",
+        new=AsyncMock(
+            return_value=PresentationAndPath(
+                presentation_id=presentation_id,
+                path="/tmp/generated/deck.pptx",
+            )
+        ),
+    ), patch.object(
+        presentation_endpoint.CONCURRENT_SERVICE,
+        "run_task",
+        new=Mock(),
+    ), patch.object(
+        presentation_endpoint,
+        "random",
+        new=Mock(randint=Mock(return_value=0)),
+    ):
+        response = _run(
+            presentation_endpoint.generate_presentation_handler(
+                request=request,
+                presentation_id=presentation_id,
+                async_status=async_status,
+                sql_session=session,
+            )
+        )
+
+    assert async_status.status == AsyncTaskStatus.COMPLETED
+    # A caller that only ever polls the task must be able to reach the file.
+    assert async_status.data["presentation_id"] == str(presentation_id)
+    assert async_status.data["path"] == response.path
+    assert async_status.data["edit_path"] == response.edit_path
+    # Progress fields are still reported alongside them.
+    assert async_status.data["created_slides"] == 2
+    assert async_status.data["remaining_slides"] == 0
+
+
+def test_async_task_data_carries_presentation_ref_before_completion():
+    """The id is present from creation, so a failed task is still identifiable."""
+    data = presentation_endpoint._presentation_task_progress_data(
+        created_slides=0,
+        remaining_slides=12,
+        presentation_id=uuid.UUID("11111111-2222-3333-4444-555555555555"),
+    )
+
+    assert data == {
+        "created_slides": 0,
+        "remaining_slides": 12,
+        "presentation_id": "11111111-2222-3333-4444-555555555555",
+    }
 
 
 def test_generate_presentation_handler_uses_template_layout():

--- a/servers/fastapi/tests/test_presentation_generation_api.py
+++ b/servers/fastapi/tests/test_presentation_generation_api.py
@@ -135,7 +135,11 @@ class TestPresentationGenerationAPI:
         assert task.type == "presentation.generate"
         assert task.status == "pending"
         assert task.message == "Queued for generation"
-        assert task.data == {"created_slides": 0, "remaining_slides": 5}
+        assert task.data["created_slides"] == 0
+        assert task.data["remaining_slides"] == 5
+        # Present from the moment the task is enqueued, so a polling caller
+        # can identify the presentation without waiting for completion.
+        assert uuid.UUID(task.data["presentation_id"])
         assert fake_session.added == [task]
         assert fake_session.commit_count == 1
         assert len(background_tasks.tasks) == 1


### PR DESCRIPTION
A caller driving /presentation/generate/async by polling /async-tasks/status/{id} could tell that a task had finished, but not what it produced. The task's data field carried only created_slides and remaining_slides throughout, and the presentation id and export path reached the caller solely through the completion webhook -- so anyone without a public webhook endpoint had no way to get from a completed task back to the file, short of listing all presentations and guessing by recency.

Task data now carries presentation_id from the moment the task is enqueued, which also makes a *failed* task identifiable -- previously an errored task left no trace of which presentation it belonged to. On completion the data additionally carries path and edit_path, the same values the synchronous /presentation/generate endpoint returns in its response body. Existing fields are unchanged and progress reporting is untouched.

This makes polling a complete alternative to the webhook, which matters for long generations behind a proxy that limits request duration: the caller can start the work, poll cheaply, and fetch the result, without any single request having to stay open for the whole run.