### PR TITLE
Fix Smart slide limits and generation defaults

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/generation.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/generation.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter
+from llmai import GenerationDefaults, GenerationProfile, get_model_capabilities
+from llmai.shared.generation import prepare_generation
+from pydantic import BaseModel, Field
+
+
+GENERATION_ROUTER = APIRouter(prefix="/generation", tags=["Generation"])
+
+PROVIDER_ALIASES = {
+    "codex": "chatgpt",
+    "custom": "openai",
+    "ollama": "openai",
+    "together": "togetherai",
+}
+
+
+class GenerationDefaultsRequest(BaseModel):
+    provider: str = Field(min_length=1, max_length=40)
+    model: str = Field(default="", max_length=300)
+
+
+class GenerationTokenDefaults(BaseModel):
+    default_max_output_tokens: int
+    model_max_output_tokens: int
+
+
+def resolve_generation_token_defaults(
+    provider: str,
+    model: str,
+) -> GenerationTokenDefaults:
+    provider_key = provider.strip().lower()
+    normalized_provider = PROVIDER_ALIASES.get(provider_key, provider_key)
+    normalized_model = model.strip() or "unknown-model"
+    capabilities = get_model_capabilities(
+        normalized_model,
+        provider=normalized_provider,
+    )
+
+    def resolve(profile: GenerationProfile) -> int:
+        prepared = prepare_generation(
+            model=normalized_model,
+            provider=normalized_provider,
+            defaults=GenerationDefaults(profile=profile),
+            capabilities=capabilities,
+        )
+        return prepared.max_output_tokens
+
+    return GenerationTokenDefaults(
+        default_max_output_tokens=resolve(GenerationProfile.BALANCED),
+        model_max_output_tokens=resolve(GenerationProfile.MODEL_MAX),
+    )
+
+
+@GENERATION_ROUTER.post("/defaults", response_model=GenerationTokenDefaults)
+def get_generation_token_defaults(
+    request: GenerationDefaultsRequest,
+) -> GenerationTokenDefaults:
+    return resolve_generation_token_defaults(request.provider, request.model)

--- a/servers/fastapi/api/v1/ppt/router.py
+++ b/servers/fastapi/api/v1/ppt/router.py
@@ -4,6 +4,7 @@ from api.v1.ppt.endpoints.anthropic import ANTHROPIC_ROUTER
 from api.v1.ppt.endpoints.chat import CHAT_ROUTER
 from api.v1.ppt.endpoints.community import COMMUNITY_ROUTER
 from api.v1.ppt.endpoints.codex_auth import CODEX_AUTH_ROUTER
+from api.v1.ppt.endpoints.generation import GENERATION_ROUTER
 from api.v1.ppt.endpoints.google import GOOGLE_ROUTER
 from api.v1.ppt.endpoints.openai import OPENAI_ROUTER
 from api.v1.ppt.endpoints.openrouter import OPENROUTER_ROUTER
@@ -33,6 +34,7 @@ API_V1_PPT_ROUTER.include_router(OPENAI_ROUTER)
 API_V1_PPT_ROUTER.include_router(OPENROUTER_ROUTER)
 API_V1_PPT_ROUTER.include_router(ANTHROPIC_ROUTER)
 API_V1_PPT_ROUTER.include_router(GOOGLE_ROUTER)
+API_V1_PPT_ROUTER.include_router(GENERATION_ROUTER)
 API_V1_PPT_ROUTER.include_router(CODEX_AUTH_ROUTER)
 API_V1_PPT_ROUTER.include_router(PRESENTATION_ROUTER)
 API_V1_PPT_ROUTER.include_router(THEMES_ROUTER)

