### PR TITLE
fix(ui): keep toggle thumbs within tracks

### DIFF
--- a/servers/nextjs/components/slide-editor/charts/ChartEditorContent.tsx
+++ b/servers/nextjs/components/slide-editor/charts/ChartEditorContent.tsx
@@ -807,8 +807,8 @@ function CompactSwitch({
       onClick={() => onChange(!checked)}
     >
       <span
-        className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${checked ? "translate-x-4" : "translate-x-0"
-          }`}
+        className="absolute top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-[left]"
+        style={{ left: checked ? "calc(100% - 18px)" : "2px" }}
       />
     </button>
   );

--- a/servers/nextjs/components/ui/switch.cy.tsx
+++ b/servers/nextjs/components/ui/switch.cy.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import "@/app/globals.css";
+import { Switch } from "@/components/ui/switch";
+
+describe("Switch", () => {
+  it("keeps the thumb inside the track when another Tailwind runtime defines translate", () => {
+    cy.document().then((document) => {
+      const style = document.createElement("style");
+      style.textContent = `
+        [class~="data-[state=checked]:translate-x-4"][data-state="checked"],
+        .translate-x-4 {
+          translate: 16px 0;
+        }
+      `;
+      document.head.appendChild(style);
+    });
+
+    cy.mount(<Switch aria-label="Test switch" />);
+
+    const expectThumbInsideTrack = () => {
+      cy.get('[role="switch"]').then(($switch) => {
+        const trackBounds = $switch[0].getBoundingClientRect();
+
+        cy.wrap($switch)
+          .children()
+          .first()
+          .then(($thumb) => {
+            const thumbBounds = $thumb[0].getBoundingClientRect();
+
+            expect(thumbBounds.left).to.be.at.least(trackBounds.left);
+            expect(thumbBounds.right).to.be.at.most(trackBounds.right);
+            expect(thumbBounds.top).to.be.at.least(trackBounds.top);
+            expect(thumbBounds.bottom).to.be.at.most(trackBounds.bottom);
+          });
+      });
+    };
+
+    expectThumbInsideTrack();
+    cy.get('[role="switch"]').click().should("have.attr", "data-state", "checked");
+    expectThumbInsideTrack();
+  });
+});

--- a/servers/nextjs/components/ui/switch.module.css
+++ b/servers/nextjs/components/ui/switch.module.css
@@ -1,0 +1,18 @@
+.thumb {
+  position: absolute;
+  top: 50%;
+  left: 2px;
+  transform: translateY(-50%);
+  transition: left 200ms ease;
+  will-change: left;
+}
+
+.thumb[data-state="checked"] {
+  left: calc(100% - 18px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thumb {
+    transition: none;
+  }
+}

--- a/servers/nextjs/components/ui/switch.tsx
+++ b/servers/nextjs/components/ui/switch.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import * as SwitchPrimitives from "@radix-ui/react-switch"
 
 import { cn } from "@/lib/utils"
+import styles from "./switch.module.css"
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
@@ -11,7 +12,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-0 p-0.5 shadow-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7A5AF8]/30 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[#7A5AF8] data-[state=unchecked]:bg-[#D9DCE3]",
+      "peer relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center overflow-hidden rounded-full border-0 p-0.5 shadow-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7A5AF8]/30 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[#7A5AF8] data-[state=unchecked]:bg-[#D9DCE3]",
       className
     )}
     {...props}
@@ -19,7 +20,8 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm ring-0 transition-transform duration-200 data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+        styles.thumb,
+        "pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm ring-0"
       )}
     />
   </SwitchPrimitives.Root>


### PR DESCRIPTION
## Summary
- position shared switch thumbs from the track edges instead of compounding translate utilities
- clip shared switch contents as a final overflow guard
- apply the same positioning fix to the chart editor compact switch
- add a component regression test for overlapping Tailwind translate rules

## Testing
- npx tsc --noEmit --pretty false
- npx cypress run --component --spec components/ui/switch.cy.tsx --browser electron