### PR TITLE
Fix LaTeX editor interaction and rendering quality

### DIFF
--- a/servers/nextjs/components/slide-editor/text/TiptapInlineTextEditor.tsx
+++ b/servers/nextjs/components/slide-editor/text/TiptapInlineTextEditor.tsx
@@ -19,7 +19,7 @@ import Underline from "@tiptap/extension-underline";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
-import { NodeSelection } from "@tiptap/pm/state";
+import { NodeSelection, TextSelection } from "@tiptap/pm/state";
 import type { Font, Marker, TextRun } from "@/components/slide-editor/types";
 import {
   isLatexTextRun,
@@ -88,6 +88,7 @@ const LatexRun = TiptapNode.create({
   inline: true,
   atom: true,
   selectable: true,
+  draggable: false,
   addAttributes() {
     return {
       latex: { default: "" },
@@ -145,7 +146,27 @@ const LatexRun = TiptapNode.create({
         scheduleTextareaResize();
       };
 
-      const commit = () => {
+      const emitTextareaSelection = () => {
+        const position = getPos();
+        if (typeof position !== "number") return;
+        const runStart = view.state.doc.textBetween(
+          0,
+          position,
+          "\n",
+          editorLeafText,
+        ).length;
+        const range = {
+          start: runStart + textarea.selectionStart,
+          end: runStart + textarea.selectionEnd,
+        };
+        view.dom.dispatchEvent(
+          new CustomEvent<TextSelectionRange>(LATEX_RUN_FOCUS_EVENT, {
+            detail: range,
+          }),
+        );
+      };
+
+      const commit = (deleteEmpty = true) => {
         if (committing) return;
         committing = true;
 
@@ -156,7 +177,14 @@ const LatexRun = TiptapNode.create({
           return;
         }
         const latex = normalizeMathLatex(textarea.value);
-        const transaction = latex
+        if (
+          latex === currentNode.attrs.latex &&
+          (latex.length > 0 || !deleteEmpty)
+        ) {
+          committing = false;
+          return;
+        }
+        const transaction = latex || !deleteEmpty
           ? view.state.tr.setNodeMarkup(position, undefined, {
               ...currentNode.attrs,
               latex,
@@ -171,29 +199,36 @@ const LatexRun = TiptapNode.create({
       textarea.setAttribute("aria-label", "Edit LaTeX expression");
       textarea.setAttribute("title", "LaTeX expression");
       textarea.spellcheck = false;
-      textarea.style.cssText = `box-sizing:border-box;display:block;min-width:8ch;max-width:100%;min-height:1.8em;padding:2px 6px;border:1px solid #7c3aed;border-radius:4px;background:#fff;color:#111827;font:500 0.8em/1.4 ui-monospace,SFMono-Regular,Menlo,monospace;outline:none;overflow:hidden;overflow-wrap:anywhere;resize:none;white-space:pre-wrap;vertical-align:middle;`;
-      textarea.addEventListener("input", resizeTextarea);
+      textarea.draggable = false;
+      textarea.style.cssText = `box-sizing:border-box;display:block;min-width:8ch;max-width:100%;min-height:1.8em;padding:2px 6px;border:1px solid #7c3aed;border-radius:4px;background:#fff;color:#111827;caret-color:currentColor;font:500 0.8em/1.4 ui-monospace,SFMono-Regular,Menlo,monospace;outline:none;overflow:hidden;overflow-wrap:anywhere;resize:none;white-space:pre-wrap;vertical-align:middle;`;
+      textarea.addEventListener("input", () => {
+        resizeTextarea();
+        commit(false);
+        emitTextareaSelection();
+      });
       textarea.addEventListener("focus", () => {
         resizeTextarea();
         const position = getPos();
         if (typeof position !== "number") return;
-        const range = selectionRangeForPositions(
-          view.state.doc,
-          position,
-          position + currentNode.nodeSize,
-        );
-        view.dispatch(
-          view.state.tr.setSelection(
-            NodeSelection.create(view.state.doc, position),
-          ),
-        );
-        view.dom.dispatchEvent(
-          new CustomEvent<TextSelectionRange>(LATEX_RUN_FOCUS_EVENT, {
-            detail: range,
-          }),
-        );
+        const { selection } = view.state;
+        if (selection instanceof NodeSelection && selection.from === position) {
+          view.dispatch(
+            view.state.tr.setSelection(
+              TextSelection.near(
+                view.state.doc.resolve(position + currentNode.nodeSize),
+              ),
+            ),
+          );
+        }
+        emitTextareaSelection();
       });
-      textarea.addEventListener("blur", commit);
+      textarea.addEventListener("select", emitTextareaSelection);
+      textarea.addEventListener("mouseup", emitTextareaSelection);
+      textarea.addEventListener("keyup", emitTextareaSelection);
+      textarea.addEventListener("dragstart", (event) => {
+        event.preventDefault();
+      });
+      textarea.addEventListener("blur", () => commit());
       textarea.addEventListener("keydown", (keyboardEvent) => {
         if (keyboardEvent.key === "Enter") {
           keyboardEvent.preventDefault();
@@ -205,6 +240,7 @@ const LatexRun = TiptapNode.create({
           view.focus();
         }
       });
+      dom.draggable = false;
       dom.appendChild(textarea);
       syncTextarea();
       return {
@@ -941,6 +977,7 @@ function tiptapEditorStyle(font: Font, runs: TextRun[]) {
     `font-family:${cssFontFamilyStack(font.family ?? "Arial")}`,
     `font-size:${font.size ?? 18}px`,
     `color:${cssColor(font.color ?? "111827")}`,
+    "caret-color:currentColor",
     font.bold ? "font-weight:700" : "font-weight:400",
     font.italic ? "font-style:italic" : "font-style:normal",
     font.underline ? "text-decoration:underline" : "text-decoration:none",
@@ -980,6 +1017,7 @@ const TIPTAP_INLINE_EDITOR_CSS = `
 }
 .template-v2-tiptap-inline-prosemirror * {
   box-sizing: border-box;
+  caret-color: currentColor;
 }
 .template-v2-table-cell-editor-content {
   width: 100%;

--- a/servers/nextjs/lib/math.ts
+++ b/servers/nextjs/lib/math.ts
@@ -1,6 +1,7 @@
 import katex from "katex";
 
 export const MAX_MATH_LATEX_LENGTH = 4000;
+const MATH_RENDER_PIXEL_RATIO = 3;
 
 const mathMeasurementCache = new Map<string, { width: number; height: number }>();
 
@@ -119,7 +120,13 @@ export function mathSvgDataUri({
   const safeWidth = Math.max(1, Math.round(width));
   const safeHeight = Math.max(1, Math.round(height));
   const safeFontSize = Math.max(1, Math.min(512, fontSize));
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${safeWidth}" height="${safeHeight}" viewBox="0 0 ${safeWidth} ${safeHeight}"><foreignObject width="100%" height="100%"><div xmlns="http://www.w3.org/1999/xhtml" style="box-sizing:border-box;display:flex;align-items:${alignItems};justify-content:${justifyContent};width:100%;height:100%;overflow:hidden;color:${escapeXmlAttribute(color)};font-size:${safeFontSize}px;line-height:1.2"><style>math{color:inherit;font-size:1em}.katex{color:inherit;font-size:1em}</style>${mathml}</div></foreignObject></svg>`;
+  // Browsers rasterize an SVG containing a foreignObject at its intrinsic
+  // pixel size before Konva paints it. Give that intermediate bitmap extra
+  // pixels while keeping the logical viewBox unchanged so equations remain
+  // sharp on scaled and high-density canvases.
+  const renderWidth = safeWidth * MATH_RENDER_PIXEL_RATIO;
+  const renderHeight = safeHeight * MATH_RENDER_PIXEL_RATIO;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${renderWidth}" height="${renderHeight}" viewBox="0 0 ${safeWidth} ${safeHeight}"><foreignObject width="100%" height="100%"><div xmlns="http://www.w3.org/1999/xhtml" style="box-sizing:border-box;display:flex;align-items:${alignItems};justify-content:${justifyContent};width:100%;height:100%;overflow:hidden;color:${escapeXmlAttribute(color)};font-size:${safeFontSize}px;line-height:1.2"><style>math{color:inherit;font-size:1em}.katex{color:inherit;font-size:1em}</style>${mathml}</div></foreignObject></svg>`;
   return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
 }
 


### PR DESCRIPTION
## Summary
- auto-save LaTeX expressions while typing, including clearing an expression
- prevent drag-selection duplication and release stuck atom selections
- keep the caret color aligned with the active text color
- render equations at a higher intrinsic pixel ratio for sharper canvas output

## Validation
- npx tsc --noEmit --pretty false --incremental false
- npx eslint components/slide-editor/text/TiptapInlineTextEditor.tsx lib/math.ts
- npm test (18 passing)