### PR TITLE
feat(export-runtime): adopt architecture-independent export core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV HF_HOME=/root/.cache/huggingface \
 RUN /opt/venv/bin/python scripts/warm_fastembed_cache.py
 
 
-FROM node:20-bookworm-slim AS nextjs-builder
+FROM node:22-bookworm-slim AS nextjs-builder
 
 WORKDIR /app/servers/nextjs
 
@@ -44,14 +44,12 @@ RUN npm run build \
     && rm -rf .next-build/cache
 
 
-FROM node:20-bookworm-slim AS assets-builder
+FROM node:22-bookworm-slim AS assets-builder
 
 WORKDIR /app
 
-ARG TARGETARCH
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates unzip \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 COPY package.json /app/
@@ -63,13 +61,9 @@ RUN mkdir -p /app/document-extraction-liteparse \
 
 COPY electron/resources/document-extraction/liteparse_runner.mjs /app/document-extraction-liteparse/liteparse_runner.mjs
 COPY scripts/sync-presentation-export.cjs /app/scripts/sync-presentation-export.cjs
-# Bundled export still loads @img/sharp-* native addons from node_modules (not inlined).
+COPY scripts/run-presentation-export.mjs /app/scripts/run-presentation-export.mjs
 RUN rm -rf /app/presentation-export \
-    && EXPORT_RUNTIME_ARCH="${TARGETARCH}" node /app/scripts/sync-presentation-export.cjs --force \
-    && find /app/presentation-export/py -maxdepth 1 -type f -name "convert-linux-*" -exec chmod +x {} \; \
-    && cd /app/presentation-export \
-    && npm init -y \
-    && npm install "sharp@^0.34.5" --include=optional --omit=dev --no-fund --no-audit --no-package-lock
+    && node /app/scripts/sync-presentation-export.cjs --force
 
 
 FROM python:3.11-slim-trixie AS runtime
@@ -77,7 +71,6 @@ FROM python:3.11-slim-trixie AS runtime
 WORKDIR /app
 
 ARG INSTALL_TESSERACT=true
-ARG TARGETARCH
 ARG CHROMIUM_VERSION=149.0.7827.196-1~deb13u1
 ARG CHROMIUM_SNAPSHOT=20260625T180000Z
 
@@ -85,8 +78,6 @@ ARG CHROMIUM_SNAPSHOT=20260625T180000Z
 ENV APP_DATA_DIRECTORY=/app_data \
     TEMP_DIRECTORY=/tmp/presenton \
     EXPORT_PACKAGE_ROOT=/app/presentation-export \
-    EXPORT_RUNTIME_DIR=/app/presentation-export \
-    BUILT_PYTHON_MODULE_PATH=/app/presentation-export/py/convert-linux-current \
     PRESENTON_APP_ROOT=/app \
     HF_HOME=/root/.cache/huggingface \
     PRESENTON_FASTEMBED_ICON_CACHE_DIR=/root/.cache/presenton/fastembed-icons \
@@ -114,7 +105,7 @@ RUN set -eux; \
     chromium-common="${CHROMIUM_VERSION}" \
     chromium-driver="${CHROMIUM_VERSION}"; \
     apt-mark hold chromium chromium-common chromium-driver; \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -; \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash -; \
     apt-get install -y --no-install-recommends nodejs; \
     rm -rf /var/lib/apt/lists/*
 
@@ -138,17 +129,8 @@ COPY --from=assets-builder /app/document-extraction-liteparse /app/document-extr
 COPY --from=assets-builder /app/presentation-export /app/presentation-export
 COPY --from=assets-builder /app/scripts/sync-presentation-export.cjs /app/scripts/sync-presentation-export.cjs
 
-RUN set -eux; \
-    if [ -z "${TARGETARCH:-}" ]; then TARGETARCH="$(dpkg --print-architecture)"; fi; \
-    case "$TARGETARCH" in \
-    amd64) export_arch="x64" ;; \
-    arm64) export_arch="arm64" ;; \
-    *) echo "Unsupported TARGETARCH: $TARGETARCH" && exit 1 ;; \
-    esac; \
-    test -f "/app/presentation-export/py/convert-linux-${export_arch}"; \
-    ln -sf "/app/presentation-export/py/convert-linux-${export_arch}" /app/presentation-export/py/convert-linux-current; \
-    chmod +x "/app/presentation-export/py/convert-linux-${export_arch}"; \
-    ls -lah /app/presentation-export/py
+RUN test -f /app/presentation-export/runner.mjs \
+    && test -f /app/presentation-export/node_modules/@presenton/export-core/dist/index.js
 
 COPY --from=nextjs-builder /app/servers/nextjs/.next-build/standalone/ /app/servers/nextjs/
 COPY --from=nextjs-builder /app/servers/nextjs/public /app/servers/nextjs/public

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,6 @@ FROM python:3.11-slim-trixie
 
 WORKDIR /app
 
-ARG TARGETARCH
 ARG CHROMIUM_VERSION=149.0.7827.196-1~deb13u1
 ARG CHROMIUM_SNAPSHOT=20260625T180000Z
 
@@ -15,8 +14,6 @@ ENV APP_DATA_DIRECTORY=/app_data \
     UV_LINK_MODE=copy \
     PATH="/root/.local/bin:${PATH}" \
     EXPORT_PACKAGE_ROOT=/app/presentation-export \
-    EXPORT_RUNTIME_DIR=/app/presentation-export \
-    BUILT_PYTHON_MODULE_PATH=/app/presentation-export/py/convert-linux-current \
     PRESENTON_APP_ROOT=/app \
     HF_HOME=/root/.cache/huggingface \
     PRESENTON_FASTEMBED_ICON_CACHE_DIR=/root/.cache/presenton/fastembed-icons \
@@ -47,7 +44,7 @@ RUN find /usr/share/fonts -type f ! -iname 'Noto*' -delete \
     && find /usr/share/fonts -type d -empty -delete \
     && fc-cache -fsv
 
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
@@ -61,22 +58,13 @@ RUN mkdir -p /app/document-extraction-liteparse \
 COPY electron/resources/document-extraction/liteparse_runner.mjs /app/document-extraction-liteparse/liteparse_runner.mjs
 
 COPY scripts/sync-presentation-export.cjs /app/scripts/sync-presentation-export.cjs
+COPY scripts/run-presentation-export.mjs /app/scripts/run-presentation-export.mjs
 COPY scripts/presenton-terminal-banner.mjs /app/scripts/presenton-terminal-banner.mjs
 COPY scripts/user-config-env.cjs /app/scripts/user-config-env.cjs
 RUN rm -rf /app/presentation-export \
-    && EXPORT_RUNTIME_ARCH="${TARGETARCH}" node /app/scripts/sync-presentation-export.cjs --force \
-    && find /app/presentation-export/py -maxdepth 1 -type f -name "convert-linux-*" -exec chmod +x {} \; \
-    && set -eux; \
-    if [ -z "${TARGETARCH:-}" ]; then TARGETARCH="$(dpkg --print-architecture)"; fi; \
-    case "$TARGETARCH" in \
-    amd64) export_arch="x64" ;; \
-    arm64) export_arch="arm64" ;; \
-    *) echo "Unsupported TARGETARCH: $TARGETARCH" && exit 1 ;; \
-    esac; \
-    test -f "/app/presentation-export/py/convert-linux-${export_arch}"; \
-    ln -sf "/app/presentation-export/py/convert-linux-${export_arch}" /app/presentation-export/py/convert-linux-current; \
-    chmod +x "/app/presentation-export/py/convert-linux-${export_arch}"; \
-    ls -lah /app/presentation-export/py
+    && node /app/scripts/sync-presentation-export.cjs --force \
+    && test -f /app/presentation-export/runner.mjs \
+    && test -f /app/presentation-export/node_modules/@presenton/export-core/dist/index.js
 
 # Bind mount `.:/app` hides any .venv under servers/fastapi at runtime — install deps into
 # system site-packages (same interpreter `start.js` uses as `python`).

--- a/electron/app/ipc/export_handlers.ts
+++ b/electron/app/ipc/export_handlers.ts
@@ -24,7 +24,6 @@ import {
 } from "../utils/export-chromium";
 import { resolveExportSpawnTarget } from "../utils/export-msix-runtime";
 
-type BinaryFormat = "elf" | "mach-o" | "pe" | "unknown";
 type RuntimeCandidate = {
   command: string;
   label: string;
@@ -96,13 +95,11 @@ export function setupExportHandlers() {
       await fs.promises.writeFile(exportTaskPath, JSON.stringify(exportTask));
 
       const packagedExportRoot = path.join(resourceBaseDir, "resources", "export");
-      const packagedExportScriptPath = path.join(packagedExportRoot, "index.js");
-      const { scriptPath: exportScriptPath, converterPath: pythonModulePath } =
-        await resolveExportSpawnTarget(
-          packagedExportRoot,
-          packagedExportScriptPath,
-          (exportRoot) => resolveConverterPath(exportRoot)
-        );
+      const packagedExportScriptPath = path.join(packagedExportRoot, "runner.mjs");
+      const { scriptPath: exportScriptPath } = await resolveExportSpawnTarget(
+        packagedExportRoot,
+        packagedExportScriptPath,
+      );
       safeLog("[Export] Spawning export task with config:", {
         exportAs,
         id,
@@ -110,7 +107,6 @@ export function setupExportHandlers() {
         pptUrl,
         exportTaskPath,
         exportScriptPath,
-        pythonModulePath,
         NEXT_PUBLIC_URL: process.env.NEXT_PUBLIC_URL,
         NEXT_PUBLIC_FAST_API: process.env.NEXT_PUBLIC_FAST_API,
       });
@@ -133,7 +129,6 @@ export function setupExportHandlers() {
         TEMP_DIRECTORY: tempDir,
         APP_DATA_DIRECTORY: appDataDir,
         NODE_ENV: "development",
-        BUILT_PYTHON_MODULE_PATH: pythonModulePath,
         PUPPETEER_EXECUTABLE_PATH: chromiumExecutablePath,
         PUPPETEER_CACHE_DIR: puppeteerCacheDir,
         PUPPETEER_TMP_DIR: puppeteerTempDir,
@@ -446,94 +441,6 @@ async function runExportTaskOnce(
     cleanup();
     destroyChildProcessStdio(exportTaskProcess);
   }
-}
-
-async function resolveConverterPath(exportRoot: string): Promise<string> {
-  const pyDir = path.join(exportRoot, "py");
-  const extension = process.platform === "win32" ? ".exe" : "";
-  const converterCandidates = [
-    path.join(pyDir, `convert-${process.platform}-${process.arch}${extension}`),
-    path.join(pyDir, `convert-${process.platform}${extension}`),
-    ...(process.platform === "win32"
-      ? [path.join(pyDir, "convert.exe"), path.join(pyDir, "convert")]
-      : [path.join(pyDir, "convert")]),
-  ];
-
-  const converterPath = await findFirstExistingPath(converterCandidates);
-  if (!converterPath) {
-    throw new Error(
-      [
-        "No converter binary found for export.",
-        "Expected one of:",
-        ...converterCandidates.map((candidate) => `  - ${candidate}`),
-      ].join("\n")
-    );
-  }
-
-  const format = await detectBinaryFormat(converterPath);
-  if (!isBinaryFormatCompatible(format)) {
-    throw new Error(
-      [
-        `Converter binary is not valid for ${process.platform}/${process.arch}.`,
-        `Selected converter: ${converterPath}`,
-        `Detected format: ${format}`,
-        "Please bundle a platform-correct converter binary (for example convert-darwin-arm64 or convert-darwin-x64).",
-      ].join("\n")
-    );
-  }
-
-  return converterPath;
-}
-
-async function findFirstExistingPath(paths: string[]): Promise<string | null> {
-  for (const candidate of paths) {
-    try {
-      await fs.promises.access(candidate, fs.constants.F_OK);
-      return candidate;
-    } catch {
-      continue;
-    }
-  }
-  return null;
-}
-
-async function detectBinaryFormat(binaryPath: string): Promise<BinaryFormat> {
-  const fd = await fs.promises.open(binaryPath, "r");
-  try {
-    const header = Buffer.alloc(4);
-    await fd.read(header, 0, 4, 0);
-
-    if (header[0] === 0x7f && header[1] === 0x45 && header[2] === 0x4c && header[3] === 0x46) {
-      return "elf";
-    }
-
-    if (header[0] === 0x4d && header[1] === 0x5a) {
-      return "pe";
-    }
-
-    const magic = header.readUInt32BE(0);
-    if (
-      magic === 0xfeedface ||
-      magic === 0xcefaedfe ||
-      magic === 0xfeedfacf ||
-      magic === 0xcffaedfe ||
-      magic === 0xcafebabe ||
-      magic === 0xbebafeca
-    ) {
-      return "mach-o";
-    }
-
-    return "unknown";
-  } finally {
-    await fd.close();
-  }
-}
-
-function isBinaryFormatCompatible(format: BinaryFormat): boolean {
-  if (process.platform === "darwin") return format === "mach-o";
-  if (process.platform === "linux") return format === "elf";
-  if (process.platform === "win32") return format === "pe";
-  return true;
 }
 
 function resolveExportedFilePath(responseData: any): string | null {

--- a/electron/app/main.ts
+++ b/electron/app/main.ts
@@ -51,6 +51,7 @@ import {
   resolveLaunchableExportChromiumPath,
 } from "./utils/export-chromium";
 import { syncUserConfigFromEnv } from "./utils/user-config-env";
+import { resolveExportRuntimeRoot } from "./utils/export-msix-runtime";
 
 installSafeConsole();
 
@@ -138,19 +139,6 @@ function recordProcessGone(kind: "child" | "renderer", details: ProcessGoneDetai
   }
 
   captureMainException(new Error(`Electron ${kind} process gone: ${reason}`), data);
-}
-
-function resolveExportConverterPath(appRoot: string): string | undefined {
-  const pyDir = path.join(appRoot, "resources", "export", "py");
-  const candidates = [
-    path.join(pyDir, `convert-${process.platform}-${process.arch}`),
-    path.join(pyDir, `convert-${process.platform}-${process.arch}.exe`),
-    path.join(pyDir, `convert-${process.platform}`),
-    path.join(pyDir, `convert-${process.platform}.exe`),
-    path.join(pyDir, "convert"),
-    path.join(pyDir, "convert.exe"),
-  ];
-  return candidates.find((candidate) => fs.existsSync(candidate));
 }
 
 function isDisableAuthEnabledValue(value?: string): boolean {
@@ -345,8 +333,9 @@ async function startServers(fastApiPort: number, nextjsPort: number) {
     const userConfigPath = getUserConfigPath();
     const disableAuthForElectron = resolveElectronDisableAuth();
     const imageMagickRuntime = resolveImageMagickRuntime();
-    const exportPackageRoot = path.join(resourceBaseDir, "resources", "export");
-    const exportConverterPath = resolveExportConverterPath(resourceBaseDir);
+    const exportPackageRoot = await resolveExportRuntimeRoot(
+      path.join(resourceBaseDir, "resources", "export"),
+    );
     await removeBrokenExportChromiumCaches();
     const exportChromiumPath = await resolveLaunchableExportChromiumPath();
     const puppeteerCacheDir = path.join(getCacheDir(), "puppeteer");
@@ -392,14 +381,10 @@ async function startServers(fastApiPort: number, nextjsPort: number) {
         LITEPARSE_NODE_BINARY: process.execPath,
         ELECTRON_RUN_AS_NODE: "1",
         EXPORT_PACKAGE_ROOT: exportPackageRoot,
-        EXPORT_RUNTIME_DIR: exportPackageRoot,
         PUPPETEER_CACHE_DIR: puppeteerCacheDir,
         PUPPETEER_TMP_DIR: puppeteerTempDir,
         ...(exportChromiumPath && {
           PUPPETEER_EXECUTABLE_PATH: exportChromiumPath,
-        }),
-        ...(exportConverterPath && {
-          BUILT_PYTHON_MODULE_PATH: exportConverterPath,
         }),
       },
       isDev,
@@ -424,9 +409,6 @@ async function startServers(fastApiPort: number, nextjsPort: number) {
         PUPPETEER_TMP_DIR: puppeteerTempDir,
         ...(exportChromiumPath && {
           PUPPETEER_EXECUTABLE_PATH: exportChromiumPath,
-        }),
-        ...(exportConverterPath && {
-          BUILT_PYTHON_MODULE_PATH: exportConverterPath,
         }),
       },
       isDev,

--- a/electron/app/types/index.d.ts
+++ b/electron/app/types/index.d.ts
@@ -11,11 +11,9 @@ interface FastApiEnv extends NodeJS.ProcessEnv {
   LITEPARSE_NODE_BINARY?: string;
   /** Root directory of the bundled presentation export runtime. */
   EXPORT_PACKAGE_ROOT?: string;
