### PR TITLE
fix(pdf-export): align slides with viewport origin

### DIFF
--- a/servers/nextjs/app/(export)/pdf-maker/PdfMakerPage.tsx
+++ b/servers/nextjs/app/(export)/pdf-maker/PdfMakerPage.tsx
@@ -43,7 +43,12 @@ const PDF_PRINT_STYLE = `
     width: 100% !important;
     display: flex !important;
     flex-direction: column !important;
-    align-items: center !important;
+    /*
+     * export-core measures PPTX elements in a 3000px-wide viewport. Keep the
+     * 1280px slide canvas at x=0 so its clipping rectangle and child element
+     * coordinates share the same origin.
+     */
+    align-items: flex-start !important;
     gap: 0 !important;
     margin: 0 !important;
     padding: 0 !important;
@@ -284,7 +289,7 @@ const PresentationPage = ({ presentation_id, exportCookie }: PresentationPagePro
           <style jsx global>{PDF_PRINT_STYLE}</style>
           <div
             id="presentation-slides-wrapper"
-            className="relative m-0 flex w-full flex-col items-center overflow-visible p-0"
+            className="relative m-0 flex w-full flex-col items-start overflow-visible p-0"
           >
             {isLoading ? (
               <div className="relative m-0 flex w-full justify-center p-0">
@@ -298,48 +303,46 @@ const PresentationPage = ({ presentation_id, exportCookie }: PresentationPagePro
                 </div>
               </div>
             ) : (
-              {
-                slides.map((slide: any, index: number) => {
-                  const useTemplateV2HtmlPreview =
-                    shouldRenderTemplateV2HtmlPreview(
-                      slide,
-                      presentationData?.version
-                    );
-
-                  return (
-                    <div
-                      key={`${slide.type}-${index}-${slide.index}`}
-                      id={`slide-${slide.index}`}
-                      className="main-slide relative flex items-center justify-center"
-                      data-speaker-note={slide.speaker_note ?? ""}
-                    >
-                      <div
-                        className="slide-export-inner group font-syne"
-                        data-layout={slide.layout}
-                        data-group={slide.layout_group}
-                      >
-                        {useTemplateV2HtmlPreview ? (
-                          <TemplateV2HtmlSlidePreview
-                            slide={slide}
-                            fonts={presentationData?.fonts}
-                            fixedSize
-                          />
-                        ) : typeof slide?.html_content === "string" &&
-                          slide.html_content.trim() ? (
-                          <SmartHtmlPdfSlide slide={slide} index={index} />
-                        ) : (
-                          <SlideScale
-                            slide={slide}
-                            theme={presentationData?.theme ?? null}
-                            isEditMode={false}
-                            fixedSize
-                          />
-                        )}
-                      </div>
-                    </div>
+              slides.map((slide: any, index: number) => {
+                const useTemplateV2HtmlPreview =
+                  shouldRenderTemplateV2HtmlPreview(
+                    slide,
+                    presentationData?.version
                   );
-                })
-              }
+
+                return (
+                  <div
+                    key={`${slide.type}-${index}-${slide.index}`}
+                    id={`slide-${slide.index}`}
+                    className="main-slide relative flex items-center justify-center"
+                    data-speaker-note={slide.speaker_note ?? ""}
+                  >
+                    <div
+                      className="slide-export-inner group font-syne"
+                      data-layout={slide.layout}
+                      data-group={slide.layout_group}
+                    >
+                      {useTemplateV2HtmlPreview ? (
+                        <TemplateV2HtmlSlidePreview
+                          slide={slide}
+                          fonts={presentationData?.fonts}
+                          fixedSize
+                        />
+                      ) : typeof slide?.html_content === "string" &&
+                        slide.html_content.trim() ? (
+                        <SmartHtmlPdfSlide slide={slide} index={index} />
+                      ) : (
+                        <SlideScale
+                          slide={slide}
+                          theme={presentationData?.theme ?? null}
+                          isEditMode={false}
+                          fixedSize
+                        />
+                      )}
+                    </div>
+                  </div>
+                );
+              })
             )}
           </div>
         </>

--- a/servers/nextjs/tests/pdf-maker-export-layout.test.mjs
+++ b/servers/nextjs/tests/pdf-maker-export-layout.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const pdfMakerPagePath = path.resolve(
+  "app/(export)/pdf-maker/PdfMakerPage.tsx",
+);
+
+test("keeps PPTX export slides aligned to the viewport origin", async () => {
+  const source = await readFile(pdfMakerPagePath, "utf8");
+
+  assert.match(source, /align-items:\s*flex-start\s*!important/);
+  assert.match(
+    source,
+    /id="presentation-slides-wrapper"[\s\S]*?className="[^"]*\bitems-start\b[^"]*"/,
+  );
+  assert.doesNotMatch(source, /align-items:\s*center\s*!important/);
+});


### PR DESCRIPTION
## Summary
- left-align the PDF maker slide wrapper so the 1280px canvas starts at viewport x=0
- keep export-core clipping rectangles and child coordinates on the same origin
- add a regression test for the print style and wrapper alignment

## Validation
- node --test tests/pdf-maker-export-layout.test.mjs
- npx tsc --noEmit --incremental false
- npx eslint app/(export)/pdf-maker/PdfMakerPage.tsx tests/pdf-maker-export-layout.test.mjs (no errors; one pre-existing hook dependency warning)
- git diff --check