--- a/servers/fastapi/tests/unit/test_generation_defaults.py
+++ b/servers/fastapi/tests/unit/test_generation_defaults.py
@@ -1,0 +1,44 @@
+from llmai import CapabilityStatus, CapabilityValue, ModelCapabilities
+
+from api.v1.ppt.endpoints import generation
+
+
+def _capabilities(max_output_tokens: int | None) -> ModelCapabilities:
+    return ModelCapabilities(
+        model="test-model",
+        provider="openai",
+        max_output_tokens=CapabilityValue(
+            status=(
+                CapabilityStatus.SUPPORTED
+                if max_output_tokens is not None
+                else CapabilityStatus.UNKNOWN
+            ),
+            value=max_output_tokens,
+        ),
+    )
+
+
+def test_generation_defaults_use_model_metadata(monkeypatch):
+    monkeypatch.setattr(
+        generation,
+        "get_model_capabilities",
+        lambda _model, provider: _capabilities(16_384),
+    )
+
+    result = generation.resolve_generation_token_defaults("openai", "gpt-test")
+
+    assert result.default_max_output_tokens == 16_384
+    assert result.model_max_output_tokens == 16_384
+
+
+def test_generation_defaults_fall_back_for_unknown_models(monkeypatch):
+    monkeypatch.setattr(
+        generation,
+        "get_model_capabilities",
+        lambda _model, provider: _capabilities(None),
+    )
+
+    result = generation.resolve_generation_token_defaults("custom", "")
+
+    assert result.default_max_output_tokens == 8_192
+    assert result.model_max_output_tokens == 32_768

--- a/servers/fastapi/tests/unit/test_smart_presentation_generation.py
+++ b/servers/fastapi/tests/unit/test_smart_presentation_generation.py
@@ -317,6 +317,7 @@ def test_smart_generation_keeps_prefix_when_continuation_hits_token_limit(
         + "<!-- SLIDE_END -->"
     )
     calls = 0
+    output_token_limits = []
     streamed_indices = []
     retry_indices = []
     metrics = SimpleNamespace(finish_reason=None)
@@ -331,6 +332,7 @@ def test_smart_generation_keeps_prefix_when_continuation_hits_token_limit(
     ):
         nonlocal calls
         calls += 1
+        output_token_limits.append(_kwargs.get("max_output_tokens"))
         if calls == 1:
             await on_chunk(first_response)
             return first_response, metrics
