### PR TITLE
Add template theme endpoint

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/template.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/template.py
@@ -59,7 +59,12 @@ from templates.v2.models.layouts import (
     SlideLayout,
     SlideLayouts,
 )
-from templates.v2.theme import generate_template_theme
+from templates.v2.theme import (
+    build_theme_profile,
+    generate_template_theme,
+    materialize_theme,
+    select_theme_roles_deterministically,
+)
 from utils.asset_directory_utils import resolve_app_path_to_filesystem
 from utils.file_utils import get_original_file_name
 from utils.icon_weights import (
@@ -250,6 +255,11 @@ class TemplateResponse(TemplateListItem):
     layouts: Optional[dict[str, Any]] = None
     theme: Optional[PresentationThemeData] = None
     fonts: dict[str, str] = Field(default_factory=dict)
+
+
+class TemplateThemeResponse(BaseModel):
+    template_id: str
+    theme: Optional[PresentationThemeData] = None
 
 
 def _template_task_progress_data(
@@ -685,6 +695,22 @@ def _get_template_fonts(template: TemplateV2) -> dict[str, str]:
     if not isinstance(template.assets, dict):
         return {}
     return _coerce_font_map(template.assets.get("fonts"))
+
+
+def _derive_template_theme(template: TemplateV2) -> PresentationThemeData | None:
+    if not isinstance(template.layouts, dict):
+        return None
+    try:
+        layouts = SlideLayouts.model_validate(template.layouts)
+        profile = build_theme_profile(layouts, _get_template_fonts(template))
+        selection = select_theme_roles_deterministically(profile)
+        return materialize_theme(profile, selection)
+    except (ValidationError, KeyError, ValueError):
+        LOGGER.exception(
+            "[template.theme] failed to derive semantic theme template_id=%s",
+            template.id,
+        )
+        return None
 
 
 def _get_template_thumbnail_from_assets(assets: Any) -> str | None:
@@ -1685,6 +1711,40 @@ async def update_template_metadata(
     await sql_session.commit()
     await sql_session.refresh(template)
     return template
+
+
+@TEMPLATE_ROUTER.get(
+    "/{template_id}/theme",
+    response_model=TemplateThemeResponse,
+    operation_id="template_theme_get",
+)
+async def get_template_theme(
+    template_id: str = Path(...),
+    sql_session: AsyncSession = Depends(get_async_session),
+):
+    template = await sql_session.get(TemplateV2, template_id)
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+
+    theme: PresentationThemeData | None = None
+    if template.theme is not None:
+        try:
+            theme = PresentationThemeData.model_validate(template.theme)
+        except ValidationError:
+            LOGGER.warning(
+                "[template.theme] replacing invalid stored theme template_id=%s",
+                template.id,
+                exc_info=True,
+            )
+
+    if theme is None:
+        theme = _derive_template_theme(template)
+        if theme is not None:
+            template.theme = theme.model_dump(mode="json", exclude_none=True)
+            sql_session.add(template)
+            await sql_session.commit()
+
+    return TemplateThemeResponse(template_id=template.id, theme=theme)
 
 
 @TEMPLATE_ROUTER.get(

--- a/servers/fastapi/tests/unit/test_template_api.py
+++ b/servers/fastapi/tests/unit/test_template_api.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import BackgroundTasks, HTTPException
 
 from api.v1.ppt.endpoints.template import (
+    TEMPLATE_ROUTER,
     CreateTemplateLayoutsRequest,
     CreateTemplateRequest,
     GenerateTemplateLayoutRequest,
@@ -23,6 +24,7 @@ from api.v1.ppt.endpoints.template import (
     generate_template_layout_from_prompt,
     generate_template_blocks,
     get_template,
+    get_template_theme,
     init_template,
     list_templates,
     patch_template_slide_layout,
@@ -782,6 +784,80 @@ def test_get_template_returns_layouts_components_and_fonts(fake_async_session):
     assert not hasattr(response, "components")
     assert not hasattr(response, "assets")
     assert not hasattr(response, "layout_schema")
+
+
+def test_get_template_theme_returns_stored_theme_without_rewriting(
+    fake_async_session,
+):
+    template_id = str(uuid.uuid4())
+    template = TemplateV2(
+        id=template_id,
+        name="Customer Brand",
+        layouts=TEMPLATE_LAYOUTS,
+        theme=GENERATED_THEME_DATA,
+    )
+    fake_async_session._get_results[template_id] = template
+
+    response = asyncio.run(
+        get_template_theme(template_id, sql_session=fake_async_session)
+    )
+
+    assert response.template_id == template_id
+    assert response.theme is not None
+    assert response.theme.model_dump(mode="json") == GENERATED_THEME_DATA
+    assert fake_async_session.added == []
+    assert fake_async_session.commit_count == 0
+
+
+def test_get_template_theme_route_is_registered_before_template_detail_get():
+    route_paths = [
+        route.path
+        for route in TEMPLATE_ROUTER.routes
+        if "GET" in getattr(route, "methods", set())
+    ]
+
+    assert "/template/{template_id}/theme" in route_paths
+    assert route_paths.index("/template/{template_id}/theme") < route_paths.index(
+        "/template/{template_id}"
+    )
+
+
+def test_get_template_theme_derives_and_persists_missing_theme(
+    fake_async_session,
+):
+    template_id = str(uuid.uuid4())
+    template = TemplateV2(
+        id=template_id,
+        name="Customer Brand",
+        layouts=TEMPLATE_LAYOUTS,
+        theme=None,
+    )
+    fake_async_session._get_results[template_id] = template
+
+    with patch(
+        "api.v1.ppt.endpoints.template._derive_template_theme",
+        return_value=GENERATED_THEME,
+    ) as derive_theme:
+        response = asyncio.run(
+            get_template_theme(template_id, sql_session=fake_async_session)
+        )
+
+    derive_theme.assert_called_once_with(template)
+    assert response.theme is not None
+    assert response.theme.model_dump(mode="json") == GENERATED_THEME_DATA
+    assert template.theme == GENERATED_THEME_DATA
+    assert fake_async_session.added == [template]
+    assert fake_async_session.commit_count == 1
+
+
+def test_get_template_theme_returns_404_for_missing_template(fake_async_session):
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            get_template_theme("missing-template", sql_session=fake_async_session)
+        )
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Template not found"
 
 
 def test_create_template_slide_layouts_returns_generated_layout(


### PR DESCRIPTION
## Summary
- add `GET /api/v1/ppt/template/{template_id}/theme`
- return persisted template themes and deterministically derive missing themes from layouts and fonts
- persist derived themes so text, charts, tables, and infographics use the same semantic theme
- cover stored, derived, missing-template, and route-registration behavior

## Validation
- `642 passed` — FastAPI unit suite
- `8 passed` — Next.js test suite
- ESLint passed for theme consumers
- Next.js production build passed