### PR TITLE
Align 0.9.8-beta release metadata

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presenton",
-  "version": "0.9.7-beta",
+  "version": "0.9.8-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presenton",
-      "version": "0.9.7-beta",
+      "version": "0.9.8-beta",
       "hasInstallScript": true,
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.2",

--- a/electron/version.json
+++ b/electron/version.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.9.7-beta",
-  "message": "Presenton Desktop electron-v0.9.7-beta\n\nWhat's New Since 0.9.5\n\n• Connect and sign in to Presenton Cloud directly from the desktop app\n• Choose between Standard and Smart presentation generation modes\n• Access cloud-generated presentations from your local dashboard\n• Improved onboarding and clearer provider connection status\n• More responsive dashboard with quicker access to Settings\n• Improved presentation deletion and action menus\n• More reliable exports, authentication, and session handling\n• Additional interface, localization, and stability fixes\n\nInstallation\nDownload Link: https://presenton.ai/download\nLove the app? Star us on GitHub → github.com/presenton/presenton",
+  "version": "0.9.8-beta",
+  "message": "Presenton Desktop electron-v0.9.8-beta\n\nWhat's New Since 0.9.5\n\n• Connect and sign in to Presenton Cloud directly from the desktop app\n• Choose between Standard and Smart presentation generation modes\n• Access cloud-generated presentations from your local dashboard\n• Improved onboarding and clearer provider connection status\n• More responsive dashboard with quicker access to Settings\n• Improved presentation deletion and action menus\n• More reliable exports, authentication, and session handling\n• Additional interface, localization, and stability fixes\n\nInstallation\nDownload Link: https://presenton.ai/download\nLove the app? Star us on GitHub → github.com/presenton/presenton",
   "downloads": {
-    "linux": "https://github.com/presenton/presenton/releases/download/electron-v0.9.7-beta/Presenton-0.9.7-beta.deb",
-    "mac": "https://github.com/presenton/presenton/releases/download/electron-v0.9.7-beta/Presenton-0.9.7-beta.dmg",
-    "windows": "https://github.com/presenton/presenton/releases/download/electron-v0.9.7-beta/Presenton-0.9.7-beta.exe"
+    "linux": "https://github.com/presenton/presenton/releases/download/electron-v0.9.8-beta/Presenton-0.9.8-beta.deb",
+    "mac": "https://github.com/presenton/presenton/releases/download/electron-v0.9.8-beta/Presenton-0.9.8-beta.dmg",
+    "windows": "https://github.com/presenton/presenton/releases/download/electron-v0.9.8-beta/Presenton-0.9.8-beta.exe"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presenton",
-  "version": "0.9.7-beta",
+  "version": "0.9.8-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presenton",
-      "version": "0.9.7-beta",
+      "version": "0.9.8-beta",
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.2",
         "sharp": "^0.34.5"


### PR DESCRIPTION
## Summary
- align root and Electron lockfile versions with 0.9.8-beta
- update Electron release metadata and download URLs to 0.9.8-beta
- restore the repository tooling version-alignment check

## Validation
- node --test scripts/package-metadata.test.mjs
- npm test
- git diff --check