### PR TITLE
Render mixed LaTeX text with native HTML flow

### DIFF
--- a/servers/nextjs/components/slide-editor/surface/TemplateV2KonvaSlide.tsx
+++ b/servers/nextjs/components/slide-editor/surface/TemplateV2KonvaSlide.tsx
@@ -55,6 +55,7 @@ import { InfographicDataEditorPopover } from "@/components/slide-editor/infograp
 import type { TemplateV2InfographicToolbarElement } from "@/components/slide-editor/layout/InfographicToolbarControls";
 import { TableInlineEditor } from "@/components/slide-editor/tables/TableInlineEditor";
 import { TemplateV2InlineEditor } from "@/components/slide-editor/text/TemplateV2InlineEditor";
+import { StaticHtmlTextLayer } from "@/components/slide-editor/text/StaticHtmlTextLayer";
 import {
   measureWordWrappedTextRunsHeight,
   type TemplateV2InlineEditBox,
@@ -2632,6 +2633,7 @@ function TemplateV2KonvaSlideComponent({
               parentBox={STAGE_BOX}
               layoutManaged={false}
               fontRevision={fontLoadState.revision}
+              renderTextAsHtml
             />
           ))}
           {components.map((component, componentIndex) => (
@@ -2662,6 +2664,7 @@ function TemplateV2KonvaSlideComponent({
               onElementDragMove={handleElementAlignmentDragMove}
               onElementDragComplete={handleElementAlignmentDragComplete}
               fontRevision={fontLoadState.revision}
+              renderTextAsHtml
             />
           ))}
           {isEditMode ? (
@@ -2751,6 +2754,14 @@ function TemplateV2KonvaSlideComponent({
           </Layer>
         ) : null}
         </Stage>
+      ) : null}
+      {isRenderActive ? (
+        <StaticHtmlTextLayer
+          editingKey={editingKey}
+          nodeRefs={nodeRefs}
+          revision={fontLoadState.revision}
+          ui={uiDraft}
+        />
       ) : null}
       <TemplateV2SelectionToolbar
         anchorBox={floatingToolbarAnchorBox}

--- a/servers/nextjs/components/slide-editor/surface/nodes.tsx
+++ b/servers/nextjs/components/slide-editor/surface/nodes.tsx
@@ -40,6 +40,11 @@ import {
   textVisualLocalBox,
   type RenderTextRun,
 } from "@/components/slide-editor/text/template-v2-text";
+import {
+  HTML_TEXT_HEIGHT_ATTR,
+  HTML_TEXT_WIDTH_ATTR,
+  shouldRenderTextElementAsHtml,
+} from "@/components/slide-editor/text/html-text-attrs";
 import type { TableCellSelection } from "@/components/slide-editor/state/state";
 import { loadKonvaImage } from "@/components/slide-editor/surface/exportAssets";
 import { constrainComponentTransformBounds } from "@/components/slide-editor/surface/componentFrameBounds";
@@ -517,6 +522,7 @@ export function RawComponentNode({
   onElementDragMove,
   onElementDragComplete,
   fontRevision,
+  renderTextAsHtml,
 }: {
   component: RawComponent;
   componentIndex: number;
@@ -563,6 +569,7 @@ export function RawComponentNode({
     node: Konva.Node,
   ) => void;
   fontRevision: number;
+  renderTextAsHtml: boolean;
 }) {
   const groupRef = useRef<Konva.Group | null>(null);
   const transformSourceRef = useRef<RawComponent | null>(null);
@@ -872,6 +879,7 @@ export function RawComponentNode({
             elementIndex === 0
           }
           fontRevision={fontRevision}
+          renderTextAsHtml={renderTextAsHtml}
         />
       ))}
     </Group>
@@ -920,7 +928,8 @@ export const MemoizedRawComponentNode = memo(
       previous.onElementDragComplete !== next.onElementDragComplete ||
       previous.selectedTableCell !== next.selectedTableCell ||
       previous.selectedKey !== next.selectedKey ||
-      previous.fontRevision !== next.fontRevision
+      previous.fontRevision !== next.fontRevision ||
+      previous.renderTextAsHtml !== next.renderTextAsHtml
     ) {
       return false;
     }
@@ -962,6 +971,7 @@ function RawElementNode({
   allowVectorPointEditing = true,
   allowDirectVectorSelection = true,
   fontRevision,
+  renderTextAsHtml,
 }: {
   element: RawElement;
   componentIndex: number;
@@ -1009,6 +1019,7 @@ function RawElementNode({
   allowVectorPointEditing?: boolean;
   allowDirectVectorSelection?: boolean;
   fontRevision: number;
+  renderTextAsHtml: boolean;
 }) {
   const groupRef = useRef<Konva.Group | null>(null);
   const transformSourceBoxRef = useRef<Box | null>(null);
@@ -1028,6 +1039,8 @@ function RawElementNode({
     selectedTableCell?.elementPath === key ? selectedTableCell : null;
   const editing = editingKey === key;
   const type = readString(element.type);
+  const usesHtmlText =
+    renderTextAsHtml && shouldRenderTextElementAsHtml(element);
   const isVector = isVectorType(type);
   const vectorPointEditing = vectorEditingKey === key;
   const [vectorDragPreview, setVectorDragPreview] =
@@ -1308,6 +1321,10 @@ function RawElementNode({
     <Group
       ref={(node) => {
         groupRef.current = node;
+        if (node) {
+          node.setAttr(HTML_TEXT_WIDTH_ATTR, visualBox.width);
+          node.setAttr(HTML_TEXT_HEIGHT_ATTR, visualBox.height);
+        }
         setNodeRef(key, node);
       }}
       x={centerOrigin ? box.x + box.width / 2 : box.x}
@@ -1402,7 +1419,18 @@ function RawElementNode({
       {isEditMode ? (
         <SelectionBoundsRect width={box.width} height={box.height} />
       ) : null}
-      {editing ? null : (
+      {editing ? null : usesHtmlText ? (
+        isEditMode ? (
+          <Rect
+            width={visualBox.width}
+            height={visualBox.height}
+            fill="rgba(0,0,0,0)"
+            listening
+            perfectDrawEnabled={false}
+            shadowForStrokeEnabled={false}
+          />
+        ) : null
+      ) : (
         <MemoizedRawElementVisual
           element={renderedElement}
           width={visualBox.width}
@@ -1460,6 +1488,7 @@ function RawElementNode({
           renderBox={childBox}
           layoutManaged={layoutManaged}
           fontRevision={fontRevision}
+          renderTextAsHtml={renderTextAsHtml}
         />
       ))}
     </Group>
@@ -1477,6 +1506,7 @@ export const MemoizedRawElementNode = memo(RawElementNode, (previous, next) => {
     previous.allowVectorPointEditing !== next.allowVectorPointEditing ||
     previous.allowDirectVectorSelection !== next.allowDirectVectorSelection ||
     previous.fontRevision !== next.fontRevision ||
+    previous.renderTextAsHtml !== next.renderTextAsHtml ||
     previous.vectorEditingKey !== next.vectorEditingKey ||
     previous.selectedTableCell !== next.selectedTableCell ||
     previous.selectedKey !== next.selectedKey ||

--- a/servers/nextjs/components/slide-editor/text/StaticHtmlTextLayer.tsx
+++ b/servers/nextjs/components/slide-editor/text/StaticHtmlTextLayer.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import {
+  memo,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type CSSProperties,
+  type RefObject,
+} from "react";
+import type Konva from "konva";
+import {
+  ROOT_ELEMENTS_COMPONENT_INDEX,
+  asRecord,
+  childArrayInfo,
+  keyForSelection,
+  readArray,
+  readNumber,
+  readString,
+  type ElementSelection,
+  type RawElement,
+  type RawUi,
+} from "@/components/slide-editor/model/model";
+import {
+  fontToSource,
+  rawFont,
+  rawTextListRunsForEditor,
+  rawTextRunsForEditor,
+} from "@/components/slide-editor/text/template-v2-text";
+import { isLatexTextRun } from "@/components/slide-editor/text/text-runs";
+import { cssFontFamilyStack } from "@/components/slide-editor/text/css-text";
+import type { Font, TextRun } from "@/components/slide-editor/types";
+import { withHash } from "@/components/slide-editor/utils/color";
+import { renderMathHtml } from "@/lib/math";
+import {
+  HTML_TEXT_HEIGHT_ATTR,
+  HTML_TEXT_WIDTH_ATTR,
+  shouldRenderTextElementAsHtml,
+} from "@/components/slide-editor/text/html-text-attrs";
+
+type HtmlTextDescriptor = {
+  element: RawElement;
+  key: string;
+};
+
+type StaticHtmlTextLayerProps = {
+  editingKey: string | null;
+  nodeRefs: RefObject<Map<string, Konva.Node>>;
+  revision: number;
+  ui: RawUi;
+};
+
+function StaticHtmlTextLayerComponent({
+  editingKey,
+  nodeRefs,
+  revision,
+  ui,
+}: StaticHtmlTextLayerProps) {
+  const elementRefs = useRef(new Map<string, HTMLDivElement>());
+  const descriptors = useMemo(() => collectHtmlTextDescriptors(ui), [ui]);
+
+  useLayoutEffect(() => {
+    const syncTextElements = () => {
+      descriptors.forEach(({ key }) => {
+        const htmlElement = elementRefs.current.get(key);
+        const konvaNode = nodeRefs.current?.get(key);
+        if (!htmlElement || !konvaNode) {
+          if (htmlElement) htmlElement.style.display = "none";
+          return;
+        }
+
+        const matrix = konvaNode.getAbsoluteTransform().getMatrix();
+        const width = readFiniteDimension(
+          konvaNode.getAttr(HTML_TEXT_WIDTH_ATTR),
+          konvaNode.width(),
+        );
+        const height = readFiniteDimension(
+          konvaNode.getAttr(HTML_TEXT_HEIGHT_ATTR),
+          konvaNode.height(),
+        );
+        htmlElement.style.display =
+          editingKey === key || !konvaNode.isVisible() ? "none" : "flex";
+        htmlElement.style.width = `${width}px`;
+        htmlElement.style.height = `${height}px`;
+        htmlElement.style.opacity = String(konvaNode.getAbsoluteOpacity());
+        htmlElement.style.transform = `matrix(${matrix.join(",")})`;
+      });
+    };
+
+    syncTextElements();
+    const stage = Array.from(nodeRefs.current?.values() ?? [])
+      .map((node) => node.getStage())
+      .find(Boolean);
+    if (!stage) return;
+
+    const layers = stage.getLayers();
+    stage.on(
+      "dragmove.staticHtmlText transform.staticHtmlText",
+      syncTextElements,
+    );
+    layers.forEach((layer) => {
+      layer.on("draw.staticHtmlText", syncTextElements);
+    });
+    return () => {
+      stage.off(
+        "dragmove.staticHtmlText transform.staticHtmlText",
+        syncTextElements,
+      );
+      layers.forEach((layer) => {
+        layer.off("draw.staticHtmlText", syncTextElements);
+      });
+    };
+  }, [descriptors, editingKey, nodeRefs, revision]);
+
+  return (
+    <div
+      data-template-v2-html-text-layer="true"
+      className="pointer-events-none absolute inset-0"
+      style={{ zIndex: 5 }}
+    >
+      {descriptors.map(({ element, key }) => (
+        <StaticHtmlTextElement
+          key={key}
+          element={element}
+          hidden={editingKey === key}
+          nodeRef={(node) => {
+            if (node) elementRefs.current.set(key, node);
+            else elementRefs.current.delete(key);
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export const StaticHtmlTextLayer = memo(StaticHtmlTextLayerComponent);
+StaticHtmlTextLayer.displayName = "StaticHtmlTextLayer";
+
+function StaticHtmlTextElement({
+  element,
+  hidden,
+  nodeRef,
+}: {
+  element: RawElement;
+  hidden: boolean;
+  nodeRef: (node: HTMLDivElement | null) => void;
+}) {
+  const type = readString(element.type);
+  const baseFont = fontToSource(rawFont(element));
+  const runs =
+    type === "text-list"
+      ? rawTextListRunsForEditor(element)
+      : rawTextRunsForEditor(element);
+  const alignment = asRecord(element.alignment);
+  const horizontal = readString(alignment?.horizontal) ?? "left";
+  const vertical = readString(alignment?.vertical) ?? "top";
+  const rootLineHeight = rootLineHeightPx(baseFont, runs);
+
+  return (
+    <div
+      ref={nodeRef}
+      aria-hidden={hidden}
+      data-template-v2-html-text="true"
+      style={{
+        position: "absolute",
+        left: 0,
+        top: 0,
+        display: hidden ? "none" : "flex",
+        boxSizing: "border-box",
+        minWidth: 0,
+        transformOrigin: "0 0",
+        flexDirection: "column",
+        justifyContent:
+          vertical === "middle"
+            ? "center"
+            : vertical === "bottom"
+              ? "flex-end"
+              : "flex-start",
+        color: withHash(baseFont.color, "#111827"),
+        fontFamily: cssFontFamilyStack(baseFont.family ?? "Arial"),
+        fontSize: baseFont.size ?? 18,
+        fontWeight: baseFont.bold ? 700 : 400,
+        fontStyle: baseFont.italic ? "italic" : "normal",
+        lineHeight: `${rootLineHeight}px`,
+        letterSpacing: baseFont.letter_spacing ?? 0,
+        textAlign: horizontal as CSSProperties["textAlign"],
+        textDecoration: baseFont.underline ? "underline" : "none",
+        textShadow: cssTextShadow(element),
+        pointerEvents: "none",
+        userSelect: "none",
+      }}
+    >
+      <div
+        style={{
+          boxSizing: "border-box",
+          margin: 0,
+          minWidth: 0,
+          width: "100%",
+          whiteSpace: "pre-wrap",
+          overflowWrap: "break-word",
+        }}
+      >
+        {(runs.length > 0 ? runs : [{ text: " ", font: baseFont }]).map(
+          (run, index) => (
+            <StaticHtmlTextRun
+              key={`${index}:${isLatexTextRun(run) ? run.latex : run.text}`}
+              baseFont={baseFont}
+              run={run}
+            />
+          ),
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StaticHtmlTextRun({
+  baseFont,
+  run,
+}: {
+  baseFont: Font;
+  run: TextRun;
+}) {
+  const font = { ...baseFont, ...(run.font ?? {}) };
+  const style: CSSProperties = {
+    color: withHash(font.color, "#111827"),
+    fontFamily: cssFontFamilyStack(font.family ?? "Arial"),
+    fontSize: font.size ?? 18,
+    fontWeight: font.bold ? 700 : 400,
+    fontStyle: font.italic ? "italic" : "normal",
+    lineHeight: font.line_height ?? 1.15,
+    letterSpacing: font.letter_spacing ?? 0,
+    opacity: font.opacity ?? 1,
+    textDecoration: font.underline ? "underline" : "none",
+  };
+
+  if (isLatexTextRun(run)) {
+    return (
+      <span
+        className="presenton-math"
+        style={{
+          ...style,
+          display: run.display_mode ? "block" : "inline-block",
+          maxWidth: "100%",
+          verticalAlign: "middle",
+        }}
+        dangerouslySetInnerHTML={{
+          __html: renderMathHtml(run.latex, {
+            displayMode: run.display_mode ?? false,
+            output: "mathml",
+          }),
+        }}
+      />
+    );
+  }
+
+  return <span style={style}>{run.text}</span>;
+}
+
+function collectHtmlTextDescriptors(ui: RawUi): HtmlTextDescriptor[] {
+  const descriptors: HtmlTextDescriptor[] = [];
+  const collect = (
+    elements: unknown[],
+    componentIndex: number,
+    parentPath: number[] = [],
+  ) => {
+    elements.forEach((value, index) => {
+      const element = asRecord(value);
+      if (!element) return;
+      const elementPath = [...parentPath, index];
+      const type = readString(element.type);
+      if (
+        (type === "text" || type === "text-list") &&
+        shouldRenderTextElementAsHtml(element)
+      ) {
+        const selection: ElementSelection = {
+          kind: "element",
+          componentIndex,
+          elementPath,
+        };
+        descriptors.push({ element, key: keyForSelection(selection) });
+      }
+      const childInfo = childArrayInfo(element);
+      if (childInfo) collect(childInfo.items, componentIndex, elementPath);
+    });
+  };
+
+  collect(readArray(ui.elements), ROOT_ELEMENTS_COMPONENT_INDEX);
+  readArray(ui.components).forEach((value, componentIndex) => {
+    const component = asRecord(value);
+    if (component) collect(readArray(component.elements), componentIndex);
+  });
+  return descriptors;
+}
+
+function rootLineHeightPx(baseFont: Font, runs: TextRun[]) {
+  const sourceRuns = runs.length > 0 ? runs : [{ text: " ", font: baseFont }];
+  return Math.max(
+    1,
+    ...sourceRuns.map((run) => {
+      const font = { ...baseFont, ...(run.font ?? {}) };
+      return (font.size ?? 18) * (font.line_height ?? 1.15);
+    }),
+  );
+}
+
+function cssTextShadow(element: RawElement) {
+  const shadow = asRecord(element.shadow);
+  if (!shadow) return undefined;
+  const opacity = Math.max(0, Math.min(1, readNumber(shadow.opacity) ?? 0.2));
+  const color = withHash(readString(shadow.color), "#000000");
+  const blur = Math.max(0, readNumber(shadow.blur) ?? 0);
+  const offsetX = readNumber(shadow.offset_x) ?? readNumber(shadow.offsetX) ?? 0;
+  const offsetY = readNumber(shadow.offset_y) ?? readNumber(shadow.offsetY) ?? 0;
+  if (opacity <= 0 || (blur <= 0 && offsetX === 0 && offsetY === 0)) {
+    return undefined;
+  }
+  return `${offsetX}px ${offsetY}px ${blur}px ${hexWithOpacity(color, opacity)}`;
+}
+
+function hexWithOpacity(color: string, opacity: number) {
+  const hex = color.replace(/^#/, "");
+  if (!/^[0-9a-f]{6}$/i.test(hex)) return color;
+  const red = Number.parseInt(hex.slice(0, 2), 16);
+  const green = Number.parseInt(hex.slice(2, 4), 16);
+  const blue = Number.parseInt(hex.slice(4, 6), 16);
+  return `rgba(${red}, ${green}, ${blue}, ${opacity})`;
+}
+
+function readFiniteDimension(value: unknown, fallback: number) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : Math.max(1, fallback);
+}

--- a/servers/nextjs/components/slide-editor/text/TemplateV2InlineEditor.tsx
+++ b/servers/nextjs/components/slide-editor/text/TemplateV2InlineEditor.tsx
@@ -18,10 +18,8 @@ import {
 } from "@/components/slide-editor/text/template-v2-text-editing";
 import { effectiveLineHeight } from "@/components/slide-editor/text/text-line-height";
 import type { TextSelectionRange } from "@/components/slide-editor/text/text-runs";
-import {
-  cssFontFamilyStack,
-  TiptapInlineTextEditor,
-} from "@/components/slide-editor/text/TiptapInlineTextEditor";
+import { TiptapInlineTextEditor } from "@/components/slide-editor/text/TiptapInlineTextEditor";
+import { cssFontFamilyStack } from "@/components/slide-editor/text/css-text";
 
 const DEFAULT_TEXT_EDIT_STYLE: TemplateV2TextEditStyle = {
   family: "Arial",

--- a/servers/nextjs/components/slide-editor/text/TiptapInlineTextEditor.tsx
+++ b/servers/nextjs/components/slide-editor/text/TiptapInlineTextEditor.tsx
@@ -26,6 +26,7 @@ import {
   mergeAdjacentTextRuns,
   type TextSelectionRange,
 } from "@/components/slide-editor/text/text-runs";
+import { cssFontFamilyStack } from "@/components/slide-editor/text/css-text";
 import { normalizeMathLatex } from "@/lib/math";
 
 export const COMMIT_TEMPLATE_V2_INLINE_TEXT_EVENT =
@@ -999,15 +1000,6 @@ function rootLineHeightPx(baseFont: Font, runs: TextRun[]) {
 
 function cssColor(color: string) {
   return color.startsWith("#") ? color : `#${color}`;
-}
-
-export function cssFontFamilyStack(family: string) {
-  const escapedFamily = family
-    .trim()
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"')
-    .replace(/[\r\n\f]/g, " ");
-  return `"${escapedFamily || "Arial"}", Helvetica, sans-serif`;
 }
 
 const TIPTAP_INLINE_EDITOR_CSS = `

--- a/servers/nextjs/components/slide-editor/text/css-text.ts
+++ b/servers/nextjs/components/slide-editor/text/css-text.ts
@@ -1,0 +1,8 @@
+export function cssFontFamilyStack(family: string) {
+  const escapedFamily = family
+    .trim()
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/[\r\n\f]/g, " ");
+  return `"${escapedFamily || "Arial"}", Helvetica, sans-serif`;
+}

--- a/servers/nextjs/components/slide-editor/text/html-text-attrs.ts
+++ b/servers/nextjs/components/slide-editor/text/html-text-attrs.ts
@@ -1,0 +1,25 @@
+import {
+  asRecord,
+  readArray,
+  readString,
+  type RawElement,
+} from "@/components/slide-editor/model/model";
+
+export const HTML_TEXT_WIDTH_ATTR = "presentonHtmlTextWidth";
+export const HTML_TEXT_HEIGHT_ATTR = "presentonHtmlTextHeight";
+
+export function shouldRenderTextElementAsHtml(element: RawElement) {
+  const type = readString(element.type);
+  if (type === "text") return runsContainLatex(readArray(element.runs));
+  if (type !== "text-list") return false;
+
+  return readArray(element.items).some((item) => {
+    if (Array.isArray(item)) return runsContainLatex(item);
+    const record = asRecord(item);
+    return Boolean(record && runsContainLatex(readArray(record.runs)));
+  });
+}
+
+function runsContainLatex(runs: unknown[]) {
+  return runs.some((run) => readString(asRecord(run)?.type) === "latex");
+}

--- a/servers/nextjs/tests/latex-html-text-rendering.test.mjs
+++ b/servers/nextjs/tests/latex-html-text-rendering.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { build } from "esbuild";
+
+let htmlText;
+let temporaryDirectory;
+
+test.before(async () => {
+  temporaryDirectory = await mkdtemp(path.join(tmpdir(), "presenton-math-html-"));
+  const outputFile = path.join(temporaryDirectory, "html-text-attrs.mjs");
+  await build({
+    entryPoints: [
+      path.resolve("components/slide-editor/text/html-text-attrs.ts"),
+    ],
+    outfile: outputFile,
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    tsconfig: path.resolve("tsconfig.json"),
+    logLevel: "silent",
+  });
+  htmlText = await import(
+    `${pathToFileURL(outputFile).href}?cache=${Date.now()}`
+  );
+});
+
+test.after(async () => {
+  if (temporaryDirectory) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("uses browser text flow only for text containing LaTeX", () => {
+  assert.equal(
+    htmlText.shouldRenderTextElementAsHtml({
+      type: "text",
+      runs: [{ text: "Plain paragraph" }],
+    }),
+    false,
+  );
+  assert.equal(
+    htmlText.shouldRenderTextElementAsHtml({
+      type: "text",
+      runs: [
+        { text: "Energy: " },
+        { type: "latex", latex: "E = mc^2" },
+      ],
+    }),
+    true,
+  );
+});
+
+test("detects LaTeX in object and array list-item runs", () => {
+  assert.equal(
+    htmlText.shouldRenderTextElementAsHtml({
+      type: "text-list",
+      items: [
+        { runs: [{ text: "First" }] },
+        { runs: [{ type: "latex", latex: "\\sum_i x_i" }] },
+      ],
+    }),
+    true,
+  );
+  assert.equal(
+    htmlText.shouldRenderTextElementAsHtml({
+      type: "text-list",
+      items: [[{ text: "Second" }, { type: "latex", latex: "x^2" }]],
+    }),
+    true,
+  );
+  assert.equal(
+    htmlText.shouldRenderTextElementAsHtml({
+      type: "text-list",
+      items: [{ runs: [{ text: "Only text" }] }],
+    }),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- render text and list elements containing LaTeX through a synchronized HTML/MathML overlay
- preserve browser-computed paragraph, bullet, and equation heights without fixed vertical padding
- retain the existing Konva rendering path for plain text

## Validation
- npm run build
- npx tsc --noEmit --pretty false --incremental false
- targeted ESLint for changed files
- npm test (20 tests passing)