### PR TITLE
feat(smart): resume streams and show reasoning metrics

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/presentation.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/presentation.py
@@ -1683,8 +1683,11 @@ async def _stream_smart_presentation(
     sql_session: AsyncSession,
 ) -> StreamingResponse:
     presentation_id = presentation.id
+    requested_slide_count = resolve_smart_slide_count(presentation.n_slides)
 
     async def inner():
+        slide_count = requested_slide_count
+        presentation.n_slides = slide_count
         existing_slides = list(
             await sql_session.scalars(
                 select(SlideModel)
@@ -1693,6 +1696,13 @@ async def _stream_smart_presentation(
             )
         )
         if existing_slides:
+            if presentation.fonts:
+                yield SSEResponse(
+                    event="response",
+                    data=json.dumps(
+                        {"type": "fonts", "fonts": presentation.fonts}
+                    ),
+                ).to_string()
             for slide in existing_slides:
                 yield SSEResponse(
                     event="response",
@@ -1706,17 +1716,31 @@ async def _stream_smart_presentation(
                         }
                     ),
                 ).to_string()
-            response = PresentationWithSlides(
-                **_presentation_response_data(presentation),
-                slides=existing_slides,
-            )
-            yield SSECompleteResponse(
-                key="presentation",
-                value=response.model_dump(mode="json"),
-            ).to_string()
-            return
+            if len(existing_slides) >= slide_count:
+                presentation.title = (
+                    presentation.title
+                    or str(existing_slides[0].content.get("title") or "").strip()
+                    or "Presentation"
+                )
+                sql_session.add(presentation)
+                await sql_session.commit()
+                response = PresentationWithSlides(
+                    **_presentation_response_data(presentation),
+                    slides=existing_slides[:slide_count],
+                )
+                yield SSECompleteResponse(
+                    key="presentation",
+                    value=response.model_dump(mode="json"),
+                ).to_string()
+                return
 
-        yield SSEStatusResponse(status="Preparing Smart presentation").to_string()
+        yield SSEStatusResponse(
+            status=(
+                f"Resuming Smart presentation from slide {len(existing_slides) + 1}"
+                if existing_slides
+                else "Preparing Smart presentation"
+            )
+        ).to_string()
         references = await load_community_references(
             presentation.community_design_ids
         )
