### PR TITLE
Sync bundled template themes during startup

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/presentation.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/presentation.py
@@ -356,6 +356,32 @@ def _layout_count(layout_payload: Any) -> int:
     return 0
 
 
+def _normalize_presentation_structure(
+    structure: PresentationStructureModel,
+    *,
+    outline_count: int,
+    layout_count: int,
+) -> PresentationStructureModel:
+    """Keep prepared structure indexes safe for the streaming endpoint.
+
+    Structured LLM responses can still contain too few indexes or indexes
+    outside the available layout range. Fill or replace those selections
+    before persisting the prepared presentation so streaming cannot reject
+    data that ``/prepare`` accepted.
+    """
+    normalized = list(structure.slides[:outline_count])
+    while len(normalized) < outline_count:
+        normalized.append(random.randrange(layout_count))
+
+    structure.slides = [
+        layout_index
+        if 0 <= layout_index < layout_count
+        else random.randrange(layout_count)
+        for layout_index in normalized
+    ]
+    return structure
+
+
 def _build_template_layout_model(
     layout_payload: dict[str, Any],
     *,
@@ -1688,14 +1714,11 @@ async def prepare_presentation(
             )
         )
 
-    presentation_structure.slides = presentation_structure.slides[: len(outlines)]
-    for index in range(total_outlines):
-        random_slide_index = random.randint(0, total_slide_layouts - 1)
-        if index >= total_outlines:
-            presentation_structure.slides.append(random_slide_index)
-            continue
-        if presentation_structure.slides[index] >= total_slide_layouts:
-            presentation_structure.slides[index] = random_slide_index
+    presentation_structure = _normalize_presentation_structure(
+        presentation_structure,
+        outline_count=total_outlines,
+        layout_count=total_slide_layouts,
+    )
 
     if presentation.include_table_of_contents:
         n_toc_slides = get_no_of_toc_required_for_n_outlines(
@@ -2119,24 +2142,23 @@ async def stream_presentation(
 
     if not layout.slides:
         raise HTTPException(status_code=400, detail="Presentation layout has no slides")
-    if len(structure.slides) > len(outline.slides):
-        raise HTTPException(
-            status_code=400,
-            detail="Presentation structure has more slides than outlines",
-        )
-    invalid_layout_index = next(
-        (
-            slide_layout_index
-            for slide_layout_index in structure.slides
-            if slide_layout_index < 0 or slide_layout_index >= len(layout.slides)
-        ),
-        None,
+    original_structure = list(structure.slides)
+    structure = _normalize_presentation_structure(
+        structure,
+        outline_count=len(outline.slides),
+        layout_count=len(layout.slides),
     )
-    if invalid_layout_index is not None:
-        raise HTTPException(
-            status_code=400,
-            detail="Presentation structure contains an invalid slide layout",
+    if structure.slides != original_structure:
+        logger.warning(
+            "Repairing invalid prepared presentation structure: "
+            "presentation_id=%s old=%s new=%s",
+            id,
+            original_structure,
+            structure.slides,
         )
+        presentation.set_structure(structure)
+        sql_session.add(presentation)
+        await sql_session.commit()
 
     image_generation_service = ImageGenerationService(get_images_directory())
 

--- a/servers/fastapi/migrations.py
+++ b/servers/fastapi/migrations.py
@@ -137,6 +137,10 @@ def _infer_revision_from_schema(
         for table in owned_tables
     )
     if "provider_settings" in tables and "user" in tables and ownership_ready:
+        if "template_v2" in tables and _has_column(
+            inspector, "template_v2", "theme"
+        ):
+            return REVISION_TEMPLATE_V2_THEME
         if "presenton_cloud_provider" in tables:
             return REVISION_PRESENTON_CLOUD_PROVIDER
         if "presentations" in tables and _has_column(

--- a/servers/fastapi/templates/default_templates.py
+++ b/servers/fastapi/templates/default_templates.py
@@ -121,6 +121,7 @@ def _load_default_template(template_dir: Path) -> TemplateV2:
     layouts = _coerce_slide_layouts(rewritten.get("layouts"))
     merged_components = _coerce_merged_components(rewritten.get("merged_components"))
     components = rewritten.get("components")
+    theme = rewritten.get("theme")
     assets = _build_assets(rewritten, template_id, layouts, merged_components)
 
     return TemplateV2(
@@ -131,6 +132,7 @@ def _load_default_template(template_dir: Path) -> TemplateV2:
         components=components if isinstance(components, dict) else None,
         merged_components=merged_components,
         layouts=layouts,
+        theme=theme if isinstance(theme, dict) else None,
         assets=assets,
         is_default=True,
     )
@@ -143,6 +145,7 @@ def _update_template_from_default(existing: TemplateV2, template: TemplateV2) ->
     existing.components = template.components
     existing.merged_components = template.merged_components
     existing.layouts = template.layouts
+    existing.theme = template.theme
     existing.assets = template.assets
     existing.is_default = True
 

--- a/servers/fastapi/tests/integration/test_presentation_generation_flow.py
+++ b/servers/fastapi/tests/integration/test_presentation_generation_flow.py
@@ -807,6 +807,71 @@ def test_prepare_presentation_accepts_template_layout_id():
     assert structure_layout.slides[0].id == "template-layout-1"
 
 
+def test_prepare_presentation_normalizes_incomplete_and_invalid_layout_indexes():
+    presentation_id = uuid.uuid4()
+    template_id = "strategy-template"
+    presentation = PresentationModel(
+        id=presentation_id,
+        version=PresentationVersion.V2_STANDARD,
+        content="deck",
+        n_slides=3,
+        language="English",
+        tone="default",
+        verbosity="standard",
+        instructions=None,
+    )
+    template = TemplateV2(
+        id=template_id,
+        name="Custom V2",
+        layouts={
+            "layouts": [
+                {
+                    "id": "layout-1",
+                    "description": "First layout",
+                    "components": [],
+                },
+                {
+                    "id": "layout-2",
+                    "description": "Second layout",
+                    "components": [],
+                },
+            ]
+        },
+    )
+    session = FakeAsyncSession(
+        get_results={presentation_id: presentation, template_id: template}
+    )
+
+    with patch.object(
+        presentation_endpoint,
+        "generate_presentation_structure",
+        new=AsyncMock(return_value=PresentationStructureModel(slides=[-1])),
+    ), patch.object(
+        presentation_endpoint.random,
+        "randrange",
+        side_effect=[1, 0, 1],
+    ), patch.object(
+        presentation_endpoint.MEM0_PRESENTATION_MEMORY_SERVICE,
+        "store_generated_outlines",
+        new=AsyncMock(),
+    ):
+        response = _run(
+            presentation_endpoint.prepare_presentation(
+                presentation_id=presentation_id,
+                outlines=[
+                    SlideOutlineModel(content="## First"),
+                    SlideOutlineModel(content="## Second"),
+                    SlideOutlineModel(content="## Third"),
+                ],
+                layout=template_id,
+                sql_session=session,
+            )
+        )
+
+    assert response.presentation_id == presentation_id
+    assert presentation.structure == {"slides": [1, 1, 0]}
+
+
 def test_get_presentation_preserves_template_detail_payload():
     presentation_id = uuid.uuid4()
     now = datetime.now()
@@ -952,7 +1017,7 @@ def test_stream_presentation_uses_template_schema_for_content_generation():
         title="Deck",
         outlines={"slides": [{"content": "## Causes"}]},
         layout=template_layouts,
-        structure={"slides": [0]},
+        structure={"slides": [-1]},
         tone="default",
         verbosity="standard",
         instructions=None,
@@ -997,10 +1062,15 @@ def test_stream_presentation_uses_template_schema_for_content_generation():
         presentation_endpoint,
         "ImageGenerationService",
         return_value=Mock(),
+    ), patch.object(
+        presentation_endpoint.random,
+        "randrange",
+        return_value=0,
     ):
         chunks = _run(consume_stream())
 
     assert chunks
+    assert presentation.structure == {"slides": [0]}
     assert len(generated_layouts) == 1
     assert generated_slide_numbers == [1]
     generated_layout = generated_layouts[0]

--- a/servers/fastapi/tests/unit/test_default_templates.py
+++ b/servers/fastapi/tests/unit/test_default_templates.py
@@ -60,6 +60,18 @@ def _write_template_bundle(root: Path, *, include_raw_layouts: bool = False) -> 
                 "description": "General purpose default template.",
                 "thumbnail": "static/thumbnail.png",
                 "fonts": {"Inter": "static/inter.ttf"},
+                "theme": {
+                    "colors": {
+                        "primary": "#3B82F6",
+                        "background": "#FFFFFF",
+                    },
+                    "fonts": {
+                        "textFont": {
+                            "name": "Inter",
+                            "url": "static/inter.ttf",
+                        }
+                    },
+                },
                 "layouts": [
                     {
                         "id": "slide_1",
@@ -175,6 +187,15 @@ def test_default_template_import_normalizes_shapes_and_copies_static(
     assert template.assets["fonts"] == {
         "Inter": "/app_data/templates/general/static/inter.ttf"
     }
+    assert template.theme == {
+        "colors": {"primary": "#3B82F6", "background": "#FFFFFF"},
+        "fonts": {
+            "textFont": {
+                "name": "Inter",
+                "url": "/app_data/templates/general/static/inter.ttf",
+            }
+        },
+    }
     assert template.assets["images"] == ["/app_data/templates/general/static/image.png"]
     assert (
         app_data_dir / "templates/general/static/image.png"
@@ -238,6 +259,7 @@ def test_default_template_import_updates_existing_database_row(tmp_path, monkeyp
         raw_layouts={"layouts": [_raw_layout()]},
         layouts={"layouts": []},
         merged_components={"components": []},
+        theme={"colors": {"primary": "#000000"}},
         assets={"thumbnail": "/old.png"},
         is_default=False,
     )
@@ -259,6 +281,15 @@ def test_default_template_import_updates_existing_database_row(tmp_path, monkeyp
     assert existing.raw_layouts is None
     assert list(existing.layouts) == ["layouts"]
     assert list(existing.merged_components) == ["components"]
+    assert existing.theme == {
+        "colors": {"primary": "#3B82F6", "background": "#FFFFFF"},
+        "fonts": {
+            "textFont": {
+                "name": "Inter",
+                "url": "/app_data/templates/general/static/inter.ttf",
+            }
+        },
+    }
     assert existing.assets["thumbnail"] == (
         "/app_data/templates/general/static/thumbnail.png"
     )
@@ -341,6 +372,8 @@ def test_bundled_general_template_json_matches_template_v2_shapes():
     assert len(template.layouts["layouts"]) > 0
     assert list(template.merged_components) == ["components"]
     assert len(template.merged_components["components"]) > 0
+    assert template.theme is not None
+    assert template.theme["colors"]["primary"] == "#3B82F6"
     assert template.assets["thumbnail"] == (
         f"/app_data/templates/{template_id}/static/thumbnail.png"
     )

--- a/templates/dynamic/template.json
+++ b/templates/dynamic/template.json
@@ -3,6 +3,32 @@
   "name": "Dynamic",
   "description": "Bold, high-contrast layouts with dark textured backgrounds and warm accents for impactful, story-driven presentations.",
   "thumbnail": "static/thumbnail.png",
+  "theme": {
+    "colors": {
+      "primary": "#C24D12",
+      "background": "#171717",
+      "card": "#000000",
+      "stroke": "#FFFFFF",
+      "primary_text": "#FFFFFF",
+      "background_text": "#FFFFFF",
+      "graph_0": "#FF9257",
+      "graph_1": "#C24D12",
+      "graph_2": "#983608",
+      "graph_3": "#E26C2C",
+      "graph_4": "#111111",
+      "graph_5": "#FD7536",
+      "graph_6": "#F4511E",
+      "graph_7": "#000000",
+      "graph_8": "#FFFFFF",
+      "graph_9": "#242424"
+    },
+    "fonts": {
+      "textFont": {
+        "name": "Montserrat",
+        "url": "/vendor/fonts/sans_serif/montserrat/Montserrat[wght].ttf"
+      }
+    }
+  },
   "merged_components": [
     {
       "id": "full_bleed_background",

--- a/templates/editorial/template.json
+++ b/templates/editorial/template.json
@@ -2,6 +2,32 @@
   "id": "editorial",
   "name": "Editorial",
   "thumbnail": "static/thumbnail.png",
+  "theme": {
+    "colors": {
+      "primary": "#155F99",
+      "background": "#1D242D",
+      "card": "#1DA1F2",
+      "stroke": "#FFFFFF",
+      "primary_text": "#FFFFFF",
+      "background_text": "#FFFFFF",
+      "graph_0": "#2075BC",
+      "graph_1": "#155F99",
+      "graph_2": "#9DCAEA",
+      "graph_3": "#448BCA",
+      "graph_4": "#FFFFFF",
+      "graph_5": "#0F92F4",
+      "graph_6": "#1DA1F2",
+      "graph_7": "#1FA8FF",
+      "graph_8": "#44AFFF",
+      "graph_9": "#49A8F4"
+    },
+    "fonts": {
+      "textFont": {
+        "name": "DM Sans Bold",
+        "url": "static/DM Sans Bold.ttf"
+      }
+    }
+  },
   "icon_type": "thin",
   "fonts": {
     "Playfair Display Bold": "static/Playfair Display Bold Italic.ttf",

--- a/templates/executive/template.json
+++ b/templates/executive/template.json
@@ -3,6 +3,32 @@
   "name": "Executive",
   "description": "Leadership-ready layouts with bold typography, crisp structure, and subtle violet accents for strategic, decision-focused presentations.",
   "thumbnail": "static/thumbnail.png",
+  "theme": {
+    "colors": {
+      "primary": "#8554EB",
+      "background": "#F8F7FB",
+      "card": "#F0EEF8",
+      "stroke": "#9081C8",
+      "primary_text": "#FFFFFF",
+      "background_text": "#000000",
+      "graph_0": "#A386EA",
+      "graph_1": "#8554EB",
+      "graph_2": "#8958F4",
+      "graph_3": "#5F4F9B",
+      "graph_4": "#6354A3",
+      "graph_5": "#8F84BE",
+      "graph_6": "#8074B4",
+      "graph_7": "#F4F0FF",
+      "graph_8": "#F0EEF8",
+      "graph_9": "#9081C8"
+    },
+    "fonts": {
+      "textFont": {
+        "name": "Montserrat Bold",
+        "url": "static/Montserrat Bold.ttf"
+      }
+    }
+  },
   "merged_components": [
     {
       "id": "background_accents",

--- a/templates/general/template.json
+++ b/templates/general/template.json
@@ -3,6 +3,32 @@
   "name": "General",
   "description": "General template best for simple presentations, great spacing and clean layout.",
   "thumbnail": "static/thumbnail.png",
+  "theme": {
+    "colors": {
+      "primary": "#3B82F6",
+      "background": "#9333EA",
+      "card": "#FFFFFF",
+      "stroke": "#E5E7EB",
+      "primary_text": "#111827",
+      "background_text": "#FFFFFF",
+      "graph_0": "#EF4444",
+      "graph_1": "#3B82F6",
+      "graph_2": "#10B981",
+      "graph_3": "#C084FC",
+      "graph_4": "#A855F7",
+      "graph_5": "#111827",
+      "graph_6": "#F8F9FA",
+      "graph_7": "#F3F4F6",
+      "graph_8": "#4B5563",
+      "graph_9": "#E5E7EB"
+    },
+    "fonts": {
+      "textFont": {
+        "name": "Poppins",
+        "url": "/vendor/fonts/sans_serif/poppins/Poppins-Regular.ttf"
+      }
+    }
+  },
   "merged_components": [
     {
       "id": "background_canvas",

--- a/templates/modern/template.json
+++ b/templates/modern/template.json
@@ -3,6 +3,32 @@
   "name": "Modern",
   "description": "Clean, contemporary layouts with generous whitespace, confident typography, and bold visual accents for a polished presentation.",
   "thumbnail": "static/thumbnail.png",
+  "theme": {
+    "colors": {
+      "primary": "#F59E0B",
+      "background": "#F5F8FE",
+      "card": "#FFFFFF",
+      "stroke": "#E5E7EB",
+      "primary_text": "#334155",
+      "background_text": "#234CD9",
+      "graph_0": "#3B82F6",
+      "graph_1": "#F59E0B",
+      "graph_2": "#234CD9",
+      "graph_3": "#3182BD",
+      "graph_4": "#E4EAF3",
+      "graph_5": "#CBE3CC",
+      "graph_6": "#334155",
+      "graph_7": "#E5E7EB",
+      "graph_8": "#6B7280",
+      "graph_9": "#FFFFFF"
+    },
+    "fonts": {
+      "textFont": {
+        "name": "Montserrat",
+        "url": "/vendor/fonts/sans_serif/montserrat/Montserrat[wght].ttf"
+      }
+    }
+  },
   "icon_type": "bold",
   "merged_components": [
     {

--- a/templates/momentum/template.json
+++ b/templates/momentum/template.json
@@ -3,6 +3,32 @@
   "name": "Momentum",
   "description": "A polished, high-energy business template for strategy, performance, product, and leadership presentations, combining bold typography, fluid accents, strong data storytelling, and versatile editorial layouts.",
   "thumbnail": "static/thumbnail.png",
+  "theme": {
+    "colors": {
+      "primary": "#213EBB",
+      "background": "#F6F7FC",
+      "card": "#FFFFFF",
+      "stroke": "#1A3DB3",
+      "primary_text": "#FFFFFF",
+      "background_text": "#000000",
+      "graph_0": "#4F68C4",
+      "graph_1": "#213EBB",
+      "graph_2": "#2745BF",
+      "graph_3": "#7D92D8",
+      "graph_4": "#D1DAF1",
+      "graph_5": "#1A3DB3",
+      "graph_6": "#1E43C6",
+      "graph_7": "#DDE3F5",
+      "graph_8": "#2E3545",
+      "graph_9": "#F6F5F4"
+    },
+    "fonts": {
+      "textFont": {
+        "name": "Lato",
+        "url": "static/Lato Regular.ttf"
+      }
+    }
+  },
   "merged_components": [
     {
       "id": "main_title_area",

--- a/templates/standard/template.json
+++ b/templates/standard/template.json
@@ -3,6 +3,32 @@
   "name": "Standard",
   "description": "Balanced, adaptable layouts that keep business and everyday content clear, organized, and easy to follow.",
   "thumbnail": "static/thumbnail.png",
+  "theme": {
+    "colors": {
+      "primary": "#3182BD",
+      "background": "#1B8C2D",
+      "card": "#F3F4F6",
+      "stroke": "#E5E7EB",
+      "primary_text": "#000000",
+      "background_text": "#000000",
+      "graph_0": "#1A4665",
+      "graph_1": "#20567D",
+      "graph_2": "#276695",
+      "graph_3": "#2D77AD",
+      "graph_4": "#3387C5",
+      "graph_5": "#4796CF",
+      "graph_6": "#5EA3D5",
+      "graph_7": "#76B1DC",
+      "graph_8": "#8EBEE2",
+      "graph_9": "#A6CCE8"
+    },
+    "fonts": {
+      "textFont": {
+        "name": "Playfair Display",
+        "url": "/vendor/fonts/serif/playfairdisplay/PlayfairDisplay[wght].ttf"
+      }
+    }
+  },
   "icon_type": "bold",
   "merged_components": [
     {

--- a/templates/swift/template.json
+++ b/templates/swift/template.json
@@ -3,6 +3,32 @@
   "name": "Swift",
   "description": "Bright, energetic layouts with crisp structure and visual momentum for concise, fast-paced presentations.",
   "thumbnail": "static/thumbnail.png",
+  "theme": {
+    "colors": {
+      "primary": "#BDEFF8",
+      "background": "#BFF4FF",
+      "card": "#111827",
+      "stroke": "#E5E7EB",
+      "primary_text": "#111827",
+      "background_text": "#111827",
+      "graph_0": "#111827",
+      "graph_1": "#BDEFF8",
+      "graph_2": "#F3F4F6",
+      "graph_3": "#E5E7EB",
+      "graph_4": "#6B7280",
+      "graph_5": "#FFFFFF",
+      "graph_6": "#000000",
+      "graph_7": "#9A9CF4",
+      "graph_8": "#E198F4",
+      "graph_9": "#F49ABC"
+    },
+    "fonts": {
+      "textFont": {
+        "name": "Inter",
+        "url": "/vendor/fonts/sans_serif/inter/Inter[opsz,wght].ttf"
+      }
+    }
+  },
   "icon_type": "bold",
   "merged_components": [
     {


### PR DESCRIPTION
## Summary
- sync semantic theme payloads from the enterprise bundled templates
- persist and refresh bundled template themes during FastAPI lifespan startup import
- recognize the template theme schema when repairing orphaned Alembic revisions
- normalize malformed presentation layout selections before streaming and repair previously persisted structures

## Testing
- `662 passed, 4 warnings` (`pytest tests/unit tests/integration/test_presentation_generation_flow.py -q`)
- verified all eight bundled theme objects exactly match the enterprise source
- verified Alembic has a single head: `e4c7a9b2d6f1`