@@ -356,7 +358,9 @@ def test_smart_generation_keeps_prefix_when_continuation_hits_token_limit(
     )
     monkeypatch.setattr(
         "utils.llm_calls.generate_smart_presentation.get_llm_config",
-        lambda **_kwargs: object(),
+        lambda **_kwargs: SimpleNamespace(
+            generation=SimpleNamespace(max_output_tokens=4_000)
+        ),
     )
     monkeypatch.setattr(
         "utils.llm_calls.generate_smart_presentation.get_model",
@@ -387,6 +391,7 @@ def test_smart_generation_keeps_prefix_when_continuation_hits_token_limit(
     )
 
     assert calls == 3
+    assert output_token_limits == [4_000, 4_000, 4_000]
     assert streamed_indices == [0, 1]
     assert retry_indices == [1, 1]
     assert deck["title"] == "Resumed deck"
@@ -820,4 +825,4 @@ def test_smart_deck_requires_exact_slide_count_and_omits_speaker_notes():
 def test_default_smart_slide_count_is_bounded():
     assert resolve_smart_slide_count(0) == 8
     assert resolve_smart_slide_count(None) == 8
-    assert resolve_smart_slide_count(200) == 20
+    assert resolve_smart_slide_count(200) == 50

--- a/servers/fastapi/utils/llm_calls/generate_smart_presentation.py
+++ b/servers/fastapi/utils/llm_calls/generate_smart_presentation.py
@@ -22,6 +22,7 @@ from llmai.shared import (
     UserMessage,
 )
 
+from constants.presentation import MAX_NUMBER_OF_SLIDES
 from utils.llm_client_error_handler import handle_llm_client_exceptions
 from utils.llm_config import (
     disable_thinking,
@@ -42,7 +43,9 @@ from utils.llm_utils import (
 from utils.smart_slide_layout import inspect_smart_slide_layout
 
 DEFAULT_SMART_SLIDE_COUNT = 8
-MAX_SMART_SLIDE_COUNT = 20
+# Smart generation shares the same product-wide limit as every other deck path.
+# Keep this alias for callers that imported the older Smart-specific constant.
+MAX_SMART_SLIDE_COUNT = MAX_NUMBER_OF_SLIDES
 SMART_GENERATION_MAX_ATTEMPTS = 8
 SMART_GENERATION_METRICS_INTERVAL_SECONDS = 5.0
 SMART_TITLE_MAX_VISIBLE_CHARACTERS = 800
@@ -633,6 +636,7 @@ async def _stream_deck_response(
     messages: Sequence[Message],
     on_chunk: Callable[[str], Awaitable[None]],
     *,
+    max_output_tokens: int | None = None,
     reasoning: ReasoningConfig | None = None,
     on_thinking_chunk: Callable[[str], Awaitable[None]] | None = None,
     model_supports_thinking: bool = False,
@@ -646,6 +650,7 @@ async def _stream_deck_response(
         **get_generate_kwargs(
             model=model,
             messages=messages,
+            max_tokens=max_output_tokens,
             reasoning=reasoning,
             stream=True,
         ),
@@ -744,8 +749,14 @@ async def generate_smart_presentation(
     on_metrics: SmartMetricsCallback | None = None,
     on_retry: SmartRetryCallback | None = None,
 ) -> dict[str, Any]:
-    client = get_client(config=get_llm_config(use_openai_responses_api=True))
+    client_config = get_llm_config(use_openai_responses_api=True)
+    client = get_client(config=client_config)
     model = get_model()
+    configured_output_token_limit = getattr(
+        getattr(client_config, "generation", None),
+        "max_output_tokens",
+        None,
+    )
     reasoning, configured_thinking_support = get_smart_reasoning_config(model)
     accepted_slides: list[dict[str, str]] = []
     for index, saved_slide in enumerate(existing_slides or []):
@@ -800,7 +811,6 @@ async def generate_smart_presentation(
         streamed_thinking = ""
         model_supports_thinking = configured_thinking_support
         attempt_started_at = time.perf_counter()
-        attempt_finish_reason: str | None = None
         estimated_input_tokens = estimate_message_tokens(messages)
 
         async def handle_chunk(chunk: str) -> None:
@@ -867,11 +877,11 @@ async def generate_smart_presentation(
                     model,
                     messages,
                     handle_chunk,
+                    max_output_tokens=configured_output_token_limit,
                     reasoning=reasoning,
                     on_thinking_chunk=handle_thinking_chunk,
                     model_supports_thinking=model_supports_thinking,
                 )
-                attempt_finish_reason = metrics.finish_reason
             finally:
                 if metrics_task is not None:
                     metrics_task.cancel()
@@ -907,26 +917,6 @@ async def generate_smart_presentation(
             if not title and title_match is not None:
                 title = title_match.group(1).strip()
             accepted_slides.extend(attempt_slides)
-            if (
-                isinstance(exc, HTTPException)
-                and exc.status_code == 422
-                and not attempt_slides
-                and not accepted_slides
-            ):
-                raise
-            if (
-                attempt_finish_reason == "length"
-                and not attempt_slides
-                and not accepted_slides
-            ):
-                raise HTTPException(
-                    status_code=422,
-                    detail=(
-                        "The model reached its output-token limit without completing "
-                        "a Smart slide. Increase Max output tokens in Advanced "
-                        "text-provider settings or reduce reasoning effort."
-                    ),
-                ) from exc
             if len(accepted_slides) >= n_slides:
                 return {
                     "title": title or accepted_slides[0]["title"],
@@ -935,6 +925,8 @@ async def generate_smart_presentation(
 
     if last_exception is not None and not isinstance(last_exception, HTTPException):
         raise handle_llm_client_exceptions(last_exception)
+    if isinstance(last_exception, HTTPException) and last_exception.status_code == 422:
+        raise last_exception
     raise HTTPException(
         status_code=500,
         detail=(

--- a/servers/nextjs/components/AdvancedTextProviderSettings.tsx
+++ b/servers/nextjs/components/AdvancedTextProviderSettings.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { useId, useMemo, useState } from "react";
-import { Check, ChevronDown, ChevronUp, Loader2, Trash2 } from "lucide-react";
+import { useEffect, useId, useMemo, useState } from "react";
+import {
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  RotateCcw,
+  Trash2,
+} from "lucide-react";
 
 import {
   Command,
@@ -24,7 +31,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { notify } from "@/components/ui/sonner";
-import { Switch } from "@/components/ui/switch";
 import { LLMConfig } from "@/types/llm_config";
 import { getApiErrorMessage, getApiUrl } from "@/utils/api";
 
@@ -57,6 +63,34 @@ const REASONING_EFFORT_OPTIONS: SelectOption[] = [
   { value: "xhigh", label: "Extra high" },
   { value: "max", label: "Maximum" },
 ];
+
+const REASONING_MODE_OPTIONS: SelectOption[] = [
+  { value: "model_default", label: "Model default" },
+  { value: "enabled", label: "On" },
+  { value: "disabled", label: "Off" },
+];
+
+const FALLBACK_DEFAULT_MAX_OUTPUT_TOKENS = 8_192;
+const FALLBACK_MODEL_MAX_OUTPUT_TOKENS = 32_768;
+
+const MODEL_FIELDS: Partial<Record<string, keyof LLMConfig>> = {
+  anthropic: "ANTHROPIC_MODEL",
+  azure: "AZURE_OPENAI_MODEL",
+  bedrock: "BEDROCK_MODEL",
+  cerebras: "CEREBRAS_MODEL",
+  codex: "CODEX_MODEL",
+  custom: "CUSTOM_MODEL",
+  deepseek: "DEEPSEEK_MODEL",
+  fireworks: "FIREWORKS_MODEL",
+  google: "GOOGLE_MODEL",
+  litellm: "LITELLM_MODEL",
+  lmstudio: "LMSTUDIO_MODEL",
+  ollama: "OLLAMA_MODEL",
+  openai: "OPENAI_MODEL",
+  openrouter: "OPENROUTER_MODEL",
+  together: "TOGETHER_MODEL",
+  vertex: "VERTEX_MODEL",
+};
 
 const inputClass =
   "flex h-12 w-full items-center justify-between gap-3 rounded-lg border border-[#D9DCE3] bg-white px-4 text-left text-sm text-[#191919] outline-none transition-colors hover:border-[#C8CBD3] focus:border-[#7A5AF8] focus:ring-2 focus:ring-[#7A5AF8]/15";
@@ -134,18 +168,31 @@ const deduplicateProviders = (providers: ProviderOption[]) => {
 export default function AdvancedTextProviderSettings({ config, onChange }: Props) {
   const providerListId = useId();
   const modelMaximumId = useId();
-  const reasoningToggleId = useId();
   const [providers, setProviders] = useState<ProviderOption[]>([]);
   const [providersLoading, setProvidersLoading] = useState(false);
   const [providerToAdd, setProviderToAdd] = useState("");
   const [providerPickerOpen, setProviderPickerOpen] = useState(false);
+  const [tokenDefaults, setTokenDefaults] = useState({
+    defaultMaxOutputTokens: FALLBACK_DEFAULT_MAX_OUTPUT_TOKENS,
+    modelMaxOutputTokens: FALLBACK_MODEL_MAX_OUTPUT_TOKENS,
+  });
   const hasManualMaxOutputTokens =
     typeof config.LLM_MAX_OUTPUT_TOKENS === "number" &&
     config.LLM_MAX_OUTPUT_TOKENS > 0;
   const useModelMaximum =
     config.LLM_GENERATION_PROFILE === "model_max" &&
     !hasManualMaxOutputTokens;
-  const reasoningEnabled = config.LLM_REASONING_MODE !== "disabled";
+  const reasoningMode =
+    config.LLM_REASONING_MODE === "enabled" ||
+    config.LLM_REASONING_MODE === "disabled"
+      ? config.LLM_REASONING_MODE
+      : "model_default";
+  const reasoningAvailable = reasoningMode !== "disabled";
+  const modelField = config.LLM ? MODEL_FIELDS[config.LLM] : undefined;
+  const selectedModel = modelField ? String(config[modelField] || "") : "";
+  const displayedMaxOutputTokens = useModelMaximum
+    ? tokenDefaults.modelMaxOutputTokens
+    : config.LLM_MAX_OUTPUT_TOKENS ?? tokenDefaults.defaultMaxOutputTokens;
   const order = useMemo(
     () => config.OPENROUTER_PROVIDER_ORDER || [],
     [config.OPENROUTER_PROVIDER_ORDER]
@@ -160,8 +207,37 @@ export default function AdvancedTextProviderSettings({ config, onChange }: Props
     [order, providers]
   );
 
+  useEffect(() => {
+    if (!config.LLM || config.LLM === "presenton") return;
+
+    const controller = new AbortController();
+    fetch(getApiUrl("/api/v1/ppt/generation/defaults"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: config.LLM, model: selectedModel }),
+      signal: controller.signal,
+    })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((payload) => {
+        if (
+          typeof payload?.default_max_output_tokens === "number" &&
+          typeof payload?.model_max_output_tokens === "number"
+        ) {
+          setTokenDefaults({
+            defaultMaxOutputTokens: payload.default_max_output_tokens,
+            modelMaxOutputTokens: payload.model_max_output_tokens,
+          });
+        }
+      })
+      .catch((error) => {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+      });
+
+    return () => controller.abort();
+  }, [config.LLM, selectedModel]);
+
   const setReasoningMode = (value: string) => {
-    onChange(value, "LLM_REASONING_MODE");
+    onChange(value === "model_default" ? "" : value, "LLM_REASONING_MODE");
     if (value === "disabled") {
       onChange("", "LLM_REASONING_EFFORT");
       onChange("", "LLM_REASONING_BUDGET_TOKENS");
@@ -233,6 +309,26 @@ export default function AdvancedTextProviderSettings({ config, onChange }: Props
     onChange(next, "OPENROUTER_PROVIDER_ORDER");
   };
 
+  const resetToDefaults = () => {
+    onChange("", "LLM_GENERATION_PROFILE");
+    onChange(
+      tokenDefaults.defaultMaxOutputTokens,
+      "LLM_MAX_OUTPUT_TOKENS"
+    );
+    onChange("", "LLM_REASONING_MODE");
+    onChange("", "LLM_REASONING_EFFORT");
+    onChange("", "LLM_REASONING_BUDGET_TOKENS");
+    onChange("", "DISABLE_THINKING");
+    onChange("", "EXTENDED_REASONING");
+    onChange([], "OPENROUTER_PROVIDER_ORDER");
+    onChange("", "OPENROUTER_ALLOW_FALLBACKS");
+    onChange("", "OPENROUTER_REQUIRE_PARAMETERS");
+    onChange("", "OPENROUTER_DATA_COLLECTION");
+    onChange("", "OPENROUTER_ZDR");
+    setProviderToAdd("");
+    setProviderPickerOpen(false);
+  };
+
   if (!config.LLM || config.LLM === "presenton") {
     return null;
   }
@@ -256,6 +352,16 @@ export default function AdvancedTextProviderSettings({ config, onChange }: Props
       </summary>
 
       <div className="mt-4 space-y-4">
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={resetToDefaults}
+            className="inline-flex items-center gap-2 rounded-[48px] border border-[#EDEEEF] bg-white px-4 py-2.5 text-xs font-semibold text-[#5146E5] transition hover:bg-[#F4F3FF]"
+          >
+            <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+            Reset to defaults
+          </button>
+        </div>
         <section className="space-y-6 rounded-[12px] border border-[#EDEEEF] bg-white p-6">
           <div>
             <h4 className="text-sm font-semibold text-[#191919]">
@@ -276,11 +382,7 @@ export default function AdvancedTextProviderSettings({ config, onChange }: Props
                 min={1}
                 step={1}
                 disabled={useModelMaximum}
-                value={
-                  useModelMaximum
-                    ? ""
-                    : config.LLM_MAX_OUTPUT_TOKENS ?? ""
-                }
+                value={displayedMaxOutputTokens}
                 onChange={(event) => {
                   onChange("", "LLM_GENERATION_PROFILE");
                   onChange(
@@ -319,41 +421,24 @@ export default function AdvancedTextProviderSettings({ config, onChange }: Props
               <p className="mt-1.5 text-xs leading-5 text-[#6B6C70]">
                 Leave blank to use the default, enter a manual limit, or select
                 model maximum to use the selected model&apos;s advertised limit.
+                The selected limit applies to every generation attempt,
+                including retries.
+                {!hasManualMaxOutputTokens && !useModelMaximum && (
+                  <> The effective default is shown in the field.</>
+                )}
               </p>
             </div>
 
             <div className="grid gap-5 md:grid-cols-2">
-              <div className="flex min-h-12 items-center justify-between gap-4 rounded-lg border border-[#D9DCE3] bg-white px-4 py-3">
-                <div className="min-w-0">
-                  <label
-                    htmlFor={reasoningToggleId}
-                    className="block cursor-pointer text-sm font-medium text-[#303036]"
-                  >
-                    Reasoning mode
-                  </label>
-                  <p className="mt-1 text-xs leading-5 text-[#6B6C70]">
-                    Turn reasoning on for supported models or off for faster
-                    responses.
-                  </p>
-                </div>
-                <div className="flex shrink-0 items-center gap-2">
-                  <span className="text-xs font-semibold text-[#52525B]">
-                    {reasoningEnabled ? "On" : "Off"}
-                  </span>
-                  <Switch
-                    id={reasoningToggleId}
-                    checked={reasoningEnabled}
-                    aria-label={`Turn reasoning ${reasoningEnabled ? "off" : "on"}`}
-                    onCheckedChange={() =>
-                      setReasoningMode(
-                        reasoningEnabled ? "disabled" : "enabled"
-                      )
-                    }
-                  />
-                </div>
-              </div>
+              <SettingSelect
+                label="Reasoning mode"
+                description="Use the backend model default, force reasoning on, or turn it off for faster responses."
+                value={reasoningMode}
+                options={REASONING_MODE_OPTIONS}
+                onValueChange={setReasoningMode}
+              />
 
-              {reasoningEnabled && (
+              {reasoningAvailable && (
                 <SettingSelect
                   label="Reasoning effort"
                   description="Higher effort may improve difficult generations, but can increase latency and token usage."


### PR DESCRIPTION
## Summary
- align Smart generation with the shared 50-slide product limit
- retry token-limited Smart generations with the same configured per-response token ceiling
- expose model-aware default and maximum output-token values to provider settings
- add a reset action that restores backend defaults and presents reasoning as Model default, On, or Off

## Validation
- `43 passed` across generation-default, Smart-generation, and provider-settings backend tests
- `npx eslint components/AdvancedTextProviderSettings.tsx`
- `npx tsc --noEmit --incremental false`
- verified `/api/v1/ppt/generation/defaults` is registered