### PR TITLE
chore(export-core): upgrade to 1.0.14

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,7 @@
   "name": "presenton",
   "productName": "Presenton Open Source",
   "version": "0.9.7-beta",
-  "exportVersion": "v1.0.12",
+  "exportVersion": "v1.0.14",
   "exportChromiumBuildId": "149.0.7827.196",
   "exportMacChromiumBuildIds": {
     "darwin-arm64": "1625085",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "presenton",
   "version": "0.9.7-beta",
-  "presentationExportVersion": "v1.0.12",
+  "presentationExportVersion": "v1.0.14",
   "type": "module",
   "description": "Open-source AI presentation generator",
   "scripts": {

--- a/servers/fastapi/services/export_task_service.py
+++ b/servers/fastapi/services/export_task_service.py
@@ -471,6 +471,38 @@ class ExportTaskService:
             output_path = self._resolve_output_path(response_data)
             with open(output_path, "r", encoding="utf-8") as output_file:
                 output_data = json.load(output_file)
+
+            # export-core intentionally writes slide asset references relative to
+            # presentation.json (for example, images/slide.png). Preserve that
+            # relationship after the conversion directory is owner-scoped by
+            # resolving the manifest's asset directories before it is moved.
+            artifact_dir = os.path.realpath(os.path.dirname(output_path))
+            for directory_key in ("images_dir", "fonts_dir"):
+                directory = output_data.get(directory_key)
+                if not isinstance(directory, str) or not directory:
+                    continue
+                resolved_directory = os.path.realpath(
+                    directory
+                    if os.path.isabs(directory)
+                    else os.path.join(artifact_dir, directory)
+                )
+                try:
+                    is_artifact_directory = (
+                        os.path.commonpath([resolved_directory, artifact_dir])
+                        == artifact_dir
+                    )
+                except ValueError:
+                    is_artifact_directory = False
+                if not is_artifact_directory:
+                    raise HTTPException(
+                        status_code=500,
+                        detail=(
+                            "PPTX-to-HTML export returned an asset directory "
+                            "outside its conversion directory"
+                        ),
+                    )
+                output_data[directory_key] = resolved_directory
+
             output_data = self._scope_conversion_artifacts(
                 output_path,
                 output_data,

--- a/servers/fastapi/templates/fonts_and_slides_preview.py
+++ b/servers/fastapi/templates/fonts_and_slides_preview.py
@@ -154,11 +154,15 @@ INVALID_PPTX_UPLOAD_ERROR = (
     "The uploaded PowerPoint file is corrupted or unsupported."
 )
 PPT_NS = {
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+    "asvg": "http://schemas.microsoft.com/office/drawing/2016/SVG/main",
     "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
     "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
 }
 REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
 
+ET.register_namespace("a", PPT_NS["a"])
+ET.register_namespace("asvg", PPT_NS["asvg"])
 ET.register_namespace("p", PPT_NS["p"])
 ET.register_namespace("r", PPT_NS["r"])
 
@@ -241,7 +245,11 @@ def _font_face_css_for_local_fonts(font_paths: List[str]) -> str:
     return "\n".join(rules)
 
 
-def _preview_asset_url_to_data_uri(url: str) -> str:
+def _preview_asset_url_to_data_uri(
+    url: str,
+    relative_asset_root: Optional[str] = None,
+    trusted_local_files: Optional[Set[str]] = None,
+) -> str:
     if not url:
         return url
 
@@ -256,10 +264,33 @@ def _preview_asset_url_to_data_uri(url: str) -> str:
     elif url.startswith(("/app_data/", "/static/")):
         candidate = url
         fallback_url = absolute_fastapi_asset_url(candidate)
+    elif (
+        not parsed.scheme
+        and relative_asset_root
+        and parsed.path
+        and not url.startswith(("/", "//"))
+    ):
+        asset_root = os.path.realpath(relative_asset_root)
+        candidate = os.path.realpath(
+            os.path.join(asset_root, urllib.parse.unquote(parsed.path))
+        )
+        try:
+            if os.path.commonpath([candidate, asset_root]) != asset_root:
+                return url
+        except ValueError:
+            return url
     else:
         return url
 
-    resolved = resolve_app_path_to_filesystem(candidate)
+    resolved = None
+    if trusted_local_files and os.path.isabs(candidate):
+        trusted_candidate = os.path.realpath(candidate)
+        if trusted_candidate in trusted_local_files and os.path.isfile(
+            trusted_candidate
+        ):
+            resolved = trusted_candidate
+    if not resolved:
+        resolved = resolve_app_path_to_filesystem(candidate)
     if not resolved:
         return fallback_url
 
@@ -268,22 +299,46 @@ def _preview_asset_url_to_data_uri(url: str) -> str:
     except OSError:
         return fallback_url
 
-    mime_type = mimetypes.guess_type(resolved)[0] or "application/octet-stream"
+    leading_data = data.lstrip()[:512].lower()
+    if leading_data.startswith(b"<svg") or (
+        leading_data.startswith(b"<?xml") and b"<svg" in leading_data
+    ):
+        mime_type = "image/svg+xml"
+    else:
+        mime_type = mimetypes.guess_type(resolved)[0] or "application/octet-stream"
     encoded = base64.b64encode(data).decode("ascii")
     return f"data:{mime_type};base64,{encoded}"
 
 
-def _localize_preview_asset_urls(html: str) -> str:
+def _localize_preview_asset_urls(
+    html: str,
+    relative_asset_root: Optional[str] = None,
+    trusted_local_files: Optional[Set[str]] = None,
+) -> str:
     def replace_attr(match: re.Match[str]) -> str:
+        localized_url = _preview_asset_url_to_data_uri(
+            match.group("url"),
+            relative_asset_root,
+            trusted_local_files,
+        )
         return (
             f"{match.group('prefix')}"
-            f"{_preview_asset_url_to_data_uri(match.group('url'))}"
+            f"{localized_url}"
             f"{match.group('suffix')}"
         )
 
     def replace_css_url(match: re.Match[str]) -> str:
         quote = match.group("quote") or ""
-        return f"url({quote}{_preview_asset_url_to_data_uri(match.group('url'))}{quote})"
+        localized_url = _preview_asset_url_to_data_uri(
+            match.group("url"),
+            relative_asset_root,
+            trusted_local_files,
+        )
+        return (
+            f"url({quote}"
+            f"{localized_url}"
+            f"{quote})"
+        )
 
     html = re.sub(
         r"(?P<prefix>\b(?:src|href|xlink:href)=['\"])(?P<url>[^'\"]+)(?P<suffix>['\"])",
@@ -694,9 +749,21 @@ async def render_pptx_slides_to_images(
         )
         logger.info("Prepared custom font CSS for HTML preview rendering")
 
-    pptx_document = await EXPORT_TASK_SERVICE.convert_pptx_to_html(
-        modified_pptx_path, get_fonts=True
-    )
+    if os.path.isfile(modified_pptx_path):
+        preview_pptx_path, remove_preview_pptx = await asyncio.to_thread(
+            _prepare_svg_images_for_pptx_to_html,
+            modified_pptx_path,
+        )
+    else:
+        preview_pptx_path, remove_preview_pptx = modified_pptx_path, False
+    try:
+        pptx_document = await EXPORT_TASK_SERVICE.convert_pptx_to_html(
+            preview_pptx_path, get_fonts=True
+        )
+    finally:
+        if remove_preview_pptx:
+            with contextlib.suppress(OSError):
+                os.unlink(preview_pptx_path)
     if not pptx_document.slides:
         raise HTTPException(status_code=500, detail="PPTX-to-HTML returned no slides")
 
@@ -715,6 +782,24 @@ async def render_pptx_slides_to_images(
     )
 
     localized_slide_htmls = []
+    asset_directories = [
+        directory
+        for directory in (
+            getattr(pptx_document, "images_dir", None),
+            getattr(pptx_document, "fonts_dir", None),
+        )
+        if isinstance(directory, str) and os.path.isabs(directory)
+    ]
+    relative_asset_root = (
+        os.path.commonpath([os.path.dirname(path) for path in asset_directories])
+        if asset_directories
+        else None
+    )
+    trusted_local_font_files = {
+        os.path.realpath(path)
+        for path in font_paths_for_install
+        if os.path.isfile(path)
+    }
     font_css = "\n".join(
         css
         for css in (
@@ -724,7 +809,11 @@ async def render_pptx_slides_to_images(
         )
         if css
     )
-    localized_font_css = _localize_preview_asset_urls(font_css)
+    localized_font_css = _localize_preview_asset_urls(
+        font_css,
+        relative_asset_root=relative_asset_root,
+        trusted_local_files=trusted_local_font_files,
+    )
     localized_font_css = "\n".join(
         css
         for css in (
@@ -735,7 +824,11 @@ async def render_pptx_slides_to_images(
     )
     explicit_font_links = _font_stylesheet_links_for_urls(font_stylesheet_urls or [])
     for slide_html in slide_htmls:
-        localized_slide_html = _localize_preview_asset_urls(slide_html)
+        localized_slide_html = _localize_preview_asset_urls(
+            slide_html,
+            relative_asset_root=relative_asset_root,
+            trusted_local_files=trusted_local_font_files,
+        )
         inferred_font_links = _font_stylesheet_links_for_slide_html(
             localized_slide_html, localized_font_css
         )
@@ -997,6 +1090,69 @@ def _validate_pptx_package(pptx_path: str) -> None:
         or not has_slide
     ):
         raise HTTPException(status_code=400, detail=INVALID_PPTX_UPLOAD_ERROR)
+
+
+def _prepare_svg_images_for_pptx_to_html(pptx_path: str) -> Tuple[str, bool]:
+    """Give SVG-only pictures a primary relationship for the HTML converter."""
+    xml_replacements: Dict[str, bytes] = {}
+    relationship_embed = f"{{{PPT_NS['r']}}}embed"
+    blip_tag = f"{{{PPT_NS['a']}}}blip"
+    svg_blip_tag = f"{{{PPT_NS['asvg']}}}svgBlip"
+
+    with zipfile.ZipFile(pptx_path, "r") as archive:
+        for member in archive.infolist():
+            if not (
+                member.filename.startswith("ppt/")
+                and member.filename.endswith(".xml")
+            ):
+                continue
+            slide_xml = ET.fromstring(archive.read(member.filename))
+            changed = False
+            for blip in slide_xml.iter(blip_tag):
+                if blip.get(relationship_embed):
+                    continue
+                svg_blip = next(blip.iter(svg_blip_tag), None)
+                svg_relationship = (
+                    svg_blip.get(relationship_embed)
+                    if svg_blip is not None
+                    else None
+                )
+                if not svg_relationship:
+                    continue
+                blip.set(relationship_embed, svg_relationship)
+                changed = True
+            if changed:
+                xml_replacements[member.filename] = ET.tostring(
+                    slide_xml,
+                    encoding="utf-8",
+                    xml_declaration=True,
+                )
+
+        if not xml_replacements:
+            return pptx_path, False
+
+        file_descriptor, preview_pptx_path = tempfile.mkstemp(
+            prefix="pptx-html-svg-",
+            suffix=".pptx",
+            dir=os.path.dirname(os.path.abspath(pptx_path)),
+        )
+        os.close(file_descriptor)
+        try:
+            with zipfile.ZipFile(preview_pptx_path, "w") as output_archive:
+                for member in archive.infolist():
+                    output_archive.writestr(
+                        member,
+                        xml_replacements.get(
+                            member.filename,
+                            archive.read(member.filename),
+                        ),
+                    )
+        except Exception:
+            with contextlib.suppress(OSError):
+                os.unlink(preview_pptx_path)
+            raise
+
+    return preview_pptx_path, True
 
 
 def _resolve_template_preview_slide_cap(max_slides: Optional[int]) -> int:

--- a/servers/fastapi/templates/fonts_and_slides_preview.py
+++ b/servers/fastapi/templates/fonts_and_slides_preview.py
@@ -154,15 +154,11 @@ INVALID_PPTX_UPLOAD_ERROR = (
     "The uploaded PowerPoint file is corrupted or unsupported."
 )
 PPT_NS = {
-    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
-    "asvg": "http://schemas.microsoft.com/office/drawing/2016/SVG/main",
     "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
     "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
 }
 REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
 
-ET.register_namespace("a", PPT_NS["a"])
-ET.register_namespace("asvg", PPT_NS["asvg"])
 ET.register_namespace("p", PPT_NS["p"])
 ET.register_namespace("r", PPT_NS["r"])
 
@@ -749,21 +745,9 @@ async def render_pptx_slides_to_images(
         )
         logger.info("Prepared custom font CSS for HTML preview rendering")
 
-    if os.path.isfile(modified_pptx_path):
-        preview_pptx_path, remove_preview_pptx = await asyncio.to_thread(
-            _prepare_svg_images_for_pptx_to_html,
-            modified_pptx_path,
-        )
-    else:
-        preview_pptx_path, remove_preview_pptx = modified_pptx_path, False
-    try:
-        pptx_document = await EXPORT_TASK_SERVICE.convert_pptx_to_html(
-            preview_pptx_path, get_fonts=True
-        )
-    finally:
-        if remove_preview_pptx:
-            with contextlib.suppress(OSError):
-                os.unlink(preview_pptx_path)
+    pptx_document = await EXPORT_TASK_SERVICE.convert_pptx_to_html(
+        modified_pptx_path, get_fonts=True
+    )
     if not pptx_document.slides:
         raise HTTPException(status_code=500, detail="PPTX-to-HTML returned no slides")
 
@@ -1090,69 +1074,6 @@ def _validate_pptx_package(pptx_path: str) -> None:
         or not has_slide
     ):
         raise HTTPException(status_code=400, detail=INVALID_PPTX_UPLOAD_ERROR)
-
-
-def _prepare_svg_images_for_pptx_to_html(pptx_path: str) -> Tuple[str, bool]:
-    """Give SVG-only pictures a primary relationship for the HTML converter."""
-    xml_replacements: Dict[str, bytes] = {}
-    relationship_embed = f"{{{PPT_NS['r']}}}embed"
-    blip_tag = f"{{{PPT_NS['a']}}}blip"
-    svg_blip_tag = f"{{{PPT_NS['asvg']}}}svgBlip"
-
-    with zipfile.ZipFile(pptx_path, "r") as archive:
-        for member in archive.infolist():
-            if not (
-                member.filename.startswith("ppt/")
-                and member.filename.endswith(".xml")
-            ):
-                continue
-            slide_xml = ET.fromstring(archive.read(member.filename))
-            changed = False
-            for blip in slide_xml.iter(blip_tag):
-                if blip.get(relationship_embed):
-                    continue
-                svg_blip = next(blip.iter(svg_blip_tag), None)
-                svg_relationship = (
-                    svg_blip.get(relationship_embed)
-                    if svg_blip is not None
-                    else None
-                )
-                if not svg_relationship:
-                    continue
-                blip.set(relationship_embed, svg_relationship)
-                changed = True
-            if changed:
-                xml_replacements[member.filename] = ET.tostring(
-                    slide_xml,
-                    encoding="utf-8",
-                    xml_declaration=True,
-                )
-
-        if not xml_replacements:
-            return pptx_path, False
-
-        file_descriptor, preview_pptx_path = tempfile.mkstemp(
-            prefix="pptx-html-svg-",
-            suffix=".pptx",
-            dir=os.path.dirname(os.path.abspath(pptx_path)),
-        )
-        os.close(file_descriptor)
-        try:
-            with zipfile.ZipFile(preview_pptx_path, "w") as output_archive:
-                for member in archive.infolist():
-                    output_archive.writestr(
-                        member,
-                        xml_replacements.get(
-                            member.filename,
-                            archive.read(member.filename),
-                        ),
-                    )
-        except Exception:
-            with contextlib.suppress(OSError):
-                os.unlink(preview_pptx_path)
-            raise
-
-    return preview_pptx_path, True
 
 
 def _resolve_template_preview_slide_cap(max_slides: Optional[int]) -> int:

--- a/servers/fastapi/tests/test_pptx_font_utils.py
+++ b/servers/fastapi/tests/test_pptx_font_utils.py
@@ -953,6 +953,94 @@ def test_localize_preview_asset_urls_leaves_external_urls(monkeypatch):
     assert calls == []
 
 
+def test_localize_preview_asset_urls_resolves_converter_relative_assets(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("APP_DATA_DIRECTORY", str(tmp_path))
+    monkeypatch.setenv("DISABLE_AUTH", "true")
+    artifact_dir = tmp_path / "pptx-to-html" / "session"
+    image_path = artifact_dir / "images" / "asset.png"
+    svg_with_png_extension_path = artifact_dir / "images" / "icon.png"
+    font_path = artifact_dir / "fonts" / "deck.woff2"
+    image_path.parent.mkdir(parents=True)
+    font_path.parent.mkdir(parents=True)
+    image_path.write_bytes(b"png")
+    svg_with_png_extension_path.write_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"/>')
+    font_path.write_bytes(b"font")
+
+    html = (
+        '<img src="images/asset.png">'
+        '<img src="images/icon.png">'
+        "<style>@font-face { src: url('fonts/deck.woff2'); }</style>"
+    )
+
+    localized = fonts_and_slides_preview._localize_preview_asset_urls(
+        html,
+        relative_asset_root=str(artifact_dir),
+    )
+
+    assert 'src="data:image/png;base64,cG5n"' in localized
+    assert 'src="data:image/svg+xml;base64,' in localized
+    assert "url('data:font/woff2;base64,Zm9udA==')" in localized
+
+
+def test_localize_preview_asset_urls_rejects_relative_path_traversal(tmp_path):
+    artifact_dir = tmp_path / "pptx-to-html" / "session"
+    artifact_dir.mkdir(parents=True)
+    outside_path = tmp_path / "secret.png"
+    outside_path.write_bytes(b"secret")
+    html = '<img src="../../secret.png">'
+
+    localized = fonts_and_slides_preview._localize_preview_asset_urls(
+        html,
+        relative_asset_root=str(artifact_dir),
+    )
+
+    assert localized == html
+
+
+def test_prepare_svg_images_for_pptx_to_html_promotes_svg_relationship(tmp_path):
+    source_path = tmp_path / "source.pptx"
+    slide_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main"
+       xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld><p:spTree><p:pic><p:blipFill><a:blip>
+    <a:extLst><a:ext><asvg:svgBlip r:embed="rId7" /></a:ext></a:extLst>
+  </a:blip></p:blipFill></p:pic></p:spTree></p:cSld>
+</p:sld>"""
+    with zipfile.ZipFile(source_path, "w") as archive:
+        archive.writestr("ppt/slides/slide1.xml", slide_xml)
+        archive.writestr("ppt/media/icon.svg", b"<svg></svg>")
+
+    preview_path, should_remove = (
+        fonts_and_slides_preview._prepare_svg_images_for_pptx_to_html(
+            str(source_path)
+        )
+    )
+
+    try:
+        assert should_remove is True
+        assert preview_path != str(source_path)
+        with zipfile.ZipFile(preview_path, "r") as archive:
+            rewritten_slide = ET.fromstring(
+                archive.read("ppt/slides/slide1.xml")
+            )
+            blip = next(
+                rewritten_slide.iter(
+                    "{http://schemas.openxmlformats.org/drawingml/2006/main}blip"
+                )
+            )
+            assert blip.get(
+                "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}embed"
+            ) == "rId7"
+            assert archive.read("ppt/media/icon.svg") == b"<svg></svg>"
+    finally:
+        os.unlink(preview_path)
+
+
 @pytest.mark.anyio
 async def test_create_slide_previews_from_html_uses_converter_dimensions_and_fonts(
     monkeypatch,
@@ -1022,6 +1110,8 @@ async def test_create_slide_previews_from_html_uses_converter_dimensions_and_fon
     assert "cdn.jsdelivr.net/npm/chart.js" not in html
     assert ".deck-font { color: black; }" in html
     assert 'font-family: "Khand Bold";' in html
+    assert "data:font/ttf;base64,Zm9udA==" in html
+    assert font_path.resolve().as_uri() not in html
     assert "fonts.googleapis.com/css2?family=Montserrat" in html
 
 

--- a/servers/fastapi/tests/test_pptx_font_utils.py
+++ b/servers/fastapi/tests/test_pptx_font_utils.py
@@ -1000,47 +1000,6 @@ def test_localize_preview_asset_urls_rejects_relative_path_traversal(tmp_path):
     assert localized == html
 
 
-def test_prepare_svg_images_for_pptx_to_html_promotes_svg_relationship(tmp_path):
-    source_path = tmp_path / "source.pptx"
-    slide_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
-<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
-       xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main"
-       xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
-       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-  <p:cSld><p:spTree><p:pic><p:blipFill><a:blip>
-    <a:extLst><a:ext><asvg:svgBlip r:embed="rId7" /></a:ext></a:extLst>
-  </a:blip></p:blipFill></p:pic></p:spTree></p:cSld>
-</p:sld>"""
-    with zipfile.ZipFile(source_path, "w") as archive:
-        archive.writestr("ppt/slides/slide1.xml", slide_xml)
-        archive.writestr("ppt/media/icon.svg", b"<svg></svg>")
-
-    preview_path, should_remove = (
-        fonts_and_slides_preview._prepare_svg_images_for_pptx_to_html(
-            str(source_path)
-        )
-    )
-
-    try:
-        assert should_remove is True
-        assert preview_path != str(source_path)
-        with zipfile.ZipFile(preview_path, "r") as archive:
-            rewritten_slide = ET.fromstring(
-                archive.read("ppt/slides/slide1.xml")
-            )
-            blip = next(
-                rewritten_slide.iter(
-                    "{http://schemas.openxmlformats.org/drawingml/2006/main}blip"
-                )
-            )
-            assert blip.get(
-                "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}embed"
-            ) == "rId7"
-            assert archive.read("ppt/media/icon.svg") == b"<svg></svg>"
-    finally:
-        os.unlink(preview_path)
-
-
 @pytest.mark.anyio
 async def test_create_slide_previews_from_html_uses_converter_dimensions_and_fonts(
     monkeypatch,

--- a/servers/fastapi/tests/unit/test_runtime_limits.py
+++ b/servers/fastapi/tests/unit/test_runtime_limits.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import sys
 from types import SimpleNamespace
@@ -125,6 +126,45 @@ def test_export_output_path_accepts_file_path_key(monkeypatch, tmp_path):
     assert ExportTaskService._resolve_output_path({"file_path": str(output_path)}) == str(
         output_path
     )
+
+
+def test_convert_pptx_to_html_resolves_relative_asset_directories(
+    monkeypatch,
+    tmp_path,
+):
+    app_data = tmp_path / "app-data"
+    artifact_dir = app_data / "pptx-to-html" / "session"
+    manifest_path = artifact_dir / "presentation.json"
+    (artifact_dir / "images").mkdir(parents=True)
+    (artifact_dir / "fonts").mkdir()
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "slides": ['<img src="images/asset.png">'],
+                "font_css": "",
+                "width": 1280,
+                "height": 720,
+                "images_dir": "images",
+                "fonts_dir": "fonts",
+            }
+        ),
+        encoding="utf-8",
+    )
+    pptx_path = tmp_path / "deck.pptx"
+    pptx_path.write_bytes(b"pptx")
+    monkeypatch.setenv("APP_DATA_DIRECTORY", str(app_data))
+    monkeypatch.setenv("TEMP_DIRECTORY", str(tmp_path))
+    service = ExportTaskService(timeout_seconds=10)
+
+    async def fake_run_task(_task_payload, _response_error_detail):
+        return {"file_path": str(manifest_path)}
+
+    service._run_task = fake_run_task
+
+    result = asyncio.run(service.convert_pptx_to_html(str(pptx_path)))
+
+    assert result.images_dir == str(artifact_dir / "images")
+    assert result.fonts_dir == str(artifact_dir / "fonts")
 
 
 def test_render_html_to_image_sends_html_task_payload(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- upgrade the bundled export-core runtime from 1.0.12 to 1.0.14
- rely on export-core 1.0.14 for SVG-only PPTX image extraction
- preserve and localize converter-relative image and font assets after owner scoping

## Tests
- `npm test`
- `npm run typecheck` (electron)
- `UV_CACHE_DIR=/private/tmp/presenton-uv-cache uv run pytest tests/test_pptx_font_utils.py tests/unit/test_runtime_limits.py -q`
- `npm run check:presentation-export`