-  EXPORT_RUNTIME_DIR?: string;
   PUPPETEER_EXECUTABLE_PATH?: string;
   PUPPETEER_CACHE_DIR?: string;
   PUPPETEER_TMP_DIR?: string;
-  BUILT_PYTHON_MODULE_PATH?: string;
 }
 
 interface NextJsEnv extends NodeJS.ProcessEnv {
@@ -30,7 +28,6 @@ interface NextJsEnv extends NodeJS.ProcessEnv {
   PUPPETEER_EXECUTABLE_PATH?: string;
   PUPPETEER_CACHE_DIR?: string;
   PUPPETEER_TMP_DIR?: string;
-  BUILT_PYTHON_MODULE_PATH?: string;
 }
 
 interface UserConfig {

--- a/electron/app/utils/export-msix-runtime.ts
+++ b/electron/app/utils/export-msix-runtime.ts
@@ -1,29 +1,26 @@
 import fs from "fs";
 import path from "path";
 import { createHash } from "crypto";
-import { baseDir, getCacheDir, resourceBaseDir } from "./constants";
+import { baseDir, getCacheDir } from "./constants";
 import { safeLog } from "./safe-console";
 
-const CACHE_LAYOUT_VERSION = "2";
+const CACHE_LAYOUT_VERSION = "3";
 
 type ExportSpawnTarget = {
   scriptPath: string;
-  converterPath: string;
 };
 
-/** MSIX installs live under Program Files\\WindowsApps and block dlopen on packaged .node files. */
+/** MSIX installs live under Program Files\WindowsApps and block native addons. */
 export function isWindowsStoreInstall(): boolean {
-  if (process.platform !== "win32") {
-    return false;
-  }
-  const markers = [baseDir, process.execPath, path.dirname(process.execPath)];
-  return markers.some((candidate) => /\\windowsapps\\/i.test(candidate));
+  if (process.platform !== "win32") return false;
+  return [baseDir, process.execPath, path.dirname(process.execPath)].some((candidate) =>
+    /\\windowsapps\\/i.test(candidate),
+  );
 }
 
 function getExportRuntimeVersion(): string {
   try {
-    const packageJsonPath = path.join(baseDir, "package.json");
-    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+    const pkg = JSON.parse(fs.readFileSync(path.join(baseDir, "package.json"), "utf8")) as {
       exportVersion?: string;
       version?: string;
     };
@@ -33,220 +30,75 @@ function getExportRuntimeVersion(): string {
   }
 }
 
-function getMsixExportCacheRoot(exportRuntimeVersion: string): string {
+function getCacheRoot(): string {
   return path.join(
     getCacheDir(),
     "msix-export-runtime",
     CACHE_LAYOUT_VERSION,
-    exportRuntimeVersion
+    getExportRuntimeVersion(),
   );
 }
 
-function sharpPackagesForPlatform(): string[] {
-  const arch = process.arch;
-  if (process.platform === "win32") {
-    if (arch === "arm64") {
-      return [
-        "sharp",
-        "@img/sharp-win32-arm64",
-        "@img/colour",
-        "detect-libc",
-        "semver",
-      ];
-    }
-    return [
-      "sharp",
-      "@img/sharp-win32-x64",
-      "@img/colour",
-      "detect-libc",
-      "semver",
-    ];
-  }
-  if (process.platform === "darwin") {
-    return arch === "arm64"
-      ? ["sharp", "@img/sharp-darwin-arm64", "@img/colour", "detect-libc", "semver"]
-      : ["sharp", "@img/sharp-darwin-x64", "@img/colour", "detect-libc", "semver"];
-  }
-  return ["sharp", "@img/sharp-linux-x64", "@img/colour", "detect-libc", "semver"];
-}
-
-function resolvePackageSourceDir(sourceModulesRoot: string, packageName: string): string {
-  if (packageName.startsWith("@")) {
-    const [scope, name] = packageName.split("/");
-    return path.join(sourceModulesRoot, scope, name);
-  }
-  return path.join(sourceModulesRoot, packageName);
-}
-
-function resolvePackageDestDir(destModulesRoot: string, packageName: string): string {
-  return resolvePackageSourceDir(destModulesRoot, packageName);
-}
-
-function assertSourcePackagesAvailable(sourceModulesRoot: string): void {
-  const missingPackages = sharpPackagesForPlatform().filter((packageName) => {
-    const sourceDir = resolvePackageSourceDir(sourceModulesRoot, packageName);
-    return !fs.existsSync(path.join(sourceDir, "package.json"));
-  });
-
-  if (missingPackages.length > 0) {
-    throw new Error(
-      [
-        "Export dependencies are missing from the unpacked app bundle.",
-        `Missing: ${missingPackages.join(", ")}`,
-        `Expected under: ${sourceModulesRoot}`,
-        "Rebuild the APPX after unpacking sharp dependencies from app.asar.",
-      ].join(" ")
-    );
-  }
-}
-
-async function fileFingerprint(filePath: string): Promise<string> {
-  const stat = await fs.promises.stat(filePath);
-  return `${stat.size}:${stat.mtimeMs}`;
-}
-
-async function buildSourceFingerprint(exportRoot: string, sourceModulesRoot: string): Promise<string> {
+async function sourceFingerprint(exportRoot: string): Promise<string> {
   const hash = createHash("sha256");
-  const indexPath = path.join(exportRoot, "index.js");
-  hash.update(await fileFingerprint(indexPath));
-
-  for (const packageName of sharpPackagesForPlatform()) {
-    const packagePath = resolvePackageSourceDir(sourceModulesRoot, packageName);
-    hash.update(packageName);
-    hash.update(await fileFingerprint(path.join(packagePath, "package.json")));
-    if (packageName.startsWith("@img/sharp-")) {
-      const libDir = path.join(packagePath, "lib");
-      const entries = await fs.promises.readdir(libDir);
-      const nodeBinary = entries.find((entry) => entry.endsWith(".node"));
-      if (nodeBinary) {
-        hash.update(await fileFingerprint(path.join(libDir, nodeBinary)));
-      }
-    }
+  const trackedFiles = [
+    "runner.mjs",
+    "presenton-export-version.json",
+    path.join("node_modules", "@presenton", "export-core", "package.json"),
+    path.join("node_modules", "@presenton", "export-core", "dist", "index.js"),
+  ];
+  for (const relativePath of trackedFiles) {
+    const filePath = path.join(exportRoot, relativePath);
+    const stat = await fs.promises.stat(filePath);
+    hash.update(relativePath);
+    hash.update(`${stat.size}:${stat.mtimeMs}`);
   }
-
-  const pyDir = path.join(exportRoot, "py");
-  try {
-    const pyEntries = await fs.promises.readdir(pyDir);
-    for (const entry of pyEntries) {
-      if (!/^convert/i.test(entry)) {
-        continue;
-      }
-      hash.update(await fileFingerprint(path.join(pyDir, entry)));
-    }
-  } catch {
-    // Converter binaries are optional for fingerprinting.
-  }
-
   return hash.digest("hex");
 }
 
-async function readCacheFingerprint(cacheRoot: string): Promise<string | null> {
-  const stampPath = path.join(cacheRoot, ".source-fingerprint");
+async function readFingerprint(cacheRoot: string): Promise<string | null> {
   try {
-    return (await fs.promises.readFile(stampPath, "utf8")).trim() || null;
+    return (await fs.promises.readFile(path.join(cacheRoot, ".source-fingerprint"), "utf8")).trim();
   } catch {
     return null;
   }
 }
 
-async function copyPath(source: string, destination: string): Promise<void> {
-  await fs.promises.mkdir(path.dirname(destination), { recursive: true });
-  await fs.promises.cp(source, destination, { recursive: true, force: true });
-}
+export async function resolveExportRuntimeRoot(packagedExportRoot: string): Promise<string> {
+  if (!isWindowsStoreInstall()) return packagedExportRoot;
 
-async function materializeMsixExportRuntime(
-  exportRoot: string,
-  sourceModulesRoot: string,
-  cacheRoot: string
-): Promise<void> {
-  safeLog("[Export] Preparing MSIX export runtime in user cache:", cacheRoot);
+  const cacheRoot = getCacheRoot();
+  const fingerprint = await sourceFingerprint(packagedExportRoot);
+  const cachedFingerprint = await readFingerprint(cacheRoot);
+  const cachedRunner = path.join(cacheRoot, "runner.mjs");
+  if (fingerprint === cachedFingerprint && fs.existsSync(cachedRunner)) {
+    return cacheRoot;
+  }
+
+  safeLog("[Export] Preparing MSIX export-core runtime in user cache:", cacheRoot);
   await fs.promises.rm(cacheRoot, { recursive: true, force: true });
-  await fs.promises.mkdir(cacheRoot, { recursive: true });
-
-  await copyPath(path.join(exportRoot, "index.js"), path.join(cacheRoot, "index.js"));
-
-  const pyDir = path.join(exportRoot, "py");
-  if (fs.existsSync(pyDir)) {
-    await copyPath(pyDir, path.join(cacheRoot, "py"));
-  }
-
-  const destModulesRoot = path.join(cacheRoot, "node_modules");
-  for (const packageName of sharpPackagesForPlatform()) {
-    const sourceDir = resolvePackageSourceDir(sourceModulesRoot, packageName);
-    const destDir = resolvePackageDestDir(destModulesRoot, packageName);
-    if (!fs.existsSync(sourceDir)) {
-      throw new Error(`Export dependency missing from app bundle: ${packageName} (${sourceDir})`);
-    }
-    await copyPath(sourceDir, destDir);
-  }
-
-  const fingerprint = await buildSourceFingerprint(exportRoot, sourceModulesRoot);
-  await fs.promises.writeFile(path.join(cacheRoot, ".source-fingerprint"), fingerprint, "utf8");
-  safeLog("[Export] MSIX export runtime ready.");
-}
-
-async function resolveConverterPathFromExportRoot(exportRoot: string): Promise<string> {
-  const pyDir = path.join(exportRoot, "py");
-  const extension = process.platform === "win32" ? ".exe" : "";
-  const converterCandidates = [
-    path.join(pyDir, `convert-${process.platform}-${process.arch}${extension}`),
-    path.join(pyDir, `convert-${process.platform}${extension}`),
-    ...(process.platform === "win32"
-      ? [path.join(pyDir, "convert.exe"), path.join(pyDir, "convert")]
-      : [path.join(pyDir, "convert")]),
-  ];
-
-  for (const candidate of converterCandidates) {
-    try {
-      await fs.promises.access(candidate, fs.constants.F_OK);
-      return candidate;
-    } catch {
-      continue;
-    }
-  }
-
-  throw new Error(
-    [
-      "No converter binary found for export.",
-      "Expected one of:",
-      ...converterCandidates.map((candidate) => `  - ${candidate}`),
-    ].join("\n")
+  await fs.promises.mkdir(path.dirname(cacheRoot), { recursive: true });
+  await fs.promises.cp(packagedExportRoot, cacheRoot, {
+    recursive: true,
+    force: true,
+  });
+  await fs.promises.writeFile(
+    path.join(cacheRoot, ".source-fingerprint"),
+    fingerprint,
+    "utf8",
   );
+  return cacheRoot;
 }
 
-/**
- * For Microsoft Store (MSIX) installs, copy export JS + sharp native addons to a writable
- * directory so Node can dlopen them. Returns the original paths elsewhere.
- */
 export async function resolveExportSpawnTarget(
   packagedExportRoot: string,
   packagedScriptPath: string,
-  resolvePackagedConverterPath: (exportRoot: string) => Promise<string>
 ): Promise<ExportSpawnTarget> {
-  if (!isWindowsStoreInstall()) {
-    return {
-      scriptPath: packagedScriptPath,
-      converterPath: await resolvePackagedConverterPath(packagedExportRoot),
-    };
-  }
-
-  const exportRuntimeVersion = getExportRuntimeVersion();
-  const cacheRoot = getMsixExportCacheRoot(exportRuntimeVersion);
-  const cachedScriptPath = path.join(cacheRoot, "index.js");
-  const sourceModulesRoot = path.join(resourceBaseDir, "node_modules");
-  assertSourcePackagesAvailable(sourceModulesRoot);
-
-  const expectedFingerprint = await buildSourceFingerprint(packagedExportRoot, sourceModulesRoot);
-  const cachedFingerprint = await readCacheFingerprint(cacheRoot);
-  const cacheIsCurrent =
-    cachedFingerprint === expectedFingerprint && fs.existsSync(cachedScriptPath);
-
-  if (!cacheIsCurrent) {
-    await materializeMsixExportRuntime(packagedExportRoot, sourceModulesRoot, cacheRoot);
-  }
-
+  const exportRoot = await resolveExportRuntimeRoot(packagedExportRoot);
   return {
-    scriptPath: cachedScriptPath,
-    converterPath: await resolveConverterPathFromExportRoot(cacheRoot),
+    scriptPath:
+      exportRoot === packagedExportRoot
+        ? packagedScriptPath
+        : path.join(exportRoot, path.basename(packagedScriptPath)),
   };
 }

--- a/electron/build.js
+++ b/electron/build.js
@@ -679,6 +679,16 @@ function collectMissingBundleResources(resourcesRoot) {
     "models.json"
   )
   const nextjsRoot = path.join(resourcesRoot, "nextjs")
+  const exportRunner = path.join(resourcesRoot, "export", "runner.mjs")
+  const exportCore = path.join(
+    resourcesRoot,
+    "export",
+    "node_modules",
+    "@presenton",
+    "export-core",
+    "dist",
+    "index.js"
+  )
   const missing = []
 
   if (!fs.existsSync(fastapiPath)) {
@@ -694,6 +704,12 @@ function collectMissingBundleResources(resourcesRoot) {
       label: "Next.js standalone server",
       path: `${directNextServer} or ${nestedNextServer}`,
     })
+  }
+  if (!fs.existsSync(exportRunner)) {
+    missing.push({ label: "Export task runner", path: exportRunner })
+  }
+  if (!fs.existsSync(exportCore)) {
+    missing.push({ label: "Export Core package", path: exportCore })
   }
 
   return missing
@@ -744,13 +760,6 @@ const afterPack = async (context) => {
     assertPackagedBundleResourcesReady(resourcesRoot)
 
     const fastapiPath = path.join(resourcesRoot, "fastapi", getFastApiBinaryName("darwin"))
-    const exportPyDir = path.join(resourcesRoot, "export", "py")
-    const converterCandidates = [
-      `convert-${process.platform}-${process.arch}`,
-      `convert-${process.platform}`,
-      "convert",
-    ]
-
     console.log("Setting executable permissions for FastAPI binary...")
     console.log("FastAPI path:", fastapiPath)
 
@@ -761,27 +770,9 @@ const afterPack = async (context) => {
       console.warn("⚠ FastAPI binary not found at:", fastapiPath)
     }
 
-    console.log("Setting executable permissions for export converter binary...")
-    let converterFound = false
-    for (const candidate of converterCandidates) {
-      const candidatePath = path.join(exportPyDir, candidate)
-      if (fs.existsSync(candidatePath)) {
-        fs.chmodSync(candidatePath, 0o755)
-        console.log("✓ Execute permissions set for converter:", candidatePath)
-        converterFound = true
-      }
-    }
-    if (!converterFound) {
-      console.warn("⚠ No converter binary found in:", exportPyDir)
-    }
-
     const fastapiDir = path.join(resourcesRoot, "fastapi")
     if (fs.existsSync(fastapiDir)) {
       console.log("FastAPI directory contents:", fs.readdirSync(fastapiDir))
-    }
-
-    if (fs.existsSync(exportPyDir)) {
-      console.log("Export py directory contents:", fs.readdirSync(exportPyDir))
     }
 
     pruneUnsupportedPackagedPrebuilds(

--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,7 @@
   "name": "presenton",
   "productName": "Presenton Open Source",
   "version": "0.9.7-beta",
-  "exportVersion": "v0.4.8",
+  "exportVersion": "v1.0.12",
   "exportChromiumBuildId": "149.0.7827.196",
   "exportMacChromiumBuildIds": {
     "darwin-arm64": "1625085",

--- a/electron/scripts/sync-export-runtime.cjs
+++ b/electron/scripts/sync-export-runtime.cjs
@@ -1,605 +1,76 @@
+/** Copy the architecture-independent export-core runtime into Electron resources. */
 const fs = require("fs");
-const http = require("http");
-const https = require("https");
 const path = require("path");
 const { execFileSync } = require("child_process");
 
 const electronRoot = path.join(__dirname, "..");
+const repoRoot = path.join(electronRoot, "..");
+const sourceRoot = path.join(repoRoot, "presentation-export");
+const targetRoot = path.join(electronRoot, "resources", "export");
+const rootSyncScript = path.join(repoRoot, "scripts", "sync-presentation-export.cjs");
 const packageJson = JSON.parse(
   fs.readFileSync(path.join(electronRoot, "package.json"), "utf8"),
 );
-
-const targetRoot = path.join(electronRoot, "resources", "export");
-const targetPyDir = path.join(targetRoot, "py");
-const targetIndex = path.join(targetRoot, "index.js");
-const versionManifestPath = path.join(
-  targetRoot,
-  "presenton-export-version.json",
-);
-const cacheDir = path.join(electronRoot, ".cache", "export-runtime");
-const exportRepoBase = "https://github.com/presenton/presenton-export/releases/download";
-const exportVersion = packageJson.exportVersion || "v0.1.0";
-
+const expectedVersion = String(packageJson.exportVersion || "").replace(/^v/, "");
 const cliArgs = new Set(process.argv.slice(2));
-const forceDownload = cliArgs.has("--force");
-const checkOnly = cliArgs.has("--check-only");
-const allowVersionOverride = cliArgs.has("--allow-version-override");
 
-async function getTargetVersion() {
-  const requestedVersion = allowVersionOverride
-    ? process.env.EXPORT_RUNTIME_VERSION || exportVersion
-    : exportVersion;
-  if (requestedVersion !== "latest") {
-    return requestedVersion;
-  }
-
-  const apiUrl = "https://api.github.com/repos/presenton/presenton-export/releases/latest";
-  const latest = await requestJson(apiUrl);
-  if (!latest.tag_name) {
-    throw new Error(`Could not resolve latest release tag from ${apiUrl}`);
-  }
-
-  return latest.tag_name;
-}
-
-function readInstalledVersion() {
-  if (!fs.existsSync(versionManifestPath)) {
-    return {
-      ok: false,
-      reason: `Missing export version manifest: ${versionManifestPath}`,
-    };
-  }
-
+function installedVersion(root) {
+  const packagePath = path.join(
+    root,
+    "node_modules",
+    "@presenton",
+    "export-core",
+    "package.json",
+  );
+  const runnerPath = path.join(root, "runner.mjs");
+  if (!fs.existsSync(packagePath) || !fs.existsSync(runnerPath)) return null;
   try {
-    const manifest = JSON.parse(fs.readFileSync(versionManifestPath, "utf8"));
-    return { ok: true, manifest };
-  } catch (error) {
-    return {
-      ok: false,
-      reason: `Invalid export version manifest ${versionManifestPath}: ${error.message}`,
-    };
-  }
-}
-
-function writeInstalledVersion(version, asset) {
-  fs.writeFileSync(
-    versionManifestPath,
-    `${JSON.stringify({ version, asset }, null, 2)}\n`,
-    "utf8",
-  );
-}
-
-function getPlatformAssetName() {
-  const platformArch = `${process.platform}-${process.arch}`;
-  if (platformArch === "linux-arm64") return "export-Linux-ARM64.zip";
-  if (platformArch === "linux-x64") return "export-Linux-X64.zip";
-  if (platformArch === "darwin-arm64") return "export-macOS-ARM64.zip";
-  if (platformArch === "darwin-x64") return "export-macOS-X64.zip";
-  if (platformArch === "win32-x64") return "export-Windows-X64.zip";
-
-  throw new Error(
-    `Unsupported export runtime platform: ${platformArch}. Supported: linux-arm64, linux-x64, darwin-arm64, darwin-x64, win32-x64`
-  );
-}
-
-function getConverterCandidates() {
-  const platformAliases = {
-    linux: ["linux"],
-    darwin: ["darwin", "macos", "mac"],
-    win32: ["win32", "windows", "win"],
-  };
-  const archAliases = {
-    x64: ["x64", "amd64"],
-    arm64: ["arm64", "aarch64"],
-  };
-
-  const candidates = [];
-  const platforms = platformAliases[process.platform] || [process.platform];
-  const archs = archAliases[process.arch] || [process.arch];
-  const windows = process.platform === "win32";
-
-  for (const p of platforms) {
-    for (const a of archs) {
-      candidates.push(path.join(targetPyDir, `convert-${p}-${a}`));
-      candidates.push(path.join(targetPyDir, `convert-${p}-${a}.exe`));
-    }
-    candidates.push(path.join(targetPyDir, `convert-${p}`));
-    candidates.push(path.join(targetPyDir, `convert-${p}.exe`));
-  }
-
-  if (windows) {
-    candidates.push(path.join(targetPyDir, "convert.exe"));
-  }
-  candidates.push(path.join(targetPyDir, "convert"));
-
-  return [...new Set(candidates)];
-}
-
-function ensureDir(dirPath) {
-  fs.mkdirSync(dirPath, { recursive: true });
-}
-
-function chmodIfPossible(filePath) {
-  if (process.platform !== "win32") {
-    fs.chmodSync(filePath, 0o755);
-  }
-}
-
-function detectBinaryFormat(filePath) {
-  const fd = fs.openSync(filePath, "r");
-  try {
-    const header = Buffer.alloc(4);
-    fs.readSync(fd, header, 0, 4, 0);
-
-    if (header[0] === 0x7f && header[1] === 0x45 && header[2] === 0x4c && header[3] === 0x46) {
-      return "elf";
-    }
-
-    if (header[0] === 0x4d && header[1] === 0x5a) {
-      return "pe";
-    }
-
-    const magic = header.readUInt32BE(0);
-    if (
-      magic === 0xfeedface ||
-      magic === 0xcefaedfe ||
-      magic === 0xfeedfacf ||
-      magic === 0xcffaedfe ||
-      magic === 0xcafebabe ||
-      magic === 0xbebafeca
-    ) {
-      return "mach-o";
-    }
-
-    return "unknown";
-  } finally {
-    fs.closeSync(fd);
-  }
-}
-
-function isFormatCompatible(format) {
-  if (process.platform === "darwin") return format === "mach-o";
-  if (process.platform === "linux") return format === "elf";
-  if (process.platform === "win32") return format === "pe";
-  return true;
-}
-
-function validateExistingRuntime(expectedVersion, expectedAsset) {
-  const installedVersion = readInstalledVersion();
-  if (!installedVersion.ok) {
-    return installedVersion;
-  }
-  if (
-    installedVersion.manifest.version !== expectedVersion ||
-    installedVersion.manifest.asset !== expectedAsset
-  ) {
-    return {
-      ok: false,
-      reason: [
-        "Installed export runtime does not match electron/package.json.",
-        `Expected: ${expectedVersion} (${expectedAsset})`,
-        `Installed: ${installedVersion.manifest.version || "unknown"} (${installedVersion.manifest.asset || "unknown"})`,
-      ].join("\n"),
-    };
-  }
-
-  if (!fs.existsSync(targetIndex)) {
-    return { ok: false, reason: `Missing runtime bundle: ${targetIndex}` };
-  }
-
-  const converterCandidates = getConverterCandidates();
-  const converterPath = converterCandidates.find((candidate) => fs.existsSync(candidate));
-
-  if (!converterPath) {
-    return {
-      ok: false,
-      reason: [
-        "No converter binary found in electron/resources/export/py.",
-        "Expected one of:",
-        ...converterCandidates.map((candidate) => `  - ${candidate}`),
-      ].join("\n"),
-    };
-  }
-
-  const binaryFormat = detectBinaryFormat(converterPath);
-  if (!isFormatCompatible(binaryFormat)) {
-    return {
-      ok: false,
-      reason: [
-        `Converter binary is not valid for ${process.platform}/${process.arch}.`,
-        `Selected converter: ${converterPath}`,
-        `Detected format: ${binaryFormat}`,
-      ].join("\n"),
-    };
-  }
-
-  chmodIfPossible(converterPath);
-  return { ok: true, converterPath };
-}
-
-function patchHtmlToImageRuntime() {
-  if (!fs.existsSync(targetIndex)) {
-    return false;
-  }
-
-  const original = fs.readFileSync(targetIndex, "utf8");
-  let patched = original.replace(
-    'await C.setContent(a.html,{waitUntil:"networkidle0",timeout:12e4})',
-    'await C.setContent(a.html,{waitUntil:"domcontentloaded",timeout:12e4})',
-  );
-  patched = patched.replace(
-    'catch(C){throw C instanceof ig?C:new ig("Failed to render HTML to image",500)}',
-    'catch(C){console.error("[html-to-image]",C);throw C instanceof ig?C:new ig("Failed to render HTML to image",500)}',
-  );
-
-  if (patched === original) {
-    return false;
-  }
-  fs.writeFileSync(targetIndex, patched);
-  console.log("[export-runtime] Patched HTML-to-image readiness and error logging.");
-  return true;
-}
-
-function hasExportDirectoryContent() {
-  if (!fs.existsSync(targetRoot)) return false;
-  return fs.readdirSync(targetRoot).length > 0;
-}
-
-function request(url) {
-  const client = url.startsWith("https:") ? https : http;
-  return client;
-}
-
-function requestJson(url, redirects = 5) {
-  return new Promise((resolve, reject) => {
-    const client = request(url);
-    const req = client.get(
-      url,
-      {
-        headers: {
-          "User-Agent": "presenton-export-runtime-sync",
-          Accept: "application/vnd.github+json",
-        },
-      },
-      (res) => {
-        if ([301, 302, 303, 307, 308].includes(res.statusCode) && res.headers.location) {
-          if (redirects <= 0) {
-            reject(new Error(`Too many redirects for JSON request: ${url}`));
-            return;
-          }
-          requestJson(res.headers.location, redirects - 1).then(resolve).catch(reject);
-          return;
-        }
-
-        if (res.statusCode < 200 || res.statusCode >= 300) {
-          reject(new Error(`Failed to fetch ${url}. HTTP ${res.statusCode}`));
-          return;
-        }
-
-        let payload = "";
-        res.setEncoding("utf8");
-        res.on("data", (chunk) => {
-          payload += chunk;
-        });
-        res.on("end", () => {
-          try {
-            resolve(JSON.parse(payload));
-          } catch (error) {
-            reject(new Error(`Invalid JSON received from ${url}: ${error.message}`));
-          }
-        });
-      }
-    );
-
-    req.on("error", reject);
-  });
-}
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function downloadFile(url, outputPath, redirects = 5) {
-  return new Promise((resolve, reject) => {
-    const client = request(url);
-    const req = client.get(
-      url,
-      {
-        headers: {
-          "User-Agent": "presenton-export-runtime-sync",
-          Accept: "application/octet-stream",
-        },
-      },
-      (res) => {
-        if ([301, 302, 303, 307, 308].includes(res.statusCode) && res.headers.location) {
-          if (redirects <= 0) {
-            reject(new Error(`Too many redirects while downloading ${url}`));
-            return;
-          }
-          downloadFile(res.headers.location, outputPath, redirects - 1).then(resolve).catch(reject);
-          return;
-        }
-
-        if (res.statusCode < 200 || res.statusCode >= 300) {
-          reject(new Error(`Failed to download ${url}. HTTP ${res.statusCode}`));
-          return;
-        }
-
-        ensureDir(path.dirname(outputPath));
-        const fileStream = fs.createWriteStream(outputPath);
-        res.pipe(fileStream);
-        fileStream.on("finish", () => {
-          fileStream.close(resolve);
-        });
-        fileStream.on("error", reject);
-      }
-    );
-
-    req.on("error", reject);
-  });
-}
-
-async function downloadFileWithRetries(url, outputPath, attempts = 4) {
-  let lastError;
-  for (let i = 0; i < attempts; i++) {
-    try {
-      if (i > 0) {
-        const delay = 1500 * Math.pow(2, i - 1);
-        console.log(`[export-runtime] Retrying download (attempt ${i + 1}/${attempts}) after ${delay}ms…`);
-        await sleep(delay);
-      }
-      try {
-        fs.unlinkSync(outputPath);
-      } catch {
-        /* ignore */
-      }
-      await downloadFile(url, outputPath);
-      const st = fs.statSync(outputPath);
-      if (st.size < 512) {
-        throw new Error(`Downloaded file is too small (${st.size} bytes); likely corrupt or HTML error page`);
-      }
-      const magic = Buffer.alloc(4);
-      const fd = fs.openSync(outputPath, "r");
-      try {
-        fs.readSync(fd, magic, 0, 4, 0);
-      } finally {
-        fs.closeSync(fd);
-      }
-      if (magic[0] !== 0x50 || magic[1] !== 0x4b) {
-        throw new Error("Downloaded file is not a ZIP (missing PK header); delete cache and retry");
-      }
-      return;
-    } catch (err) {
-      lastError = err;
-    }
-  }
-  throw lastError;
-}
-
-function unzipArchive(zipPath, destDir) {
-  ensureDir(destDir);
-  if (process.platform === "win32") {
-    const psQuote = (p) => p.replace(/'/g, "''");
-    execFileSync(
-      "powershell.exe",
-      [
-        "-NoProfile",
-        "-Command",
-        `Expand-Archive -LiteralPath '${psQuote(zipPath)}' -DestinationPath '${psQuote(destDir)}' -Force`,
-      ],
-      { stdio: "inherit" }
-    );
-    return;
-  }
-
-  execFileSync("unzip", ["-o", zipPath, "-d", destDir], { stdio: "inherit" });
-}
-
-function hasRuntimeLayout(dir) {
-  const indexPath = path.join(dir, "index.js");
-  if (!fs.existsSync(indexPath)) return false;
-
-  const pyPath = path.join(dir, "py");
-  if (fs.existsSync(pyPath)) {
-    try {
-      return fs.statSync(pyPath).isDirectory();
-    } catch {
-      return false;
-    }
-  }
-
-  // Windows release zips are often flat: index.js + convert-*.exe (no py/ yet).
-  try {
-    return fs.readdirSync(dir).some((name) => {
-      if (!/^convert/i.test(name)) return false;
-      const p = path.join(dir, name);
-      try {
-        return fs.statSync(p).isFile();
-      } catch {
-        return false;
-      }
-    });
+    return JSON.parse(fs.readFileSync(packagePath, "utf8")).version || null;
   } catch {
-    return false;
+    return null;
   }
 }
 
-/** Flat Windows bundles ship convert-*.exe next to index.js; runtime expects py/. */
-function ensurePyConverterLayout(root) {
-  const pyDir = path.join(root, "py");
-  let needMoveFromRoot = false;
-
-  if (fs.existsSync(pyDir)) {
-    try {
-      if (fs.statSync(pyDir).isDirectory()) {
-        const inner = fs.readdirSync(pyDir);
-        const hasBin = inner.some(
-          (n) =>
-            n === "convert" ||
-            n === "convert.exe" ||
-            /^convert-/i.test(n)
-        );
-        if (hasBin) return;
-        needMoveFromRoot = true;
-      }
-    } catch {
-      needMoveFromRoot = true;
-    }
-  } else {
-    needMoveFromRoot = true;
+function validateTarget(expected = expectedVersion) {
+  const version = installedVersion(targetRoot);
+  if (version !== expected) {
+    throw new Error(
+      `Expected export-core ${expected} in Electron resources, found ${version || "nothing"}.`,
+    );
   }
-
-  if (!needMoveFromRoot) return;
-
-  fs.mkdirSync(pyDir, { recursive: true });
-  const names = fs.readdirSync(root, { withFileTypes: true });
-  for (const ent of names) {
-    if (!ent.isFile()) continue;
-    const base = ent.name;
-    if (!/^convert/i.test(base)) continue;
-    const from = path.join(root, base);
-    const to = path.join(pyDir, base);
-    fs.renameSync(from, to);
-  }
+  return version;
 }
 
-function describeExtractTree(extractDir, maxEntries = 30) {
-  const lines = [];
-  function walk(dir, prefix, depth) {
-    if (depth > 3 || lines.length >= maxEntries) return;
-    let entries;
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const e of entries) {
-      if (lines.length >= maxEntries) break;
-      const p = path.join(dir, e.name);
-      lines.push(`${prefix}${e.name}${e.isDirectory() ? "/" : ""}`);
-      if (e.isDirectory()) walk(p, `${prefix}  `, depth + 1);
-    }
-  }
-  walk(extractDir, "", 0);
-  return lines.length ? lines.join("\n") : "(empty)";
-}
-
-function resolveExtractedRoot(extractDir) {
-  if (hasRuntimeLayout(extractDir)) {
-    return extractDir;
-  }
-
-  const queue = [{ dir: extractDir, depth: 0 }];
-  const maxDepth = 8;
-  while (queue.length > 0) {
-    const { dir, depth } = queue.shift();
-    if (depth >= maxDepth) continue;
-    let children;
-    try {
-      children = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of children) {
-      if (!entry.isDirectory()) continue;
-      const candidate = path.join(dir, entry.name);
-      if (hasRuntimeLayout(candidate)) {
-        return candidate;
-      }
-      queue.push({ dir: candidate, depth: depth + 1 });
-    }
-  }
-
-  const hint = describeExtractTree(extractDir);
-  throw new Error(
-    `Unable to locate export runtime root under ${extractDir}\n` +
-      `Expected a folder containing index.js and a py/ directory. Extracted layout (partial):\n${hint}`
-  );
-}
-
-async function downloadAndInstallRuntime(tag, assetName) {
-  const downloadUrl = `${exportRepoBase}/${tag}/${assetName}`;
-
-  ensureDir(cacheDir);
-  const cacheKey = tag.replace(/[^a-zA-Z0-9._-]/g, "_");
-  const zipPath = path.join(cacheDir, `${cacheKey}-${assetName}`);
-  const extractDir = path.join(cacheDir, `extract-${Date.now()}`);
-
-  console.log(`[export-runtime] Downloading ${downloadUrl}`);
-  try {
-    await downloadFileWithRetries(downloadUrl, zipPath);
-  } catch (err) {
-    try {
-      fs.unlinkSync(zipPath);
-    } catch {
-      /* ignore */
-    }
-    throw err;
-  }
-
-  console.log(`[export-runtime] Extracting ${zipPath}`);
-  try {
-    unzipArchive(zipPath, extractDir);
-    const sourceRoot = resolveExtractedRoot(extractDir);
-    ensurePyConverterLayout(sourceRoot);
-    fs.rmSync(targetRoot, { recursive: true, force: true });
-    ensureDir(targetRoot);
-    fs.cpSync(sourceRoot, targetRoot, { recursive: true, force: true });
-    writeInstalledVersion(tag, assetName);
-  } finally {
-    fs.rmSync(extractDir, { recursive: true, force: true });
-  }
-
-  return { tag, downloadUrl };
-}
-
-async function main() {
-  const targetVersion = await getTargetVersion();
-  const assetName = getPlatformAssetName();
-  const existing = validateExistingRuntime(targetVersion, assetName);
-
-  if (checkOnly) {
-    if (!existing.ok) {
-      throw new Error(existing.reason);
-    }
-    console.log("[export-runtime] Existing runtime is valid.");
-    console.log(`  - ${targetIndex}`);
-    console.log(`  - ${existing.converterPath}`);
-    console.log(`  - release: ${targetVersion}`);
+function main() {
+  if (cliArgs.has("--check-only")) {
+    console.log(`[export-runtime] OK (${validateTarget()})`);
     return;
   }
 
-  if (existing.ok && !forceDownload) {
-    patchHtmlToImageRuntime();
-    console.log("[export-runtime] Using existing runtime artifacts:");
-    console.log(`  - ${targetIndex}`);
-    console.log(`  - ${existing.converterPath}`);
-    console.log(`  - release: ${targetVersion}`);
-    return;
+  const syncArgs = [];
+  if (cliArgs.has("--force")) syncArgs.push("--force");
+  if (cliArgs.has("--allow-version-override")) {
+    syncArgs.push("--allow-version-override");
   }
+  execFileSync(process.execPath, [rootSyncScript, ...syncArgs], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: "inherit",
+  });
 
-  if (!existing.ok && hasExportDirectoryContent()) {
-    console.log("[export-runtime] Existing export directory is invalid, re-syncing package.");
+  fs.rmSync(targetRoot, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(targetRoot), { recursive: true });
+  fs.cpSync(sourceRoot, targetRoot, { recursive: true, force: true });
+  const sourceVersion = installedVersion(sourceRoot);
+  if (!sourceVersion) {
+    throw new Error("The synced export-core package is missing from presentation-export.");
   }
-
-  const { tag, downloadUrl } = await downloadAndInstallRuntime(
-    targetVersion,
-    assetName,
-  );
-  patchHtmlToImageRuntime();
-  const installed = validateExistingRuntime(targetVersion, assetName);
-  if (!installed.ok) {
-    throw new Error(installed.reason);
-  }
-
-  console.log("[export-runtime] Runtime synced successfully:");
-  console.log(`  - release: ${tag}`);
-  console.log(`  - url: ${downloadUrl}`);
-  console.log(`  - ${targetIndex}`);
-  console.log(`  - ${installed.converterPath}`);
+  console.log(`[export-runtime] Installed export-core ${validateTarget(sourceVersion)}`);
 }
 
-main().catch((error) => {
+try {
+  main();
+} catch (error) {
   console.error(`[export-runtime] ${error.message}`);
   process.exit(1);
-});
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "presenton",
   "version": "0.9.7-beta",
-  "presentationExportVersion": "v0.4.8",
+  "presentationExportVersion": "v1.0.12",
   "type": "module",
   "description": "Open-source AI presentation generator",
   "scripts": {

--- a/scripts/run-presentation-export.mjs
+++ b/scripts/run-presentation-export.mjs
@@ -1,0 +1,108 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { runTask } from "@presenton/export-core";
+
+function parseCookieHeader(cookieHeader) {
+  if (!cookieHeader) return undefined;
+
+  const cookies = {};
+  for (const item of cookieHeader.split(";")) {
+    const separator = item.indexOf("=");
+    if (separator <= 0) continue;
+    const name = item.slice(0, separator).trim();
+    if (!name) continue;
+    cookies[name] = item.slice(separator + 1).trim();
+  }
+  return Object.keys(cookies).length > 0 ? cookies : undefined;
+}
+
+function buildModifyWindow(fastapiUrl) {
+  const assetsBaseUrl = process.env.ASSETS_BASE_URL?.trim();
+  if (!fastapiUrl && !assetsBaseUrl) return undefined;
+
+  const runtimeConfig = JSON.stringify({
+    ...(fastapiUrl ? { NEXT_PUBLIC_FAST_API: fastapiUrl } : {}),
+    ...(assetsBaseUrl ? { ASSETS_BASE_URL: assetsBaseUrl } : {}),
+  });
+
+  return new Function(
+    `const target = window; target.env = { ...(target.env ?? {}), ...${runtimeConfig} };`,
+  );
+}
+
+function buildRunOptions(task, legacyTask) {
+  const appDataDirectory = process.env.APP_DATA_DIRECTORY?.trim();
+  const tempDirectory = process.env.TEMP_DIRECTORY?.trim();
+  const executablePath = process.env.PUPPETEER_EXECUTABLE_PATH?.trim();
+  const puppeteerCacheDirectory = process.env.PUPPETEER_CACHE_DIR?.trim();
+  const fastapiUrl = legacyTask.fastapiUrl || process.env.NEXT_PUBLIC_FAST_API?.trim();
+  const cookies = parseCookieHeader(legacyTask.cookieHeader);
+
+  const outputDirectory = appDataDirectory
+    ? task.type === "export" || task.type === "html-to-any"
+      ? path.join(appDataDirectory, "exports")
+      : appDataDirectory
+    : undefined;
+
+  const urlConfigs =
+    cookies && typeof task.url === "string"
+      ? [{ url: task.url, match: "origin", cookies }]
+      : undefined;
+
+  return {
+    ...(outputDirectory ? { outputDirectory } : {}),
+    ...(tempDirectory ? { tempDirectory } : {}),
+    ...(executablePath ? { browserLaunchOptions: { executablePath } } : {}),
+    ...(puppeteerCacheDirectory ? { puppeteerCacheDirectory } : {}),
+    ...(urlConfigs ? { urlConfigs } : {}),
+    ...(fastapiUrl || process.env.ASSETS_BASE_URL?.trim()
+      ? { modifyWindow: buildModifyWindow(fastapiUrl) }
+      : {}),
+  };
+}
+
+function normalizeResponse(response) {
+  if (typeof response === "string") {
+    return { data: response };
+  }
+  if (response.type === "files") {
+    return {
+      ...response,
+      paths: response.filePaths,
+      file_paths: response.filePaths,
+    };
+  }
+  return {
+    ...response,
+    path: response.filePath,
+    file_path: response.filePath,
+  };
+}
+
+async function main() {
+  const taskPath = process.argv[2];
+  if (!taskPath) {
+    throw new Error("Usage: run-presentation-export.mjs <task.json>");
+  }
+
+  const rawTask = JSON.parse(await fs.readFile(taskPath, "utf8"));
+  const {
+    fastapiUrl,
+    cookieHeader,
+    slide_concurrency: _slideConcurrency,
+    ...task
+  } = rawTask;
+  task.__taskFilePath = path.resolve(taskPath);
+
+  const response = await runTask(
+    task,
+    buildRunOptions(task, { fastapiUrl, cookieHeader }),
+  );
+  const responsePath = taskPath.replace(/\.json$/i, ".response.json");
+  await fs.writeFile(responsePath, JSON.stringify(normalizeResponse(response)), "utf8");
+}
+
+main().catch((error) => {
+  console.error("[presentation-export]", error);
+  process.exitCode = 1;
+});

--- a/scripts/sync-presentation-export.cjs
+++ b/scripts/sync-presentation-export.cjs
@@ -1,16 +1,10 @@
 /**
- * Download presenton-export release into repo-root `presentation-export/`.
- * Same release host as Electron (`electron/scripts/sync-export-runtime.cjs`); Docker uses this at build time.
+ * Install the architecture-independent @presenton/export-core open-source
+ * release into repo-root `presentation-export/`.
  *
- * Version resolution defaults to package.json → presentationExportVersion.
- * EXPORT_RUNTIME_VERSION is only honored with --allow-version-override so build
- * environments cannot accidentally replace the pinned runtime.
- *
- * CLI: --force  re-download even if valid runtime already exists
- *       --check-only  verify index.cjs + converter exist and exit 0/1
- *
- * On every run (including --check-only), index.cjs is overwritten from index.js
- * so the CommonJS entrypoint never drifts from the bundled ESM build.
+ * CLI: --force       reinstall even when the pinned package is already valid
+ *      --check-only  verify the installed package and runner
+ *      --allow-version-override  honor EXPORT_RUNTIME_VERSION
  */
 const fs = require("fs");
 const path = require("path");
@@ -20,105 +14,57 @@ const { execFileSync } = require("child_process");
 
 const repoRoot = path.join(__dirname, "..");
 const targetRoot = path.join(repoRoot, "presentation-export");
-const targetPyDir = path.join(targetRoot, "py");
-const targetIndexJs = path.join(targetRoot, "index.js");
-const targetIndexCjs = path.join(targetRoot, "index.cjs");
-const versionManifestPath = path.join(
+const targetRunner = path.join(targetRoot, "runner.mjs");
+const installedPackageJson = path.join(
   targetRoot,
-  "presenton-export-version.json"
+  "node_modules",
+  "@presenton",
+  "export-core",
+  "package.json",
 );
+const sourceRunner = path.join(repoRoot, "scripts", "run-presentation-export.mjs");
+const versionManifestPath = path.join(targetRoot, "presenton-export-version.json");
 const packageJsonFile = path.join(repoRoot, "package.json");
 const cacheDir = path.join(repoRoot, ".cache", "presentation-export");
 const exportRepoBase =
   "https://github.com/presenton/presenton-export/releases/download";
 
 const cliArgs = new Set(process.argv.slice(2));
-const forceDownload = cliArgs.has("--force");
+const forceInstall = cliArgs.has("--force");
 const checkOnly = cliArgs.has("--check-only");
 const allowVersionOverride = cliArgs.has("--allow-version-override");
 
-function resolveLinuxAssetName() {
-  const arch = (
-    process.env.EXPORT_RUNTIME_ARCH ||
-    process.env.TARGETARCH ||
-    process.arch
-  ).toLowerCase();
-
-  if (arch === "amd64" || arch === "x64") {
-    return "export-Linux-X64.zip";
-  }
-  if (arch === "arm64" || arch === "aarch64") {
-    return "export-Linux-ARM64.zip";
-  }
-
-  throw new Error(`Unsupported Linux export arch: ${arch}`);
-}
-
-const linuxAssetName = resolveLinuxAssetName();
-
-function ensureDir(dirPath) {
-  fs.mkdirSync(dirPath, { recursive: true });
+function normalizeVersion(version) {
+  const value = String(version || "").trim();
+  return value.startsWith("v") ? value.slice(1) : value;
 }
 
 function readPinnedVersion() {
-  if (!fs.existsSync(packageJsonFile)) {
-    throw new Error(
-      `Missing ${path.relative(repoRoot, packageJsonFile)}. Add \"presentationExportVersion\": \"vX.Y.Z\".`
-    );
-  }
   const raw = JSON.parse(fs.readFileSync(packageJsonFile, "utf8"));
-  const v = (raw.presentationExportVersion || "").trim();
-  if (!v) {
-    throw new Error(
-      `${path.relative(repoRoot, packageJsonFile)} must set \"presentationExportVersion\" (e.g. \"v0.2.0\").`
-    );
+  const version = String(raw.presentationExportVersion || "").trim();
+  if (!version) {
+    throw new Error('package.json must set "presentationExportVersion".');
   }
-  return v;
+  return version;
 }
 
 async function getTargetVersion() {
-  const fromEnv = (process.env.EXPORT_RUNTIME_VERSION || "").trim();
-  if (allowVersionOverride && fromEnv) {
-    return fromEnv === "latest" ? await resolveLatestTag() : fromEnv;
-  }
-  const pinned = readPinnedVersion();
-  if (pinned === "latest") {
-    return await resolveLatestTag();
-  }
-  return pinned;
+  const override = String(process.env.EXPORT_RUNTIME_VERSION || "").trim();
+  const requested = allowVersionOverride && override ? override : readPinnedVersion();
+  return requested === "latest" ? resolveLatestTag() : requested;
 }
 
-function readInstalledVersion() {
-  if (!fs.existsSync(versionManifestPath)) {
-    return {
-      ok: false,
-      reason: `Missing export version manifest: ${versionManifestPath}`,
-    };
-  }
-
-  try {
-    const manifest = JSON.parse(fs.readFileSync(versionManifestPath, "utf8"));
-    return { ok: true, manifest };
-  } catch (err) {
-    return {
-      ok: false,
-      reason: `Invalid export version manifest ${versionManifestPath}: ${err.message}`,
-    };
-  }
+function assetNameForVersion(version) {
+  return `presenton-export-core-opensource-${normalizeVersion(version)}.tgz`;
 }
 
-function writeInstalledVersion(version) {
-  fs.writeFileSync(
-    versionManifestPath,
-    `${JSON.stringify({ version, asset: linuxAssetName }, null, 2)}\n`,
-    "utf8"
-  );
+function requestClient(url) {
+  return url.startsWith("https:") ? https : http;
 }
 
 function requestJson(url, redirects = 5) {
   return new Promise((resolve, reject) => {
-    const client = url.startsWith("https:") ? https : http;
-    const req = client.get(
+    const req = requestClient(url).get(
       url,
       {
         headers: {
@@ -128,11 +74,8 @@ function requestJson(url, redirects = 5) {
       },
       (res) => {
         if ([301, 302, 303, 307, 308].includes(res.statusCode) && res.headers.location) {
-          if (redirects <= 0) {
-            reject(new Error(`Too many redirects for JSON request: ${url}`));
-            return;
-          }
-          requestJson(res.headers.location, redirects - 1).then(resolve).catch(reject);
+          if (redirects <= 0) return reject(new Error(`Too many redirects: ${url}`));
+          requestJson(res.headers.location, redirects - 1).then(resolve, reject);
           return;
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
@@ -141,172 +84,31 @@ function requestJson(url, redirects = 5) {
         }
         let payload = "";
         res.setEncoding("utf8");
-        res.on("data", (chunk) => {
-          payload += chunk;
-        });
+        res.on("data", (chunk) => (payload += chunk));
         res.on("end", () => {
           try {
             resolve(JSON.parse(payload));
-          } catch (e) {
-            reject(new Error(`Invalid JSON from ${url}: ${e.message}`));
+          } catch (error) {
+            reject(new Error(`Invalid JSON from ${url}: ${error.message}`));
           }
         });
-      }
+      },
     );
     req.on("error", reject);
   });
 }
 
 async function resolveLatestTag() {
-  const apiUrl =
-    "https://api.github.com/repos/presenton/presenton-export/releases/latest";
-  const latest = await requestJson(apiUrl);
-  if (!latest.tag_name) {
-    throw new Error(`Could not resolve latest tag from ${apiUrl}`);
-  }
-  return latest.tag_name;
-}
-
-function chmodIfPossible(filePath) {
-  if (process.platform !== "win32") {
-    fs.chmodSync(filePath, 0o755);
-  }
-}
-
-function ensureCurrentConverterLink(converterPath) {
-  const currentPath = path.join(targetPyDir, "convert-linux-current");
-  fs.rmSync(currentPath, { force: true });
-
-  if (process.platform === "win32") {
-    fs.copyFileSync(converterPath, currentPath);
-    return currentPath;
-  }
-
-  fs.symlinkSync(path.basename(converterPath), currentPath);
-  return currentPath;
-}
-
-function getConverterCandidates(baseDir = targetPyDir) {
-  if (linuxAssetName === "export-Linux-ARM64.zip") {
-    return [
-      path.join(baseDir, "convert-linux-arm64"),
-      path.join(baseDir, "convert"),
-    ];
-  }
-
-  return [
-    path.join(baseDir, "convert-linux-x64"),
-    path.join(baseDir, "convert-linux-amd64"),
-    path.join(baseDir, "convert"),
-  ];
-}
-
-function hasRuntimeBundle(baseDir) {
-  const indexPath = path.join(baseDir, "index.js");
-  if (!fs.existsSync(indexPath)) {
-    return false;
-  }
-
-  const pyCandidates = getConverterCandidates(path.join(baseDir, "py"));
-  const rootCandidates = getConverterCandidates(baseDir);
-  return [...pyCandidates, ...rootCandidates].some((candidate) =>
-    fs.existsSync(candidate)
+  const latest = await requestJson(
+    "https://api.github.com/repos/presenton/presenton-export/releases/latest",
   );
-}
-
-function moveFileAtomic(src, dest) {
-  try {
-    fs.renameSync(src, dest);
-  } catch {
-    fs.copyFileSync(src, dest);
-    fs.rmSync(src, { force: true });
-  }
-}
-
-function normalizeRuntimeLayout() {
-  if (!fs.existsSync(targetRoot)) {
-    return;
-  }
-
-  ensureDir(targetPyDir);
-
-  const rootCandidates = getConverterCandidates(targetRoot);
-  for (const sourcePath of rootCandidates) {
-    if (!fs.existsSync(sourcePath)) {
-      continue;
-    }
-
-    const destinationPath = path.join(targetPyDir, path.basename(sourcePath));
-    if (!fs.existsSync(destinationPath)) {
-      moveFileAtomic(sourcePath, destinationPath);
-    }
-  }
-}
-
-function ensureCommonJsEntrypoint() {
-  if (!fs.existsSync(targetIndexJs)) {
-    return { ok: false, reason: `Missing runtime bundle: ${targetIndexJs}` };
-  }
-
-  try {
-    fs.copyFileSync(targetIndexJs, targetIndexCjs);
-    return { ok: true, entrypointPath: targetIndexCjs };
-  } catch (err) {
-    return {
-      ok: false,
-      reason: `Failed to create CommonJS entrypoint ${targetIndexCjs}: ${err.message}`,
-    };
-  }
-}
-
-function validateExistingRuntime(expectedVersion) {
-  const installedVersion = readInstalledVersion();
-  if (!installedVersion.ok) {
-    return installedVersion;
-  }
-  if (
-    installedVersion.manifest.version !== expectedVersion ||
-    installedVersion.manifest.asset !== linuxAssetName
-  ) {
-    return {
-      ok: false,
-      reason: [
-        "Installed export runtime does not match package.json.",
-        `Expected: ${expectedVersion} (${linuxAssetName})`,
-        `Installed: ${installedVersion.manifest.version || "unknown"} (${installedVersion.manifest.asset || "unknown"})`,
-      ].join("\n"),
-    };
-  }
-
-  normalizeRuntimeLayout();
-
-  const entrypoint = ensureCommonJsEntrypoint();
-  if (!entrypoint.ok) {
-    return { ok: false, reason: entrypoint.reason };
-  }
-
-  const candidates = getConverterCandidates();
-  const converterPath = candidates.find((c) => fs.existsSync(c));
-  if (!converterPath) {
-    return {
-      ok: false,
-      reason: `No Linux converter binary under ${targetPyDir} or ${targetRoot}.`,
-    };
-  }
-  chmodIfPossible(converterPath);
-  const currentConverterPath = ensureCurrentConverterLink(converterPath);
-  return {
-    ok: true,
-    entrypointPath: entrypoint.entrypointPath,
-    converterPath,
-    currentConverterPath,
-  };
+  if (!latest.tag_name) throw new Error("Latest export release has no tag_name.");
+  return latest.tag_name;
 }
 
 function downloadFile(url, outputPath, redirects = 5) {
   return new Promise((resolve, reject) => {
-    const client = url.startsWith("https:") ? https : http;
-    const req = client.get(
+    const req = requestClient(url).get(
       url,
       {
         headers: {
@@ -316,118 +118,133 @@ function downloadFile(url, outputPath, redirects = 5) {
       },
       (res) => {
         if ([301, 302, 303, 307, 308].includes(res.statusCode) && res.headers.location) {
-          if (redirects <= 0) {
-            reject(new Error(`Too many redirects while downloading ${url}`));
-            return;
-          }
-          downloadFile(res.headers.location, outputPath, redirects - 1)
-            .then(resolve)
-            .catch(reject);
+          if (redirects <= 0) return reject(new Error(`Too many redirects: ${url}`));
+          downloadFile(res.headers.location, outputPath, redirects - 1).then(resolve, reject);
           return;
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           reject(new Error(`Failed to download ${url}. HTTP ${res.statusCode}`));
           return;
         }
-        ensureDir(path.dirname(outputPath));
-        const fileStream = fs.createWriteStream(outputPath);
-        res.pipe(fileStream);
-        fileStream.on("finish", () => {
-          fileStream.close(resolve);
-        });
-        fileStream.on("error", reject);
-      }
+        fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+        const stream = fs.createWriteStream(outputPath);
+        res.pipe(stream);
+        stream.on("finish", () => stream.close(resolve));
+        stream.on("error", reject);
+      },
     );
     req.on("error", reject);
   });
 }
 
-function unzipArchive(zipPath, destDir) {
-  ensureDir(destDir);
-  execFileSync("unzip", ["-o", zipPath, "-d", destDir], { stdio: "inherit" });
-}
-
-function resolveExtractedRoot(extractDir) {
-  if (hasRuntimeBundle(extractDir)) {
-    return extractDir;
+function validateExistingRuntime(expectedVersion) {
+  if (!fs.existsSync(targetRunner)) {
+    return { ok: false, reason: `Missing export runner: ${targetRunner}` };
   }
-
-  const children = fs.readdirSync(extractDir, { withFileTypes: true });
-  for (const entry of children) {
-    if (!entry.isDirectory()) continue;
-    const candidate = path.join(extractDir, entry.name);
-    if (hasRuntimeBundle(candidate)) {
-      return candidate;
+  if (!fs.existsSync(installedPackageJson)) {
+    return { ok: false, reason: `Missing export package: ${installedPackageJson}` };
+  }
+  if (!fs.existsSync(versionManifestPath)) {
+    return { ok: false, reason: `Missing export version manifest: ${versionManifestPath}` };
+  }
+  try {
+    const installedPackage = JSON.parse(fs.readFileSync(installedPackageJson, "utf8"));
+    const manifest = JSON.parse(fs.readFileSync(versionManifestPath, "utf8"));
+    if (installedPackage.version !== normalizeVersion(expectedVersion)) {
+      return {
+        ok: false,
+        reason: `Expected export-core ${normalizeVersion(expectedVersion)}, found ${installedPackage.version}.`,
+      };
     }
+    if (manifest.package !== assetNameForVersion(expectedVersion)) {
+      return {
+        ok: false,
+        reason: `Expected ${assetNameForVersion(expectedVersion)}, found ${manifest.package || "an unknown package"}.`,
+      };
+    }
+    return { ok: true, packageVersion: installedPackage.version };
+  } catch (error) {
+    return { ok: false, reason: `Invalid installed export package: ${error.message}` };
   }
-  throw new Error(`Unable to locate export runtime root under ${extractDir}`);
 }
 
-async function downloadAndInstallRuntime(tag) {
-  const downloadUrl = `${exportRepoBase}/${tag}/${linuxAssetName}`;
-
-  ensureDir(cacheDir);
-  const cacheKey = tag.replace(/[^a-zA-Z0-9._-]/g, "_");
-  const zipPath = path.join(cacheDir, `${cacheKey}-${linuxAssetName}`);
-  const extractDir = path.join(cacheDir, `extract-${Date.now()}`);
-
-  console.log(`[presentation-export] Downloading ${downloadUrl}`);
-  await downloadFile(downloadUrl, zipPath);
-
-  console.log(`[presentation-export] Extracting ${zipPath}`);
-  unzipArchive(zipPath, extractDir);
-
-  const sourceRoot = resolveExtractedRoot(extractDir);
+function installRuntime(version, archivePath) {
   fs.rmSync(targetRoot, { recursive: true, force: true });
-  ensureDir(targetRoot);
-  fs.cpSync(sourceRoot, targetRoot, { recursive: true, force: true });
-  writeInstalledVersion(tag);
-
-  fs.rmSync(extractDir, { recursive: true, force: true });
-
-  return { tag, downloadUrl };
+  fs.mkdirSync(targetRoot, { recursive: true });
+  fs.copyFileSync(sourceRunner, targetRunner);
+  fs.writeFileSync(
+    path.join(targetRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        private: true,
+        type: "module",
+        dependencies: { "@presenton/export-core": `file:${archivePath}` },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+  execFileSync(
+    npm,
+    [
+      "install",
+      "--omit=dev",
+      "--ignore-scripts",
+      "--no-package-lock",
+      "--no-fund",
+      "--no-audit",
+      "--cache",
+      path.join(cacheDir, "npm"),
+    ],
+    { cwd: targetRoot, stdio: "inherit" },
+  );
+  fs.writeFileSync(
+    versionManifestPath,
+    `${JSON.stringify(
+      { version, package: assetNameForVersion(version) },
+      null,
+      2,
+    )}\n`,
+  );
 }
 
 async function main() {
-  const targetVersion = await getTargetVersion();
-  const existing = validateExistingRuntime(targetVersion);
-
+  const version = await getTargetVersion();
+  const existing = validateExistingRuntime(version);
   if (checkOnly) {
-    if (!existing.ok) {
-      throw new Error(existing.reason);
+    if (!existing.ok) throw new Error(existing.reason);
+    console.log(`[presentation-export] OK (${existing.packageVersion})`);
+    return;
+  }
+  if (existing.ok && !forceInstall) {
+    console.log(`[presentation-export] Using export-core ${existing.packageVersion}`);
+    return;
+  }
+
+  const assetName = assetNameForVersion(version);
+  const archivePath = path.join(cacheDir, assetName);
+  const downloadUrl = `${exportRepoBase}/${version}/${assetName}`;
+  fs.mkdirSync(cacheDir, { recursive: true });
+  const localArchive = String(process.env.EXPORT_CORE_ARCHIVE || "").trim();
+  if (localArchive) {
+    if (!fs.existsSync(localArchive)) {
+      throw new Error(`EXPORT_CORE_ARCHIVE does not exist: ${localArchive}`);
     }
-    console.log("[presentation-export] OK");
-    console.log(`  - ${existing.entrypointPath}`);
-    console.log(`  - ${existing.converterPath}`);
-    console.log(`  - ${existing.currentConverterPath}`);
-    console.log(`  - release: ${targetVersion}`);
-    return;
+    console.log(`[presentation-export] Using local package ${localArchive}`);
+    fs.copyFileSync(localArchive, archivePath);
+  } else {
+    console.log(`[presentation-export] Downloading ${downloadUrl}`);
+    await downloadFile(downloadUrl, archivePath);
   }
+  installRuntime(version, archivePath);
 
-  if (existing.ok && !forceDownload) {
-    console.log("[presentation-export] Using existing runtime:");
-    console.log(`  - ${existing.entrypointPath}`);
-    console.log(`  - ${existing.converterPath}`);
-    console.log(`  - ${existing.currentConverterPath}`);
-    console.log(`  - release: ${targetVersion}`);
-    return;
-  }
-
-  const { tag, downloadUrl } = await downloadAndInstallRuntime(targetVersion);
-  const installed = validateExistingRuntime(targetVersion);
-  if (!installed.ok) {
-    throw new Error(installed.reason);
-  }
-
-  console.log("[presentation-export] Synced successfully:");
-  console.log(`  - release: ${tag}`);
-  console.log(`  - url: ${downloadUrl}`);
-  console.log(`  - ${installed.entrypointPath}`);
-  console.log(`  - ${installed.converterPath}`);
-  console.log(`  - ${installed.currentConverterPath}`);
+  const installed = validateExistingRuntime(version);
+  if (!installed.ok) throw new Error(installed.reason);
+  console.log(`[presentation-export] Installed export-core ${installed.packageVersion}`);
 }
 
-main().catch((err) => {
-  console.error(`[presentation-export] ${err.message}`);
+main().catch((error) => {
+  console.error(`[presentation-export] ${error.message}`);
   process.exit(1);
 });

--- a/servers/fastapi/services/export_task_service.py
+++ b/servers/fastapi/services/export_task_service.py
@@ -11,7 +11,7 @@ from typing import Any, Literal, Mapping
 from urllib.parse import unquote, urlparse
 
 from fastapi import HTTPException
-from pydantic import BaseModel, ValidationError, model_validator
+from pydantic import BaseModel, ValidationError
 
 from services.liteparse_service import _command_str, _snippet
 from api.v1.auth.context import get_current_owner_id
@@ -20,7 +20,6 @@ from utils.asset_directory_utils import (
     resolve_app_path_to_filesystem,
 )
 from utils.get_env import get_app_data_directory_env, get_temp_directory_env
-from utils.icon_weights import DEFAULT_ICON_TYPE, extract_icon_type_from_settings
 from utils.runtime_limits import (
     BoundedTextBuffer,
     log_memory,
@@ -120,46 +119,15 @@ class JsonToImageTaskResult(BaseModel):
     path: str
 
 
-class ExtractSchemaSlide(BaseModel):
-    id: str
-    name: str | None = None
-    description: str | None = None
-    json_schema: dict
-
-
-class ExtractSchemaDocument(BaseModel):
-    name: str
-    ordered: bool = False
-    icon_type: str = DEFAULT_ICON_TYPE
-    icon_weight: str = DEFAULT_ICON_TYPE
-    slides: list[ExtractSchemaSlide]
-
-    @model_validator(mode="before")
-    @classmethod
-    def normalize_icon_type(cls, data):
-        if isinstance(data, dict):
-            normalized = dict(data)
-            icon_type = extract_icon_type_from_settings(normalized)
-            normalized["icon_type"] = icon_type
-            normalized["icon_weight"] = icon_type
-            return normalized
-        return data
-
-
 class ExportTaskService:
     def __init__(self, timeout_seconds: int = 300):
         self.timeout_seconds = timeout_seconds
         self.node_binary = os.getenv("LITEPARSE_NODE_BINARY", "node")
         self.export_dir = self._resolve_export_dir()
         self.entrypoint_path = self._resolve_entrypoint_path(self.export_dir)
-        self.converter_path = self._resolve_converter_path(self.export_dir)
 
     @staticmethod
     def _resolve_export_dir() -> str:
-        configured = (os.getenv("EXPORT_RUNTIME_DIR") or "").strip()
-        if configured:
-            return configured
-
         package_root = (os.getenv("EXPORT_PACKAGE_ROOT") or "").strip()
         if package_root:
             return package_root
@@ -174,61 +142,14 @@ class ExportTaskService:
         ]
 
         for candidate in candidates:
-            if os.path.isfile(os.path.join(candidate, "index.cjs")) or os.path.isfile(
-                os.path.join(candidate, "index.js")
-            ):
+            if os.path.isfile(os.path.join(candidate, "runner.mjs")):
                 return candidate
 
         return candidates[0]
 
     @staticmethod
     def _resolve_entrypoint_path(export_dir: str) -> str:
-        index_cjs = os.path.join(export_dir, "index.cjs")
-        if os.path.isfile(index_cjs):
-            return index_cjs
-
-        index_js = os.path.join(export_dir, "index.js")
-        if os.path.isfile(index_js):
-            # Packaged app resource directories can be read-only (e.g. /opt installs).
-            # Try to create index.cjs for compatibility, but fall back to index.js
-            # when writing is not permitted.
-            try:
-                shutil.copyfile(index_js, index_cjs)
-                return index_cjs
-            except OSError:
-                return index_js
-
-        return index_cjs
-
-    @staticmethod
-    def _resolve_converter_path(export_dir: str) -> str:
-        py_dir = os.path.join(export_dir, "py")
-        extension = ".exe" if os.name == "nt" else ""
-        platform_name = sys_platform()
-        arch_name = sys_arch()
-
-        candidates: list[str] = []
-        configured = (os.getenv("BUILT_PYTHON_MODULE_PATH") or "").strip()
-        if configured:
-            candidates.append(configured)
-
-        candidates.append(
-            os.path.join(py_dir, f"convert-{platform_name}-{arch_name}{extension}")
-        )
-        if platform_name == "linux" and arch_name == "x64":
-            # Older Linux export bundles used amd64 while Node reports x64.
-            candidates.append(os.path.join(py_dir, f"convert-linux-amd64{extension}"))
-        candidates.extend(
-            [
-                os.path.join(py_dir, f"convert-{platform_name}{extension}"),
-                os.path.join(py_dir, f"convert{extension}"),
-                os.path.join(py_dir, "convert"),
-            ]
-        )
-        for candidate in candidates:
-            if candidate and os.path.isfile(candidate):
-                return candidate
-        return candidates[0]
+        return os.path.join(export_dir, "runner.mjs")
 
     def _build_node_env(self) -> Mapping[str, str]:
         env = os.environ.copy()
@@ -277,8 +198,6 @@ class ExportTaskService:
         # rendering. Docker intentionally leaves NEXT_PUBLIC_FAST_API unset so
         # nginx remains the public origin; Electron supplies its dynamic origin.
         env["ASSETS_BASE_URL"] = "/app_data"
-        env["BUILT_PYTHON_MODULE_PATH"] = self.converter_path
-
         return env
 
     def _ensure_runtime_ready(self) -> None:
@@ -287,10 +206,18 @@ class ExportTaskService:
                 status_code=500,
                 detail=f"Export runtime not found at {self.entrypoint_path}",
             )
-        if not os.path.isfile(self.converter_path):
+        package_entrypoint = os.path.join(
+            self.export_dir,
+            "node_modules",
+            "@presenton",
+            "export-core",
+            "dist",
+            "index.js",
+        )
+        if not os.path.isfile(package_entrypoint):
             raise HTTPException(
                 status_code=500,
-                detail=f"Export converter binary not found at {self.converter_path}",
+                detail=f"Export package not found at {package_entrypoint}",
             )
 
     @staticmethod
@@ -677,12 +604,7 @@ class ExportTaskService:
 
         return HtmlToImagesTaskResult(paths=output_paths)
 
-    async def convert_pptx_to_json(
-        self,
-        pptx_path: str,
-        *,
-        slide_concurrency: int | None = None,
-    ) -> PptxToJsonDocument:
+    async def convert_pptx_to_json(self, pptx_path: str) -> PptxToJsonDocument:
         if not os.path.isfile(pptx_path):
             raise HTTPException(status_code=400, detail=f"PPTX not found: {pptx_path}")
 
@@ -690,8 +612,6 @@ class ExportTaskService:
             "type": "pptx-to-json",
             "pptx_path": pptx_path,
         }
-        if slide_concurrency is not None:
-            task_payload["slide_concurrency"] = slide_concurrency
 
         try:
             response_data = await self._run_task(
@@ -735,7 +655,15 @@ class ExportTaskService:
         resolved_output = os.path.realpath(output_path)
         resolved_destination_dir = os.path.realpath(destination_dir)
         source_parent = os.path.dirname(resolved_output)
-        if source_parent not in {exports_root, resolved_destination_dir}:
+        try:
+            relative_source = os.path.relpath(resolved_output, exports_root)
+            source_is_export = (
+                os.path.commonpath([resolved_output, exports_root]) == exports_root
+                and relative_source.split(os.sep, 1)[0] != "users"
+            )
+        except ValueError:
+            source_is_export = False
+        if not source_is_export and source_parent != resolved_destination_dir:
             raise HTTPException(
                 status_code=500,
                 detail="Export task returned an output outside its asset directory",
@@ -800,69 +728,5 @@ class ExportTaskService:
             return value
 
         return rewrite(output_data)
-
-    async def extract_schema(self, url: str) -> ExtractSchemaDocument:
-        LOGGER.info(
-            "[export_runtime] extract_schema spawn "
-            "url=%s entrypoint=%s export_dir=%s",
-            url,
-            self.entrypoint_path,
-            self.export_dir,
-        )
-        try:
-            response_data = await self._run_task(
-                {
-                    "type": "extract-schema",
-                    "url": url,
-                },
-                "Extract-schema task did not produce a response file",
-            )
-            slides = response_data.get("slides") if isinstance(response_data, dict) else None
-            slide_n = len(slides) if isinstance(slides, list) else "?"
-            LOGGER.info(
-                "[export_runtime] extract_schema node finished url=%s "
-                "response_name=%r ordered=%s icon_type=%s slides=%s",
-                url,
-                response_data.get("name") if isinstance(response_data, dict) else None,
-                response_data.get("ordered") if isinstance(response_data, dict) else None,
-                (
-                    response_data.get("icon_type") or response_data.get("icon_weight")
-                    if isinstance(response_data, dict)
-                    else None
-                ),
-                slide_n,
-            )
-            return ExtractSchemaDocument(**response_data)
-        except ValidationError as exc:
-            LOGGER.exception(
-                "[export_runtime] extract_schema pydantic validation failed url=%s",
-                url,
-            )
-            raise HTTPException(
-                status_code=500,
-                detail="Extract-schema task produced invalid output",
-            ) from exc
-
-
-def sys_platform() -> str:
-    if os.name == "nt":
-        return "win32"
-    return os.sys.platform
-
-
-def sys_arch() -> str:
-    machine = (os.environ.get("PROCESSOR_ARCHITECTURE") or "").lower()
-    if not machine and hasattr(os, "uname"):
-        machine = os.uname().machine.lower()
-
-    arch_map = {
-        "x86_64": "x64",
-        "amd64": "x64",
-        "x64": "x64",
-        "aarch64": "arm64",
-        "arm64": "arm64",
-    }
-    return arch_map.get(machine, machine or "x64")
-
 
 EXPORT_TASK_SERVICE = ExportTaskService()

--- a/servers/fastapi/templates/get_layout_by_name.py
+++ b/servers/fastapi/templates/get_layout_by_name.py
@@ -2,13 +2,11 @@ import logging
 import json
 import os
 import aiohttp
-from urllib.parse import urlencode
 from typing import Any
 
 from fastapi import HTTPException
 
 from api.v1.auth.internal import authenticated_internal_request_headers
-from services.export_task_service import EXPORT_TASK_SERVICE
 from templates.custom_layout_from_db import load_custom_presentation_layout
 from templates.presentation_layout import PresentationLayoutModel
 from utils.icon_weights import extract_icon_type_from_settings
@@ -129,76 +127,25 @@ async def get_layout_by_name(layout_name: str) -> PresentationLayoutModel:
     if layout_name.startswith("custom-"):
         return await load_custom_presentation_layout(layout_name)
 
-    query = urlencode({"group": layout_name})
-    url = f"http://localhost/schema?{query}"
-
     LOGGER.info(
-        "[template_layout] resolving template=%r primary_schema_url=%s",
+        "[template_layout] resolving template=%r",
         layout_name,
-        url,
     )
 
-    schema_payload: dict[str, Any] | None = None
-    runtime_error: str | None = None
-
-    try:
-        schema = await EXPORT_TASK_SERVICE.extract_schema(url)
-        schema_payload = schema.model_dump()
-        slide_ids = [s.get("id") for s in schema_payload.get("slides") or []][:12]
-        LOGGER.info(
-            "[template_layout] extract-schema succeeded template=%r "
-            "payload_name=%r ordered=%s icon_type=%s slide_count=%d slide_ids(sample)=%s",
-            layout_name,
-            schema_payload.get("name"),
-            schema_payload.get("ordered"),
-            schema_payload.get("icon_type") or schema_payload.get("icon_weight"),
-            len(schema_payload.get("slides") or []),
-            slide_ids,
-        )
-    except HTTPException as exc:
-        # Backward compatibility: older export runtimes do not implement
-        # extract-schema and return "Invalid task type".
-        runtime_error = str(exc.detail)
-    except Exception as exc:  # noqa: BLE001
-        runtime_error = str(exc)
-
+    schema_payload, fallback_error = await _fetch_template_fallback_payload(
+        layout_name
+    )
     if schema_payload is None:
-        schema_payload, fallback_error = await _fetch_template_fallback_payload(
-            layout_name
+        error_detail = fallback_error or "unknown error"
+        LOGGER.error(
+            "[template_layout] no schema payload template=%r detail=%s",
+            layout_name,
+            _preview_detail(error_detail),
         )
-        if schema_payload and runtime_error:
-            LOGGER.info(
-                "[template_layout] primary extract-schema failed template=%r detail=%s",
-                layout_name,
-                _preview_detail(runtime_error),
-            )
-
-        if schema_payload is None:
-            error_detail = runtime_error or fallback_error or "unknown error"
-            if runtime_error:
-                LOGGER.warning(
-                    "[template_layout] extract-schema HTTP error template=%r detail=%s",
-                    layout_name,
-                    _preview_detail(runtime_error),
-                )
-            LOGGER.error(
-                "[template_layout] no schema payload template=%r combined_detail=%s",
-                layout_name,
-                _preview_detail(error_detail),
-            )
-            raise HTTPException(
-                status_code=404,
-                detail=f"Template '{layout_name}' not found: {error_detail}",
-            )
-    elif not layout_name.startswith("custom-"):
-        # The bundled export runtime can read the schema page but currently keeps
-        # only name/order/slides from settings. The JSON fallback is cheaper and
-        # preserves template-level settings such as icon type.
-        fallback_payload, _ = await _fetch_template_fallback_payload(layout_name)
-        if fallback_payload:
-            fallback_icon_type = extract_icon_type_from_settings(fallback_payload)
-            schema_payload["icon_type"] = fallback_icon_type
-            schema_payload["icon_weight"] = fallback_icon_type
+        raise HTTPException(
+            status_code=404,
+            detail=f"Template '{layout_name}' not found: {error_detail}",
+        )
 
     local_settings = _read_builtin_template_settings(layout_name)
     if local_settings:

--- a/servers/fastapi/tests/unit/test_runtime_limits.py
+++ b/servers/fastapi/tests/unit/test_runtime_limits.py
@@ -321,25 +321,7 @@ def test_render_htmls_to_images_falls_back_when_batch_render_fails(tmp_path):
     ]
 
 
-def test_export_converter_resolver_accepts_linux_amd64_name(tmp_path, monkeypatch):
-    monkeypatch.delenv("BUILT_PYTHON_MODULE_PATH", raising=False)
-    monkeypatch.setattr("services.export_task_service.sys_platform", lambda: "linux")
-    monkeypatch.setattr("services.export_task_service.sys_arch", lambda: "x64")
-    converter = tmp_path / "py" / "convert-linux-amd64"
-    converter.parent.mkdir()
-    converter.write_text("binary")
-
-    assert ExportTaskService._resolve_converter_path(str(tmp_path)) == str(converter)
-
-
-def test_export_converter_resolver_prefers_existing_configured_path(
-    tmp_path, monkeypatch
-):
-    configured = tmp_path / "custom-converter"
-    configured.write_text("binary")
-    converter = tmp_path / "py" / "convert-linux-x64"
-    converter.parent.mkdir()
-    converter.write_text("binary")
-    monkeypatch.setenv("BUILT_PYTHON_MODULE_PATH", str(configured))
-
-    assert ExportTaskService._resolve_converter_path(str(tmp_path)) == str(configured)
+def test_export_entrypoint_resolves_architecture_independent_runner(tmp_path):
+    assert ExportTaskService._resolve_entrypoint_path(str(tmp_path)) == str(
+        tmp_path / "runner.mjs"
+    )

--- a/servers/nextjs/app/api/export-presentation/route.ts
+++ b/servers/nextjs/app/api/export-presentation/route.ts
@@ -74,7 +74,13 @@ async function moveExportIntoOwnerDirectory(
   if (sourceParent === ownerDirectory) {
     return sourcePath;
   }
-  if (sourceParent !== exportsDirectory) {
+  const relativeSource = path.relative(exportsDirectory, sourcePath);
+  if (
+    !relativeSource ||
+    relativeSource.startsWith("..") ||
+    path.isAbsolute(relativeSource) ||
+    relativeSource.split(path.sep)[0] === "users"
+  ) {
     throw new Error("Export finished outside the current user's export directory.");
   }
 

--- a/servers/nextjs/app/api/template/route.ts
+++ b/servers/nextjs/app/api/template/route.ts
@@ -11,8 +11,7 @@ export const dynamic = "force-dynamic";
  * Server-only layout + JSON Schema for built-in templates (no import of
  * `presentation-templates/index.tsx`, which would pull Recharts into RSC).
  *
- * Used by FastAPI when `extract-schema` (Puppeteer) fails — e.g. `next dev`
- * + `networkidle0`.
+ * Used by FastAPI to load template schemas without involving the export engine.
  */
 export async function GET(request: Request) {
   const group = new URL(request.url).searchParams.get("group");

--- a/servers/nextjs/lib/run-bundled-presentation-export.ts
+++ b/servers/nextjs/lib/run-bundled-presentation-export.ts
@@ -37,42 +37,18 @@ function extractSessionTokenFromCookieHeader(cookieHeader?: string): string | un
 }
 
 async function resolveExportEntrypoint(exportRoot: string): Promise<string> {
-  const indexCjs = path.join(exportRoot, "index.cjs");
-  const indexJs = path.join(exportRoot, "index.js");
-
-  try {
-    await fs.access(indexCjs);
-    return indexCjs;
-  } catch {
-    await fs.access(indexJs);
-    await fs.copyFile(indexJs, indexCjs);
-    return indexCjs;
-  }
-}
-
-function bundledConverterPath(exportRoot: string): string {
-  const fromEnv = process.env.BUILT_PYTHON_MODULE_PATH?.trim();
-  if (fromEnv) {
-    return fromEnv;
-  }
-  if (process.platform === "linux") {
-    if (process.arch === "x64") {
-      return path.join(exportRoot, "py", "convert-linux-x64");
-    }
-    if (process.arch === "arm64") {
-      return path.join(exportRoot, "py", "convert-linux-arm64");
-    }
-  }
-  throw new Error(
-    `No bundled export converter for ${process.platform}/${process.arch}. Set BUILT_PYTHON_MODULE_PATH.`
-  );
+  const runner = path.join(exportRoot, "runner.mjs");
+  await fs.access(runner);
+  return runner;
 }
 
 export async function bundledExportPackageAvailable(): Promise<boolean> {
   try {
     const root = getExportPackageRoot();
     await resolveExportEntrypoint(root);
-    await fs.access(bundledConverterPath(root));
+    await fs.access(
+      path.join(root, "node_modules", "@presenton", "export-core", "dist", "index.js")
+    );
     return true;
   } catch {
     return false;
@@ -156,8 +132,7 @@ async function ensureExportFileReadable(filePath: string): Promise<void> {
 }
 
 /**
- * Runs the bundled export entrypoint (`presentation-export/index.js`) with
- * `BUILT_PYTHON_MODULE_PATH` pointing at the PyInstaller converter binary.
+ * Runs the bundled @presenton/export-core task runner in an isolated process.
  */
 export async function runBundledPresentationExport(params: {
   presentationId: string;
@@ -177,10 +152,7 @@ async function runBundledPresentationExportLocked(params: {
   const { presentationId, title, format, cookieHeader } = params;
   const exportRoot = getExportPackageRoot();
   const entrypoint = await resolveExportEntrypoint(exportRoot);
-  const converter = bundledConverterPath(exportRoot);
   const appRoot = getPresentonAppRoot();
-
-  await fs.access(converter);
 
   const nextjsUrl =
     process.env.NEXT_PUBLIC_URL?.trim() || "http://127.0.0.1";
@@ -227,10 +199,7 @@ async function runBundledPresentationExportLocked(params: {
       const child = spawn(process.execPath, [entrypoint, exportTaskPath], {
         cwd: appRoot,
         stdio: ["ignore", "pipe", "pipe"],
-        env: {
-          ...process.env,
-          BUILT_PYTHON_MODULE_PATH: converter,
-        },
+        env: process.env,
       });
       const stderr = new BoundedTextBuffer();
       const stdout = new BoundedTextBuffer();


### PR DESCRIPTION
## Summary
- replace platform-specific export bundles with the architecture-independent @presenton/export-core runtime
- add a shared Node runner for Docker, Electron, FastAPI, and Next.js export paths
- simplify runtime sync, packaging, template schema loading, and export output handling

## Validation
- npm test
- npm run typecheck (electron)
- npx tsc --noEmit (servers/nextjs)
- uv run pytest tests/unit/test_runtime_limits.py (14 passed)
- node --check on the new runner and sync scripts
- git diff --check