### PR TITLE
fix(templates): show actionable loading errors

### DIFF
--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/templates/components/TemplatePanel.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/templates/components/TemplatePanel.tsx
@@ -23,6 +23,7 @@ const LayoutPreview = () => {
     customTemplates,
     processingTemplateTasks,
     loading,
+    error,
   } = useTemplateSummaries({ includeProcessingTemplateTasks: true });
 
   useEffect(() => {
@@ -91,6 +92,8 @@ const LayoutPreview = () => {
         <section className="my-12">
           {loading ? (
             <TemplateListLoadingState />
+          ) : error ? (
+            <TemplateListEmptyState message={`Templates could not be loaded: ${error}`} />
           ) : tab === "custom" ? (
             <div className="grid grid-cols-1 items-center gap-6 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
               <CreateCustomTemplate />

--- a/servers/nextjs/app/(presentation-generator)/hooks/useTemplateSummaries.ts
+++ b/servers/nextjs/app/(presentation-generator)/hooks/useTemplateSummaries.ts
@@ -72,6 +72,7 @@ export function useTemplateSummaries({
     TemplateCreateTaskResponse[]
   >([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -108,6 +109,7 @@ export function useTemplateSummaries({
 
     const loadInitialTemplates = async () => {
       setLoading(true);
+      setError(null);
       try {
         const [loadedTemplates, processingTasks] = await Promise.all([
           loadTemplateSummaries(),
@@ -122,7 +124,12 @@ export function useTemplateSummaries({
       } catch (error) {
         console.error("Failed to load templates", error);
         if (!cancelled) {
-          toast.error("Failed to load templates");
+          const message =
+            error instanceof Error
+              ? error.message
+              : "The template service could not be reached. Please try again.";
+          setError(message);
+          toast.error("Could not load templates", { description: message });
         }
       } finally {
         if (!cancelled) {
@@ -177,5 +184,6 @@ export function useTemplateSummaries({
     customTemplates,
     processingTemplateTasks,
     loading,
+    error,
   };
 }

--- a/servers/nextjs/app/(presentation-generator)/outline/components/TemplateSelection.tsx
+++ b/servers/nextjs/app/(presentation-generator)/outline/components/TemplateSelection.tsx
@@ -47,7 +47,7 @@ const TemplateSelection: React.FC<TemplateSelectionProps> = memo(
     const presentonCloudOnly = useSelector(
       (state: RootState) => state.userConfig.llm_config.LLM === "presenton"
     );
-    const { defaultTemplates, customTemplates, loading } =
+    const { defaultTemplates, customTemplates, loading, error } =
       useTemplateSummaries({ presentonCloudOnly });
 
     useEffect(() => {
@@ -91,6 +91,14 @@ const TemplateSelection: React.FC<TemplateSelectionProps> = memo(
 
     if (loading) {
       return <TemplateListLoadingState />;
+    }
+
+    if (error) {
+      return (
+        <TemplateListEmptyState
+          message={`Templates could not be loaded: ${error}`}
+        />
+      );
     }
 
     const renderTemplateCard = (


### PR DESCRIPTION
## Summary
- expose template-loading failures from the shared summaries hook
- replace the generic toast-only failure with an inline actionable empty state
- use the same error treatment in the templates directory and outline selector

## Validation
- Next.js TypeScript production build passed
- full GitHub Next.js workflow will run on this PR