### PR TITLE
Fix justified text in imported templates

### DIFF
--- a/servers/fastapi/models/sql/async_task.py
+++ b/servers/fastapi/models/sql/async_task.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 
 import uuid
 
+from pydantic import field_serializer
 from sqlalchemy import JSON, Column, DateTime, ForeignKey, String
 from sqlmodel import Field, SQLModel
 
@@ -48,3 +49,8 @@ class AsyncTaskModel(SQLModel, table=True):
             onupdate=get_current_utc_datetime,
         )
     )
+
+    @field_serializer("status")
+    def serialize_status(self, status: AsyncTaskStatus | str) -> str:
+        """Serialize values hydrated from the database's string column."""
+        return status.value if isinstance(status, AsyncTaskStatus) else status

--- a/servers/fastapi/services/chat/schemas.py
+++ b/servers/fastapi/services/chat/schemas.py
@@ -638,7 +638,7 @@ class SlideElementFontInput(OpenAIStrictSchemaModel):
 
 
 class SlideElementAlignmentInput(OpenAIStrictSchemaModel):
-    horizontal: Literal["left", "center", "right"] | None = Field(...)
+    horizontal: Literal["left", "center", "right", "justify"] | None = Field(...)
     vertical: Literal["top", "middle", "bottom"] | None = Field(...)
 
 

--- a/servers/fastapi/templates/v2/models/elements.py
+++ b/servers/fastapi/templates/v2/models/elements.py
@@ -31,6 +31,7 @@ class HorizontalAlignment(str, Enum):
     LEFT = "left"
     CENTER = "center"
     RIGHT = "right"
+    JUSTIFY = "justify"
 
 
 class VerticalAlignment(str, Enum):

--- a/servers/fastapi/tests/unit/test_async_tasks_api.py
+++ b/servers/fastapi/tests/unit/test_async_tasks_api.py
@@ -1,4 +1,5 @@
 import asyncio
+import warnings
 from datetime import datetime, timezone
 from typing import Any
 
@@ -58,6 +59,17 @@ def test_async_task_status_enum_uses_string_column():
     status_column_type = AsyncTaskModel.__table__.c.status.type
     assert isinstance(status_column_type, String)
     assert not isinstance(status_column_type, SQLAlchemyEnum)
+
+
+@pytest.mark.parametrize("status", [AsyncTaskStatus.PENDING, "pending"])
+def test_async_task_status_serializes_without_pydantic_warnings(status):
+    task = AsyncTaskModel(type="template.create", status=status)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        payload = task.model_dump_json()
+
+    assert '"status":"pending"' in payload
 
 
 def test_check_async_task_status_returns_task():

--- a/servers/fastapi/tests/unit/test_templates_v2_elements.py
+++ b/servers/fastapi/tests/unit/test_templates_v2_elements.py
@@ -94,6 +94,26 @@ def test_table_cell_accepts_latex_runs():
     assert cell.runs[0].display_mode is False
 
 
