### PR TITLE
fix: update MCP authentication handling in nginx configuration and ad…

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -74,7 +74,9 @@ http {
 
     # MCP
     location /mcp/ {
-      auth_request /_auth_check;
+      # FastMCP validates the Presenton bearer key itself. Do not use the
+      # app-data auth subrequest here: /_auth_check applies path ownership
+      # rules to X-Original-URI and therefore rejects the non-asset /mcp path.
       proxy_pass http://localhost:8001/mcp/;
       proxy_read_timeout 30m;
       proxy_connect_timeout 30m;
@@ -85,7 +87,7 @@ http {
     }
 
     location /mcp {
-      auth_request /_auth_check;
+      # Authentication is enforced by PresentonTokenVerifier in mcp_server.py.
       proxy_pass http://localhost:8001/mcp;
       proxy_read_timeout 30m;
       proxy_connect_timeout 30m;

--- a/servers/fastapi/tests/unit/test_nginx_mcp_config.py
+++ b/servers/fastapi/tests/unit/test_nginx_mcp_config.py
@@ -1,0 +1,35 @@
+import re
+from pathlib import Path
+
+
+NGINX_CONFIG = Path(__file__).resolve().parents[4] / "nginx.conf"
+
+
+def _location_block(config: str, path: str) -> str:
+    match = re.search(
+        rf"location {re.escape(path)} \{{(?P<body>.*?)\n    \}}",
+        config,
+        flags=re.DOTALL,
+    )
+    assert match is not None, f"Missing Nginx location for {path}"
+    return match.group("body")
+
+
+def test_mcp_routes_delegate_authentication_to_fastmcp():
+    config = NGINX_CONFIG.read_text(encoding="utf-8")
+
+    for path in ("/mcp/", "/mcp"):
+        block = _location_block(config, path)
+        assert "auth_request" not in block
+        assert "proxy_pass http://localhost:8001/mcp" in block
+
+
+def test_private_app_data_routes_still_use_auth_subrequest():
+    config = NGINX_CONFIG.read_text(encoding="utf-8")
+
+    for path in (
+        "/app_data/images/",
+        "/app_data/exports/",
+        "/app_data/uploads/",
+    ):
+        assert "auth_request /_auth_check;" in _location_block(config, path)


### PR DESCRIPTION
This pull request updates the Nginx configuration to delegate authentication for `/mcp` routes to the FastMCP service itself, rather than using the standard Nginx auth subrequest. It also adds tests to ensure the correct authentication behavior for both `/mcp` and private app data routes.

**Nginx configuration changes:**

* Removed `auth_request /_auth_check;` from the `/mcp/` and `/mcp` location blocks in `nginx.conf`, with comments explaining that authentication for these routes is now handled internally by FastMCP or PresentonTokenVerifier, not by Nginx. [[1]](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaL77-R79) [[2]](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaL88-R90)

**Testing and verification:**

* Added `test_nginx_mcp_config.py` to verify that `/mcp` routes do not use the Nginx auth subrequest and that private app data routes still require it. This ensures the configuration changes are enforced and that authentication is handled as intended.…d tests