@@ -1750,23 +1774,32 @@ async def _stream_smart_presentation(
         if len(source_context) > 90_000:
             source_context = source_context[:90_000]
 
-        slide_count = resolve_smart_slide_count(presentation.n_slides)
-        presentation.n_slides = slide_count
-        presentation.fonts = reference_fonts or {
+        presentation.fonts = presentation.fonts or reference_fonts or {
             "Inter": "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
         }
+        # Release the request session's read transaction before independent
+        # checkpoint sessions begin writing (important for SQLite), while also
+        # persisting the resolved slide count and fonts for reconnects.
+        sql_session.add(presentation)
+        await sql_session.commit()
         yield SSEResponse(
             event="response",
             data=json.dumps({"type": "fonts", "fonts": presentation.fonts}),
         ).to_string()
         yield SSEStatusResponse(
             status=(
-                "Applying community design reference"
-                if references
-                else "Designing the complete presentation"
+                f"Continuing from slide {len(existing_slides) + 1}"
+                if existing_slides
+                else (
+                    "Applying community design reference"
+                    if references
+                    else "Designing the complete presentation"
+                )
             )
         ).to_string()
-        streamed_slides: dict[int, SlideModel] = {}
+        streamed_slides: dict[int, SlideModel] = {
+            slide.index: slide for slide in existing_slides
+        }
         generation_events: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
 
         async def emit_slide(index: int, slide: dict[str, str]) -> None:
@@ -1788,10 +1821,59 @@ async def _stream_smart_presentation(
                 streamed_slide.content = {"title": slide["title"]}
                 streamed_slide.html_content = slide["html"]
                 streamed_slide.speaker_note = ""
+
+            # Checkpoint before emitting. If the model later runs out of tokens
+            # or the SSE client reconnects, generation resumes after this slide
+            # instead of throwing away the accepted prefix.
+            async with async_session_maker() as checkpoint_session:
+                checkpoint = (
+                    await checkpoint_session.scalars(
+                        select(SlideModel).where(
+                            SlideModel.presentation == presentation_id,
+                            SlideModel.index == index,
+                        )
+                    )
+                ).first()
+                if checkpoint is None:
+                    checkpoint = SlideModel(
+                        id=streamed_slide.id,
+                        owner_id=get_current_owner_id(),
+                        presentation=presentation_id,
+                        layout_group="smart-html",
+                        layout="smart-html",
+                        index=index,
+                        content={"title": slide["title"]},
+                        html_content=slide["html"],
+                        speaker_note="",
+                    )
+                else:
+                    streamed_slide.id = checkpoint.id
+                    checkpoint.layout_group = "smart-html"
+                    checkpoint.layout = "smart-html"
+                    checkpoint.content = {"title": slide["title"]}
+                    checkpoint.html_content = slide["html"]
+                    checkpoint.speaker_note = ""
+                checkpoint_session.add(checkpoint)
+                checkpoint_presentation = await checkpoint_session.get(
+                    PresentationModel, presentation_id
+                )
+                if checkpoint_presentation is not None:
+                    checkpoint_presentation.n_slides = slide_count
+                    checkpoint_presentation.fonts = presentation.fonts
+                    checkpoint_session.add(checkpoint_presentation)
+                await checkpoint_session.commit()
             await generation_events.put(("slide", streamed_slide))
 
         async def emit_metrics(metrics: TextGenerationMetrics) -> None:
             await generation_events.put(("metrics", metrics))
+
+        async def emit_retry(next_slide_index: int, _error: str) -> None:
+            await generation_events.put(
+                (
+                    "status",
+                    f"Retrying from slide {next_slide_index + 1} with saved progress",
+                )
+            )
 
         generation_task = asyncio.create_task(
             generate_smart_presentation(
@@ -1806,8 +1888,13 @@ async def _stream_smart_presentation(
                 source_context=source_context,
                 community_design_context=community_context,
                 fonts=presentation.fonts,
+                existing_slides=[
+                    {"html": slide.html_content or ""} for slide in existing_slides
+                ],
+                existing_title=presentation.title,
                 on_slide=emit_slide,
                 on_metrics=emit_metrics,
+                on_retry=emit_retry,
             )
         )
 
@@ -1818,6 +1905,9 @@ async def _stream_smart_presentation(
                         generation_events.get(), timeout=0.1
                     )
                 except asyncio.TimeoutError:
+                    continue
+                if event_type == "status":
+                    yield SSEStatusResponse(status=str(event_value)).to_string()
                     continue
                 if event_type == "metrics":
                     metrics = event_value
@@ -1851,50 +1941,48 @@ async def _stream_smart_presentation(
                 generation_task.cancel()
                 await asyncio.gather(generation_task, return_exceptions=True)
 
-        presentation.title = deck["title"]
-        slides: list[SlideModel] = []
-        for index, slide in enumerate(deck["slides"]):
-            final_slide = streamed_slides.get(index)
-            if final_slide is None:
-                final_slide = SlideModel(
-                    presentation=presentation_id,
-                    layout_group="smart-html",
-                    layout="smart-html",
-                    index=index,
-                    content={"title": slide["title"]},
-                    html_content=slide["html"],
-                    speaker_note="",
-                )
-                yield SSEResponse(
-                    event="response",
-                    data=json.dumps(
-                        {
-                            "type": "slide_html",
-                            "index": index,
-                            "slide_id": str(final_slide.id),
-                            "html": final_slide.html_content,
-                            "slide": final_slide.model_dump(mode="json"),
-                        }
-                    ),
-                ).to_string()
-            else:
-                final_slide.content = {"title": slide["title"]}
-                final_slide.html_content = slide["html"]
-                final_slide.speaker_note = ""
-            slides.append(final_slide)
+        final_title = deck["title"]
+        final_fonts = dict(presentation.fonts or {})
 
-        await sql_session.execute(
-            delete(SlideModel).where(
-                SlideModel.presentation == presentation_id,
-                SlideModel.owner_id == get_current_owner_id(),
+        # Start a fresh transaction so this session sees slides committed by
+        # the checkpoint sessions. Do not delete/reinsert them: the editor may
+        # already have persisted asset or HTML updates while generation ran.
+        await sql_session.rollback()
+        final_presentation = await sql_session.get(PresentationModel, presentation_id)
+        if final_presentation is None:
+            raise HTTPException(status_code=404, detail="Presentation not found")
+        slides = list(
+            await sql_session.scalars(
+                select(SlideModel)
+                .where(SlideModel.presentation == presentation_id)
+                .order_by(SlideModel.index)
             )
         )
-        sql_session.add(presentation)
-        sql_session.add_all(slides)
+        slides_by_index = {slide.index: slide for slide in slides}
+        for index, slide in enumerate(deck["slides"]):
+            if index in slides_by_index:
+                continue
+            recovered_slide = SlideModel(
+                presentation=presentation_id,
+                layout_group="smart-html",
+                layout="smart-html",
+                index=index,
+                content={"title": slide["title"]},
+                html_content=slide["html"],
+                speaker_note="",
+            )
+            sql_session.add(recovered_slide)
+            slides_by_index[index] = recovered_slide
+        slides = [slides_by_index[index] for index in range(slide_count)]
+
+        final_presentation.title = final_title
+        final_presentation.n_slides = slide_count
+        final_presentation.fonts = final_fonts
+        sql_session.add(final_presentation)
         await sql_session.commit()
 
         response = PresentationWithSlides(
-            **_presentation_response_data(presentation),
+            **_presentation_response_data(final_presentation),
             slides=slides,
         )
         yield SSECompleteResponse(
@@ -1905,12 +1993,36 @@ async def _stream_smart_presentation(
     async def rollback_stream_session():
         await sql_session.rollback()
 
+    async def smart_error_metadata(exc: Exception) -> dict[str, object]:
+        async with async_session_maker() as progress_session:
+            completed_slides = len(
+                list(
+                    await progress_session.scalars(
+                        select(SlideModel).where(
+                            SlideModel.presentation == presentation_id
+                        )
+                    )
+                )
+            )
+        status_code = exc.status_code if isinstance(exc, HTTPException) else 500
+        return {
+            "source": "generation",
+            "status_code": status_code,
+            "error_type": exc.__class__.__name__,
+            "retryable": (
+                status_code in {408, 429} or status_code >= 500
+            ),
+            "completed_slides": completed_slides,
+            "total_slides": requested_slide_count,
+        }
+
     return StreamingResponse(
         safe_sse_stream(
             inner(),
             logger=logger,
             error_detail="Failed to generate the Smart presentation. Please try again.",
             on_error=rollback_stream_session,
+            error_metadata=smart_error_metadata,
         ),
         media_type="text/event-stream",
     )

--- a/servers/fastapi/models/sse_response.py
+++ b/servers/fastapi/models/sse_response.py
@@ -31,10 +31,17 @@ class SSETraceResponse(BaseModel):
 
 class SSEErrorResponse(BaseModel):
     detail: str
+    source: str | None = None
+    status_code: int | None = None
+    error_type: str | None = None
+    retryable: bool | None = None
+    completed_slides: int | None = None
+    total_slides: int | None = None
 
     def to_string(self):
+        payload = {"type": "error", **self.model_dump(exclude_none=True)}
         return SSEResponse(
-            event="response", data=json.dumps({"type": "error", "detail": self.detail})
+            event="response", data=json.dumps(payload)
         ).to_string()
 
 

--- a/servers/fastapi/tests/unit/test_small_surfaces_coverage.py
+++ b/servers/fastapi/tests/unit/test_small_surfaces_coverage.py
@@ -209,6 +209,44 @@ def test_safe_sse_stream_converts_late_exception_to_error_frame():
     assert data == {"type": "error", "detail": "Stream failed"}
 
 
+def test_safe_sse_stream_includes_structured_progress_metadata():
+    async def broken_stream():
+        raise HTTPException(status_code=422, detail="Generation was incomplete")
+        yield ""  # pragma: no cover
+
+    async def error_metadata(_error):
+        return {
+            "source": "generation",
+            "status_code": 422,
+            "retryable": False,
+            "completed_slides": 3,
+            "total_slides": 8,
+        }
+
+    async def collect():
+        return [
+            chunk
+            async for chunk in safe_sse_stream(
+                broken_stream(),
+                logger=MagicMock(),
+                error_detail="Stream failed",
+                error_metadata=error_metadata,
+            )
+        ]
+
+    chunks = asyncio.run(collect())
+    _event, data = _parse_sse_frame(chunks[-1])
+    assert data == {
+        "type": "error",
+        "detail": "Generation was incomplete",
+        "source": "generation",
+        "status_code": 422,
+        "retryable": False,
+        "completed_slides": 3,
+        "total_slides": 8,
+    }
+
+
 @pytest.mark.parametrize("theme", [{}, None])
 def test_presentation_model_get_new_and_typed_getters(theme):
     outline, layout_payload, structure_payload = _outline_layout_structure_payloads()

--- a/servers/fastapi/tests/unit/test_smart_presentation_generation.py
+++ b/servers/fastapi/tests/unit/test_smart_presentation_generation.py
@@ -17,6 +17,7 @@ from utils.llm_calls.generate_smart_presentation import (
     SMART_DECK_SYSTEM_PROMPT,
     SmartSlideStreamParser,
     _stream_deck_response,
+    generate_smart_presentation,
     get_smart_messages,
     get_smart_reasoning_config,
     normalize_smart_deck,
@@ -24,6 +25,7 @@ from utils.llm_calls.generate_smart_presentation import (
     parse_smart_presentation_html,
     resolve_smart_slide_count,
 )
+from utils.llm_utils import build_text_generation_metrics
 
 
 def _smart_slide_html(title="Slide", slide_type="content", body="Content"):
@@ -164,6 +166,30 @@ def test_smart_reasoning_respects_disable_thinking(monkeypatch):
     assert supports_thinking is False
 
 
+def test_smart_explicit_reasoning_overrides_legacy_disable(monkeypatch):
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.disable_thinking",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.has_explicit_reasoning_settings",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.get_llm_provider",
+        lambda: LLMProvider.OPENAI,
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.llmai.supports_thinking",
+        lambda model, provider=None: True,
+    )
+
+    reasoning, supports_thinking = get_smart_reasoning_config("gpt-5")
+
+    assert reasoning is None
+    assert supports_thinking is True
+
+
 def test_smart_stream_separates_thinking_and_reports_exact_usage(monkeypatch):
     reasoning = ReasoningConfig(enabled=True)
     captured_kwargs = {}
@@ -221,6 +247,226 @@ def test_smart_stream_separates_thinking_and_reports_exact_usage(monkeypatch):
     assert metrics.thinking_tokens == 5
     assert metrics.thinking_tokens_estimated is False
     assert metrics.supports_thinking is True
+
+
+def test_estimated_thinking_contributes_to_live_throughput():
+    messages = [UserMessage(content="12345678")]
+    metrics = build_text_generation_metrics(
+        model="thinking-model",
+        messages=messages,
+        content="12345678",
+        streamed_thinking="abcdefghijklmnop",
+        completion=SimpleNamespace(usage=None, duration_seconds=2.0),
+        started_at=0,
+        model_supports_thinking=True,
+    )
+
+    assert metrics.input_tokens == 2
+    assert metrics.output_tokens == 2
+    assert metrics.thinking_tokens == 4
+    assert metrics.total_tokens == 8
+    assert metrics.tokens_per_second == 3
+    assert metrics.estimated is True
+
+
+def test_smart_stream_reports_no_progress_token_limit(monkeypatch):
+    async def fake_stream_generate_events(_client, **_kwargs):
+        yield SimpleNamespace(
+            type="completion",
+            content=None,
+            finish_reason="length",
+            usage=None,
+            duration_seconds=1.0,
+        )
+
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.stream_generate_events",
+        fake_stream_generate_events,
+    )
+    monkeypatch.setattr("utils.llm_utils.get_extra_body", lambda **_kwargs: None)
+
+    async def on_chunk(_chunk):
+        return None
+
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(
+            _stream_deck_response(
+                object(),
+                "limited-model",
+                [UserMessage(content="Build a deck")],
+                on_chunk,
+            )
+        )
+
+    assert error.value.status_code == 422
+    assert "output-token limit" in str(error.value.detail)
+
+
+def test_smart_generation_keeps_prefix_when_continuation_hits_token_limit(
+    monkeypatch,
+):
+    first_response = (
+        "<!-- SLIDE_START -->"
+        + _smart_slide_html("Cover", "title")
+        + "<!-- SLIDE_END -->"
+    )
+    final_response = (
+        "<!-- PRESENTATION_TITLE: Resumed deck -->"
+        "<!-- SLIDE_START -->"
+        + _smart_slide_html("Conclusion", "closing")
+        + "<!-- SLIDE_END -->"
+    )
+    calls = 0
+    streamed_indices = []
+    retry_indices = []
+    metrics = SimpleNamespace(finish_reason=None)
+    length_metrics = SimpleNamespace(finish_reason="length")
+
+    async def fake_stream_response(
+        _client,
+        _model,
+        _messages,
+        on_chunk,
+        **_kwargs,
+    ):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            await on_chunk(first_response)
+            return first_response, metrics
+        if calls == 2:
+            # A continuation can consume its entire token allowance without
+            # closing another slide. The already checkpointed prefix must make
+            # the next continuation possible instead of turning this into a
+            # terminal 422.
+            await on_chunk("<!-- incomplete continuation -->")
+            return "<!-- incomplete continuation -->", length_metrics
+        await on_chunk(final_response)
+        return final_response, metrics
+
+    async def capture_slide(index, _slide):
+        streamed_indices.append(index)
+
+    async def capture_retry(index, _error):
+        retry_indices.append(index)
+
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.get_client",
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.get_llm_config",
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.get_model",
+        lambda: "limited-model",
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.get_smart_reasoning_config",
+        lambda _model: (None, False),
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation._stream_deck_response",
+        fake_stream_response,
+    )
+
+    deck = asyncio.run(
+        generate_smart_presentation(
+            content="Build a two-slide deck",
+            n_slides=2,
+            language="English",
+            tone=None,
+            verbosity=None,
+            instructions=None,
+            include_title_slide=True,
+            include_table_of_contents=False,
+            on_slide=capture_slide,
+            on_retry=capture_retry,
+        )
+    )
+
+    assert calls == 3
+    assert streamed_indices == [0, 1]
+    assert retry_indices == [1, 1]
+    assert deck["title"] == "Resumed deck"
+    assert [slide["title"] for slide in deck["slides"]] == [
+        "Cover",
+        "Conclusion",
+    ]
+
+
+def test_smart_generation_resumes_from_existing_checkpoint(monkeypatch):
+    response = (
+        "<!-- PRESENTATION_TITLE: Saved deck -->"
+        "<!-- SLIDE_START -->"
+        + _smart_slide_html("Conclusion", "closing")
+        + "<!-- SLIDE_END -->"
+    )
+    captured_prompt = ""
+    streamed_indices = []
+    metrics = SimpleNamespace(finish_reason=None)
+
+    async def fake_stream_response(
+        _client,
+        _model,
+        messages,
+        on_chunk,
+        **_kwargs,
+    ):
+        nonlocal captured_prompt
+        captured_prompt = str(messages[1].content)
+        await on_chunk(response)
+        return response, metrics
+
+    async def capture_slide(index, _slide):
+        streamed_indices.append(index)
+
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.get_client",
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.get_llm_config",
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.get_model",
+        lambda: "test-model",
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation.get_smart_reasoning_config",
+        lambda _model: (None, False),
+    )
+    monkeypatch.setattr(
+        "utils.llm_calls.generate_smart_presentation._stream_deck_response",
+        fake_stream_response,
+    )
+
+    deck = asyncio.run(
+        generate_smart_presentation(
+            content="Build a two-slide deck",
+            n_slides=2,
+            language="English",
+            tone=None,
+            verbosity=None,
+            instructions=None,
+            include_title_slide=True,
+            include_table_of_contents=False,
+            existing_slides=[{"html": _smart_slide_html("Cover", "title")}],
+            existing_title="Saved deck",
+            on_slide=capture_slide,
+        )
+    )
+
+    assert streamed_indices == [1]
+    assert "Slides 1-1" in captured_prompt
+    assert "Generate exactly 1 remaining slide" in captured_prompt
+    assert deck["title"] == "Saved deck"
+    assert [slide["title"] for slide in deck["slides"]] == [
+        "Cover",
+        "Conclusion",
+    ]
 
 
 def test_normalize_community_ids_preserves_order_and_deduplicates():

--- a/servers/fastapi/utils/llm_calls/generate_smart_presentation.py
+++ b/servers/fastapi/utils/llm_calls/generate_smart_presentation.py
@@ -6,6 +6,7 @@ import json
 import re
 import time
 from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import replace
 from typing import Any, Optional
 
 import llmai
@@ -22,7 +23,11 @@ from llmai.shared import (
 )
 
 from utils.llm_client_error_handler import handle_llm_client_exceptions
-from utils.llm_config import disable_thinking, get_llm_config
+from utils.llm_config import (
+    disable_thinking,
+    get_llm_config,
+    has_explicit_reasoning_settings,
+)
 from utils.llm_provider import get_llm_provider, get_model
 from utils.llm_utils import (
     TextGenerationMetrics,
@@ -50,6 +55,7 @@ SMART_TOC_MAX_VISIBLE_CHARACTERS = 1900
 SMART_TOC_MAX_VISIBLE_WORDS = 220
 SmartSlideCallback = Callable[[int, dict[str, str]], Awaitable[None]]
 SmartMetricsCallback = Callable[[TextGenerationMetrics], Awaitable[None]]
+SmartRetryCallback = Callable[[int, str], Awaitable[None]]
 
 SMART_DECK_SYSTEM_PROMPT = (
     "You are an expert presentation designer and frontend engineer. Return the "
@@ -664,9 +670,19 @@ async def _stream_deck_response(
                 chunks.append(chunk)
                 await on_chunk(chunk)
     response = extract_text(getattr(completion, "content", None)) or "".join(chunks)
+    finish_reason = getattr(completion, "finish_reason", None)
     if not chunks and response:
         await on_chunk(response)
     if not response:
+        if finish_reason == "length":
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "The model reached its output-token limit before producing a "
+                    "complete Smart slide. Increase Max output tokens in Advanced "
+                    "text-provider settings or reduce the slide count/reasoning effort."
+                ),
+            )
         raise HTTPException(status_code=400, detail="LLM did not return any content")
     metrics = build_text_generation_metrics(
         model=model,
@@ -677,12 +693,13 @@ async def _stream_deck_response(
         started_at=started_at,
         model_supports_thinking=model_supports_thinking,
     )
+    metrics = replace(metrics, finish_reason=finish_reason)
     return response, metrics
 
 
 def get_smart_reasoning_config(model: str) -> tuple[ReasoningConfig | None, bool]:
     """Enable reasoning only when llmai knows the selected model supports it."""
-    if disable_thinking():
+    if disable_thinking() and not has_explicit_reasoning_settings():
         return None, False
 
     provider = get_llm_provider().value
@@ -690,6 +707,8 @@ def get_smart_reasoning_config(model: str) -> tuple[ReasoningConfig | None, bool
         supports_thinking = llmai.supports_thinking(model, provider=provider) is True
     except Exception:
         supports_thinking = False
+    if has_explicit_reasoning_settings():
+        return None, supports_thinking
     if not supports_thinking:
         return None, False
 
@@ -719,18 +738,47 @@ async def generate_smart_presentation(
     source_context: str = "",
     community_design_context: str = "",
     fonts: Optional[dict[str, str]] = None,
+    existing_slides: Optional[Sequence[dict[str, str]]] = None,
+    existing_title: Optional[str] = None,
     on_slide: SmartSlideCallback | None = None,
     on_metrics: SmartMetricsCallback | None = None,
+    on_retry: SmartRetryCallback | None = None,
 ) -> dict[str, Any]:
     client = get_client(config=get_llm_config(use_openai_responses_api=True))
     model = get_model()
     reasoning, configured_thinking_support = get_smart_reasoning_config(model)
     accepted_slides: list[dict[str, str]] = []
-    title = ""
+    for index, saved_slide in enumerate(existing_slides or []):
+        normalized_slide = _slide_from_html(saved_slide.get("html"), index)
+        _validate_slide_position(
+            normalized_slide,
+            index,
+            include_title_slide=include_title_slide,
+            include_table_of_contents=include_table_of_contents,
+        )
+        accepted_slides.append(normalized_slide)
+    if len(accepted_slides) > n_slides:
+        raise HTTPException(
+            status_code=500,
+            detail="Saved Smart presentation checkpoint has too many slides",
+        )
+
+    title = (existing_title or "").strip()
+    if len(accepted_slides) >= n_slides:
+        return {
+            "title": title or accepted_slides[0]["title"],
+            "slides": accepted_slides[:n_slides],
+            "metrics": None,
+        }
     last_exception: Exception | None = None
     retry_error: str | None = None
 
     for _attempt in range(SMART_GENERATION_MAX_ATTEMPTS):
+        if _attempt > 0 and on_retry is not None:
+            await on_retry(
+                len(accepted_slides),
+                retry_error or "The prior generation attempt was incomplete.",
+            )
         messages = get_smart_messages(
             content=content,
             n_slides=n_slides,
@@ -752,6 +800,7 @@ async def generate_smart_presentation(
         streamed_thinking = ""
         model_supports_thinking = configured_thinking_support
         attempt_started_at = time.perf_counter()
+        attempt_finish_reason: str | None = None
         estimated_input_tokens = estimate_message_tokens(messages)
 
         async def handle_chunk(chunk: str) -> None:
@@ -789,14 +838,15 @@ async def generate_smart_presentation(
                     if streamed_thinking
                     else (0 if model_supports_thinking else None)
                 )
+                generated_tokens = output_tokens + (thinking_tokens or 0)
                 if on_metrics is not None:
                     await on_metrics(
                         TextGenerationMetrics(
                             model=model,
                             input_tokens=estimated_input_tokens,
                             output_tokens=output_tokens,
-                            total_tokens=estimated_input_tokens + output_tokens,
-                            tokens_per_second=output_tokens / duration,
+                            total_tokens=estimated_input_tokens + generated_tokens,
+                            tokens_per_second=generated_tokens / duration,
                             duration_seconds=duration,
                             estimated=True,
                             thinking_tokens=thinking_tokens,
@@ -821,6 +871,7 @@ async def generate_smart_presentation(
                     on_thinking_chunk=handle_thinking_chunk,
                     model_supports_thinking=model_supports_thinking,
                 )
+                attempt_finish_reason = metrics.finish_reason
             finally:
                 if metrics_task is not None:
                     metrics_task.cancel()
@@ -856,6 +907,26 @@ async def generate_smart_presentation(
             if not title and title_match is not None:
                 title = title_match.group(1).strip()
             accepted_slides.extend(attempt_slides)
+            if (
+                isinstance(exc, HTTPException)
+                and exc.status_code == 422
+                and not attempt_slides
+                and not accepted_slides
+            ):
+                raise
+            if (
+                attempt_finish_reason == "length"
+                and not attempt_slides
+                and not accepted_slides
+            ):
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "The model reached its output-token limit without completing "
+                        "a Smart slide. Increase Max output tokens in Advanced "
+                        "text-provider settings or reduce reasoning effort."
+                    ),
+                ) from exc
             if len(accepted_slides) >= n_slides:
                 return {
                     "title": title or accepted_slides[0]["title"],

--- a/servers/fastapi/utils/llm_utils.py
+++ b/servers/fastapi/utils/llm_utils.py
@@ -41,6 +41,7 @@ class TextGenerationMetrics:
     thinking_tokens: Optional[int] = None
     thinking_tokens_estimated: bool = False
     supports_thinking: bool = False
+    finish_reason: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -233,6 +234,15 @@ def build_text_generation_metrics(
         thinking_tokens = 0
         thinking_tokens_estimated = True
 
+    # Provider-reported output usage normally already includes reasoning
+    # tokens. When usage is unavailable, however, ``output_tokens`` is only an
+    # estimate of visible content. Include the separately streamed thinking
+    # estimate so live throughput does not incorrectly read 0 t/s while a
+    # reasoning model is actively working.
+    generated_tokens = output_tokens
+    if exact_output_tokens is None and thinking_tokens is not None:
+        generated_tokens += thinking_tokens
+
     duration_seconds = (
         getattr(completion, "duration_seconds", None)
         if completion is not None
@@ -242,14 +252,14 @@ def build_text_generation_metrics(
         duration_seconds = max(time.perf_counter() - started_at, 1e-9)
     total_tokens = _usage_token_value(usage, "total_tokens")
     if total_tokens is None:
-        total_tokens = input_tokens + output_tokens
+        total_tokens = input_tokens + generated_tokens
 
     return TextGenerationMetrics(
         model=model,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
-        tokens_per_second=output_tokens / duration_seconds,
+        tokens_per_second=generated_tokens / duration_seconds,
         duration_seconds=duration_seconds,
         estimated=exact_input_tokens is None or exact_output_tokens is None,
         thinking_tokens=thinking_tokens,

--- a/servers/fastapi/utils/sse.py
+++ b/servers/fastapi/utils/sse.py
@@ -13,6 +13,7 @@ async def safe_sse_stream(
     logger: logging.Logger,
     error_detail: str,
     on_error: Callable[[], Awaitable[None]] | None = None,
+    error_metadata: Callable[[Exception], Awaitable[dict[str, object]]] | None = None,
 ) -> AsyncGenerator[str, None]:
     try:
         async for chunk in stream:
@@ -28,4 +29,10 @@ async def safe_sse_stream(
             except Exception:
                 logger.exception("SSE stream error cleanup failed")
         detail = exc.detail if isinstance(exc, HTTPException) else error_detail
-        yield SSEErrorResponse(detail=str(detail)).to_string()
+        metadata: dict[str, object] = {}
+        if error_metadata:
+            try:
+                metadata = await error_metadata(exc)
+            except Exception:
+                logger.exception("SSE stream error metadata lookup failed")
+        yield SSEErrorResponse(detail=str(detail), **metadata).to_string()

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/PresentationHeader.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/PresentationHeader.tsx
@@ -54,6 +54,7 @@ import { cn } from "@/lib/utils";
 import { KeyboardShortcutsDialog } from "./KeyboardShortcutsDialog";
 import { sanitizeAnalyticsError } from "@/utils/analytics";
 import { v4 as uuidv4 } from "uuid";
+import StreamingGenerationMetrics from "./StreamingGenerationMetrics";
 
 const MAX_EXPORT_TITLE_LENGTH = 40;
 
@@ -117,9 +118,12 @@ const PresentationHeader = ({
   const pathname = usePathname();
   const dispatch = useDispatch();
 
-  const { presentationData, isStreaming, enableHtmlSelector } = useSelector(
-    (state: RootState) => state.presentationGeneration
-  );
+  const {
+    presentationData,
+    isStreaming,
+    enableHtmlSelector,
+    generationMetrics,
+  } = useSelector((state: RootState) => state.presentationGeneration);
   const { onUndo, onRedo, canUndo, canRedo } = usePresentationUndoRedo();
 
   useEffect(() => {
@@ -565,7 +569,7 @@ const PresentationHeader = ({
   return (
     <>
       <div className="py-[18px] px-4 sticky top-0 bg-white z-50 shadow-sm font-syne flex justify-between items-center gap-4">
-        <div className="flex items-center gap-3">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
           <img
             onClick={() => {
               router.push("/dashboard");
@@ -582,7 +586,10 @@ const PresentationHeader = ({
          
         </div>
 
-        <div className="flex items-center gap-2.5">
+        <div className="flex shrink-0 items-center gap-2.5">
+          {generationMode === "smart" && generationMetrics ? (
+            <StreamingGenerationMetrics metrics={generationMetrics} />
+          ) : null}
           {isPresentationSaving && (
             <div className="flex items-center gap-2">
               <Loader2 className="w-3.5 h-3.5 animate-spin" />

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/StreamingGenerationMetrics.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/StreamingGenerationMetrics.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import type { GenerationMetrics } from "@/store/slices/presentationGeneration";
+
+const integerFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+});
+
+const decimalFormatter = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+const formatTokens = (value: number | null, estimated = false) => {
+  if (value === null || !Number.isFinite(value)) return "—";
+  return `${estimated ? "~" : ""}${integerFormatter.format(Math.round(value))}`;
+};
+
+export default function StreamingGenerationMetrics({
+  metrics,
+}: {
+  metrics: GenerationMetrics;
+}) {
+  const thinkingPending =
+    metrics.supports_thinking &&
+    metrics.thinking_tokens_estimated &&
+    (metrics.thinking_tokens ?? 0) === 0;
+
+  return (
+    <div
+      aria-live="polite"
+      className="hidden h-[38px] shrink-0 items-center rounded-[80px] border border-[#E4E2EB] bg-[#F6F6F9] px-3 font-syne sm:flex"
+      title={
+        metrics.estimated
+          ? "Live token counts are estimated until the provider reports final usage."
+          : `Final usage from ${metrics.model || "the selected model"}`
+      }
+    >
+      <div className="flex items-center gap-2 text-[11px] font-semibold text-[#555766]">
+        <span
+          aria-hidden="true"
+          className={`h-1.5 w-1.5 rounded-full ${
+            metrics.estimated ? "animate-pulse bg-[#6847F4]" : "bg-emerald-500"
+          }`}
+        />
+        <span className="whitespace-nowrap">
+          In {formatTokens(metrics.input_tokens, metrics.estimated)}
+        </span>
+        <span className="h-3.5 w-px bg-[#D8D8DF]" aria-hidden="true" />
+        <span className="whitespace-nowrap">
+          Out {formatTokens(metrics.output_tokens, metrics.estimated)}
+        </span>
+        {metrics.supports_thinking ? (
+          <>
+            <span className="h-3.5 w-px bg-[#D8D8DF]" aria-hidden="true" />
+            <span
+              className={`whitespace-nowrap ${
+                thinkingPending ? "animate-pulse text-[#6847F4]" : ""
+              }`}
+              title={
+                thinkingPending
+                  ? "Reasoning is enabled; waiting for thinking-token usage."
+                  : undefined
+              }
+            >
+              Think{" "}
+              {formatTokens(
+                metrics.thinking_tokens,
+                metrics.thinking_tokens_estimated
+              )}
+            </span>
+          </>
+        ) : null}
+        <span className="h-3.5 w-px bg-[#D8D8DF]" aria-hidden="true" />
+        <span className="whitespace-nowrap">
+          {decimalFormatter.format(metrics.tokens_per_second)} t/s
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/servers/nextjs/app/(presentation-generator)/presentation/hooks/usePresentationStreaming.ts
+++ b/servers/nextjs/app/(presentation-generator)/presentation/hooks/usePresentationStreaming.ts
@@ -2,8 +2,10 @@ import { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   clearPresentationData,
+  setGenerationMetrics,
   setPresentationData,
   setStreaming,
+  type GenerationMetrics,
   type PresentationData,
 } from "@/store/slices/presentationGeneration";
 import { jsonrepair } from "jsonrepair";
@@ -25,6 +27,26 @@ import { isTemplateV2Slide } from "../../_shared/blank-slide";
 
 const MAX_STREAM_RETRIES = 3;
 const STREAM_RETRY_DELAY_MS = 1_000;
+
+interface PresentationStreamData {
+  type?: string;
+  model?: unknown;
+  input_tokens?: unknown;
+  output_tokens?: unknown;
+  thinking_tokens?: unknown;
+  total_tokens?: unknown;
+  tokens_per_second?: unknown;
+  duration_seconds?: unknown;
+  estimated?: unknown;
+  thinking_tokens_estimated?: unknown;
+  supports_thinking?: unknown;
+  [key: string]: any;
+}
+
+const readMetricNumber = (value: unknown, fallback: number) => {
+  const parsedValue = Number(value);
+  return Number.isFinite(parsedValue) ? Math.max(0, parsedValue) : fallback;
+};
 
 function mergePresentationPreservingTemplateData(
   incoming: PresentationData
@@ -129,6 +151,7 @@ export const usePresentationStreaming = (
     const streamStartedAt = Date.now();
     let streamIsTemplateV2 = preloadPresentationData;
     let smartGenerationOutcomeTracked = false;
+    let latestGenerationMetrics: GenerationMetrics | null = null;
 
     const closeEventSource = () => {
       if (eventSource) {
@@ -166,6 +189,7 @@ export const usePresentationStreaming = (
           error_message: sanitizeAnalyticsError(description, "Stream failed"),
         });
       }
+      isClosed = true;
       closeEventSource();
       clearRetryTimer();
       setLoading(false);
@@ -287,9 +311,9 @@ export const usePresentationStreaming = (
       );
 
       eventSource.addEventListener("response", async (event) => {
-        let data: any;
+        let data: PresentationStreamData;
         try {
-          data = JSON.parse(event.data);
+          data = JSON.parse(event.data) as PresentationStreamData;
         } catch {
           if (!scheduleRetry("invalid SSE payload")) {
             finalizeFailure("Failed to parse stream response.");
@@ -298,6 +322,97 @@ export const usePresentationStreaming = (
         }
 
         switch (data.type) {
+          case "generation_metrics": {
+            const previousMetrics = latestGenerationMetrics;
+            const inputTokens = readMetricNumber(
+              data.input_tokens,
+              previousMetrics?.input_tokens ?? 0
+            );
+            const outputTokens = readMetricNumber(
+              data.output_tokens,
+              previousMetrics?.output_tokens ?? 0
+            );
+            const totalTokens = readMetricNumber(
+              data.total_tokens,
+              previousMetrics?.total_tokens ?? 0
+            );
+            const thinkingTokens =
+              data.thinking_tokens === null ||
+              data.thinking_tokens === undefined
+                ? previousMetrics?.thinking_tokens ?? null
+                : readMetricNumber(
+                    data.thinking_tokens,
+                    previousMetrics?.thinking_tokens ?? 0
+                  );
+            const hasExactThinkingTokens =
+              data.thinking_tokens !== null &&
+              data.thinking_tokens !== undefined &&
+              data.thinking_tokens_estimated === false;
+
+            const nextMetrics: GenerationMetrics = {
+              model:
+                data.model === undefined
+                  ? previousMetrics?.model ?? ""
+                  : String(data.model),
+              input_tokens: Math.max(
+                previousMetrics?.input_tokens ?? 0,
+                inputTokens
+              ),
+              output_tokens: Math.max(
+                previousMetrics?.output_tokens ?? 0,
+                outputTokens
+              ),
+              thinking_tokens:
+                thinkingTokens === null
+                  ? null
+                  : hasExactThinkingTokens
+                    ? thinkingTokens
+                    : Math.max(
+                        previousMetrics?.thinking_tokens ?? 0,
+                        thinkingTokens
+                      ),
+              total_tokens: Math.max(
+                previousMetrics?.total_tokens ?? 0,
+                totalTokens
+              ),
+              tokens_per_second: readMetricNumber(
+                data.tokens_per_second,
+                previousMetrics?.tokens_per_second ?? 0
+              ),
+              duration_seconds: Math.max(
+                previousMetrics?.duration_seconds ?? 0,
+                readMetricNumber(
+                  data.duration_seconds,
+                  previousMetrics?.duration_seconds ?? 0
+                )
+              ),
+              estimated:
+                data.estimated === undefined
+                  ? previousMetrics?.estimated ?? false
+                  : Boolean(data.estimated),
+              thinking_tokens_estimated:
+                data.thinking_tokens_estimated === undefined
+                  ? previousMetrics?.thinking_tokens_estimated ?? false
+                  : Boolean(data.thinking_tokens_estimated),
+              supports_thinking:
+                previousMetrics?.supports_thinking === true ||
+                data.supports_thinking === true,
+            };
+
+            const hasMeaningfulMetrics =
+              nextMetrics.input_tokens > 0 ||
+              nextMetrics.output_tokens > 0 ||
+              nextMetrics.total_tokens > 0 ||
+              nextMetrics.tokens_per_second > 0 ||
+              nextMetrics.supports_thinking;
+
+            if (previousMetrics || hasMeaningfulMetrics) {
+              latestGenerationMetrics = nextMetrics;
+              dispatch(setGenerationMetrics(nextMetrics));
+            }
+            break;
+          }
+
           case "fonts": {
             if (data.fonts && typeof data.fonts === "object") {
               const prev = store.getState().presentationGeneration.presentationData;
@@ -548,15 +663,26 @@ export const usePresentationStreaming = (
               );
               break;
             }
+            const completedSlides = Number(data.completed_slides);
+            const totalSlides = Number(data.total_slides);
+            const detail =
+              data.detail || "Failed to connect to the server. Please try again.";
+            const detailWithProgress =
+              Number.isFinite(completedSlides) && completedSlides > 0
+                ? `${detail} ${completedSlides}${
+                    Number.isFinite(totalSlides) && totalSlides > 0
+                      ? ` of ${totalSlides}`
+                      : ""
+                  } slides were saved and will be reused.`
+                : detail;
+            if (data.retryable === false) {
+              finalizeFailure(detailWithProgress);
+              break;
+            }
             if (
-              !scheduleRetry(
-                data.detail || "server returned stream error response"
-              )
+              !scheduleRetry(detail || "server returned stream error response")
             ) {
-              finalizeFailure(
-                data.detail ||
-                  "Failed to connect to the server. Please try again."
-              );
+              finalizeFailure(detailWithProgress);
             }
             break;
         }
@@ -573,6 +699,8 @@ export const usePresentationStreaming = (
     const startStream = async () => {
       dispatch(setStreaming(true));
       dispatch(clearPresentationData());
+      latestGenerationMetrics = null;
+      dispatch(setGenerationMetrics(null));
       trackEvent(MixpanelEvent.Presentation_Stream_API_Call, {
         presentation_id: presentationId,
         generation_mode: options.generationMode ?? "standard",

--- a/servers/nextjs/store/slices/presentationGeneration.ts
+++ b/servers/nextjs/store/slices/presentationGeneration.ts
@@ -34,6 +34,19 @@ export interface ChatHtmlSelection {
   selectedAt: number;
 }
 
+export interface GenerationMetrics {
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  thinking_tokens: number | null;
+  total_tokens: number;
+  tokens_per_second: number;
+  duration_seconds: number;
+  estimated: boolean;
+  thinking_tokens_estimated: boolean;
+  supports_thinking: boolean;
+}
+
 interface PresentationGenerationState {
   presentation_id: string | null;
   isLoading: boolean;
@@ -41,6 +54,7 @@ interface PresentationGenerationState {
   outlines: { content: string }[];
   error: string | null;
   presentationData: PresentationData | null;
+  generationMetrics: GenerationMetrics | null;
   isSlidesRendered: boolean;
   isLayoutLoading: boolean;
   enableHtmlSelector: boolean;
@@ -56,6 +70,7 @@ const initialState: PresentationGenerationState = {
   isStreaming: null,
   error: null,
   presentationData: null,
+  generationMetrics: null,
   enableHtmlSelector: false,
   chatHtmlSelection: null,
 };
@@ -94,7 +109,14 @@ const presentationGenerationSlice = createSlice({
     // Clear presentation data
     clearPresentationData: (state) => {
       state.presentationData = null;
+      state.generationMetrics = null;
       state.chatHtmlSelection = null;
+    },
+    setGenerationMetrics: (
+      state,
+      action: PayloadAction<GenerationMetrics | null>
+    ) => {
+      state.generationMetrics = action.payload;
     },
     clearOutlines: (state) => {
       state.outlines = [];
@@ -557,6 +579,7 @@ export const {
   setSlidesRendered,
   setError,
   clearPresentationData,
+  setGenerationMetrics,
   clearOutlines,
   deleteSlideOutline,
   setPresentationData,


### PR DESCRIPTION
## Summary
- checkpoint each valid Smart slide before emitting it to the browser
- resume generation and SSE reconnects from the persisted slide prefix
- preserve checkpointed/editor-updated slides during finalization
- return structured stream errors with saved-slide progress and retryability
- consume live generation metrics and show Input, Output, Thinking, and TPS
- calculate estimated TPS from visible and thinking tokens while reasoning

## Validation
- `111 passed` across Smart generation, SSE, and presentation API tests
- `npm test` passes
- Next.js production build and TypeScript pass
- Python compilation and diff checks passed

## Notes
- completed slide HTML is streamed only after validation
- no authentication was added to stream endpoints