+def test_text_and_table_cells_accept_justified_alignment():
+    text = Text.model_validate(
+        {
+            "type": "text",
+            "decorative": False,
+            "name": "body",
+            "runs": [{"text": "Justified body copy"}],
+            "alignment": {"horizontal": "justify"},
+            "min_length": 1,
+            "max_length": 100,
+        }
+    )
+    cell = TableCell.model_validate(
+        {"alignment": "justify", "runs": [{"text": "Justified cell"}]}
+    )
+
+    assert text.model_dump(mode="json")["alignment"]["horizontal"] == "justify"
+    assert cell.model_dump(mode="json")["alignment"] == "justify"
+
+
 def test_chart_accepts_legacy_boolean_data_labels():
     chart = Chart.model_validate(
         {

--- a/servers/nextjs/app/(presentation-generator)/custom-template/components/EachSlide/TemplateV2LayoutPreview.tsx
+++ b/servers/nextjs/app/(presentation-generator)/custom-template/components/EachSlide/TemplateV2LayoutPreview.tsx
@@ -1377,7 +1377,9 @@ function verticalAlign(value: string | null) {
 }
 
 function textAlign(value: string | null): React.CSSProperties["textAlign"] {
-  if (value === "center" || value === "right") return value;
+  if (value === "center" || value === "right" || value === "justify") {
+    return value;
+  }
   return "left";
 }
 

--- a/servers/nextjs/components/slide-editor/importing/template-v2-import.ts
+++ b/servers/nextjs/components/slide-editor/importing/template-v2-import.ts
@@ -1720,7 +1720,11 @@ function adaptLayoutItem(value: UnknownRecord | null): LayoutItem | null {
 function adaptAlignment(value: UnknownRecord | null): Alignment | null {
   if (!value) return null;
   return stripNullish({
-    horizontal: readEnum(value, ["left", "center", "right"], "horizontal"),
+    horizontal: readEnum(
+      value,
+      ["left", "center", "right", "justify"],
+      "horizontal",
+    ),
     vertical: readEnum(value, ["top", "middle", "bottom"], "vertical"),
   });
 }
@@ -1911,7 +1915,11 @@ function adaptTableCells(value: unknown[]): TableCell[] {
           adaptFont(readRecord(record, "font")) ??
           adaptFont(readRecord(firstRun, "font")) ??
           adaptFont(readRecord(textRecord ?? {}, "font")),
-        alignment: readEnum(record, ["left", "center", "right"], "alignment"),
+        alignment: readEnum(
+          record,
+          ["left", "center", "right", "justify"],
+          "alignment",
+        ),
         runs,
       }) as TableCell;
     })

--- a/servers/nextjs/components/slide-editor/surface/nodes.tsx
+++ b/servers/nextjs/components/slide-editor/surface/nodes.tsx
@@ -2008,12 +2008,31 @@ function RawRichTextElement({
           width: 0,
         };
         const startX = lineStartX(align, width, lineMetric.width, false);
+        const justifyGapCount =
+          align === "justify" && lineIndex < lines.length - 1
+            ? line.filter(
+                (segment, segmentIndex) =>
+                  segmentIndex < line.length - 1 &&
+                  segment.type !== "latex" &&
+                  /^\s+$/.test(segment.text),
+              ).length
+            : 0;
+        const justifyGapWidth =
+          justifyGapCount > 0
+            ? Math.max(0, width - lineMetric.width) / justifyGapCount
+            : 0;
         let x = startX;
         const lineY = y;
         y += lineMetric.height;
         return line.map((segment, segmentIndex) => {
           const segmentX = x;
-          x += segment.width;
+          x +=
+            segment.width +
+            (segmentIndex < line.length - 1 &&
+            segment.type !== "latex" &&
+            /^\s+$/.test(segment.text)
+              ? justifyGapWidth
+              : 0);
           if (segment.type === "latex" && segment.latex) {
             return (
               <LatexRunNode

--- a/servers/nextjs/components/slide-editor/tables/TableToolbar.tsx
+++ b/servers/nextjs/components/slide-editor/tables/TableToolbar.tsx
@@ -1,5 +1,6 @@
 import {
   AlignCenter,
+  AlignJustify,
   AlignLeft,
   AlignRight,
   ChevronLeft,
@@ -38,8 +39,12 @@ import {
 
 type TableCellAlignment = NonNullable<TableCell["alignment"]>;
 
-const TABLE_CELL_ALIGNMENTS = ["left", "center", "right"] as const satisfies
-  readonly TableCellAlignment[];
+const TABLE_CELL_ALIGNMENTS = [
+  "left",
+  "center",
+  "right",
+  "justify",
+] as const satisfies readonly TableCellAlignment[];
 
 export function TableToolbarControls({
   element,
@@ -81,7 +86,9 @@ export function TableToolbarControls({
       ? AlignCenter
       : activeCellAlignment === "right"
         ? AlignRight
-        : AlignLeft;
+        : activeCellAlignment === "justify"
+          ? AlignJustify
+          : AlignLeft;
   const canAddRow = rows.length < 8;
   const canAddColumn = columnCount < 6;
   const canDeleteRow = rows.length > 2;

--- a/servers/nextjs/components/slide-editor/text/TextToolbar.tsx
+++ b/servers/nextjs/components/slide-editor/text/TextToolbar.tsx
@@ -10,6 +10,7 @@ import {
 import { createPortal } from "react-dom";
 import {
   AlignCenter,
+  AlignJustify,
   AlignLeft,
   AlignRight,
   Ban,
@@ -73,6 +74,7 @@ const HORIZONTAL_ALIGNMENT_ICONS = {
   left: AlignLeft,
   center: AlignCenter,
   right: AlignRight,
+  justify: AlignJustify,
 };
 
 const MIN_FONT_SIZE = 4;
@@ -597,7 +599,9 @@ export function TextToolbar({
                       ? "center"
                       : horizontalAlignment === "center"
                         ? "right"
-                        : "left",
+                        : horizontalAlignment === "right"
+                          ? "justify"
+                          : "left",
                 })
               }
             >

--- a/servers/nextjs/components/slide-editor/text/template-v2-text-editing.ts
+++ b/servers/nextjs/components/slide-editor/text/template-v2-text-editing.ts
@@ -30,7 +30,7 @@ export type TemplateV2TextEditStyle = {
   lineHeight: number;
   letterSpacing: number;
   opacity: number;
-  horizontal: "left" | "center" | "right";
+  horizontal: "left" | "center" | "right" | "justify";
   vertical: "top" | "middle" | "bottom";
 };
 

--- a/servers/nextjs/components/slide-editor/text/template-v2-text.ts
+++ b/servers/nextjs/components/slide-editor/text/template-v2-text.ts
@@ -1606,7 +1606,13 @@ function readHorizontalAlignment(
   value: unknown,
 ): TemplateV2TextEditStyle["horizontal"] {
   const normalized = readString(value);
-  if (normalized === "center" || normalized === "right") return normalized;
+  if (
+    normalized === "center" ||
+    normalized === "right" ||
+    normalized === "justify"
+  ) {
+    return normalized;
+  }
   return "left";
 }
 

--- a/servers/nextjs/components/slide-editor/types.ts
+++ b/servers/nextjs/components/slide-editor/types.ts
@@ -13,7 +13,7 @@ export type ThemeRole =
   | "text"
   | "muted";
 
-export type HorizontalAlignment = "left" | "center" | "right";
+export type HorizontalAlignment = "left" | "center" | "right" | "justify";
 export type VerticalAlignment = "top" | "middle" | "bottom";
 export type LayoutAlignment =
   | "flex-start"

--- a/servers/nextjs/lib/template-v2-json-to-html.ts
+++ b/servers/nextjs/lib/template-v2-json-to-html.ts
@@ -3980,7 +3980,9 @@ function verticalAlign(value: string | null): string {
 }
 
 function textAlign(value: string | null): string {
-  return value === "center" || value === "right" ? value : "left";
+  return value === "center" || value === "right" || value === "justify"
+    ? value
+    : "left";
 }
 
 function cssAlignment(value: string | null, fallback: string): string {


### PR DESCRIPTION
## Summary
- accept PowerPoint justify alignment in Template V2 backend and chat schemas
- preserve justified text through template import, previews, the slide editor, tables, and HTML export
- render justified rich text correctly on the Konva canvas
- serialize database-hydrated async task statuses without Pydantic warnings

## Testing
- uv run pytest tests/unit/test_async_tasks_api.py tests/unit/test_template_api.py tests/unit/test_templates_v2_elements.py -q
- npx tsc --noEmit
- npm test -- --test-name-pattern=template|export
- validated the original 19-slide PPTX-to-JSON output with RawSlideLayouts