### PR TITLE
fix(editor): localize vector component points

### DIFF
--- a/servers/nextjs/components/slide-editor/importing/template-v2-import.ts
+++ b/servers/nextjs/components/slide-editor/importing/template-v2-import.ts
@@ -600,22 +600,21 @@ function rawVectorFrame(
   if (readString(element.type) !== "vector") return null;
   const points = readArray(element, "points")
     .map(asRecord)
-    .filter((point): point is UnknownRecord => point != null);
-  const xs = points
-    .map((point) => readNumber(point, "x"))
-    .filter((value): value is number => value != null);
-  const ys = points
-    .map((point) => readNumber(point, "y"))
-    .filter((value): value is number => value != null);
-  if (xs.length === 0 || ys.length === 0) return null;
+    .map((point) => {
+      const x = readNumber(point ?? {}, "x");
+      const y = readNumber(point ?? {}, "y");
+      return x != null && y != null ? { x, y } : null;
+    })
+    .filter((point): point is { x: number; y: number } => point != null);
+  if (points.length === 0) return null;
 
-  const minX = Math.min(...xs);
-  const minY = Math.min(...ys);
+  const minX = Math.min(...points.map((point) => point.x));
+  const minY = Math.min(...points.map((point) => point.y));
   return {
     x: offsetX + minX,
     y: offsetY + minY,
-    width: Math.max(1, Math.max(...xs) - minX),
-    height: Math.max(1, Math.max(...ys) - minY),
+    width: Math.max(1, Math.max(...points.map((point) => point.x)) - minX),
+    height: Math.max(1, Math.max(...points.map((point) => point.y)) - minY),
   };
 }
 
@@ -683,6 +682,21 @@ function localizeRawElementToFrame(
       },
     }
     : { ...element };
+
+  if (readString(localized.type) === "vector") {
+    localized.points = readArray(localized, "points").map((point) => {
+      const rawPoint = asRecord(point);
+      if (!rawPoint) return point;
+      const x = readNumber(rawPoint, "x");
+      const y = readNumber(rawPoint, "y");
+      if (x == null || y == null) return point;
+      return {
+        ...rawPoint,
+        x: x - frame.x,
+        y: y - frame.y,
+      };
+    });
+  }
 
   if (!position) {
     const children = readArray(localized, "children");

--- a/servers/nextjs/tests/template-v2-component-bounds.test.mjs
+++ b/servers/nextjs/tests/template-v2-component-bounds.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { build } from "esbuild";
+
+let templateImport;
+let temporaryDirectory;
+
+test.before(async () => {
+  temporaryDirectory = await mkdtemp(
+    path.join(tmpdir(), "presenton-component-bounds-"),
+  );
+  const outputFile = path.join(temporaryDirectory, "template-v2-import.mjs");
+
+  await build({
+    entryPoints: [
+      path.resolve("components/slide-editor/importing/template-v2-import.ts"),
+    ],
+    outfile: outputFile,
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    tsconfig: path.resolve("tsconfig.json"),
+    logLevel: "silent",
+  });
+
+  templateImport = await import(
+    `${pathToFileURL(outputFile).href}?cache=${Date.now()}`
+  );
+});
+
+test.after(async () => {
+  if (temporaryDirectory) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("localizes point-only vectors within an unpositioned component", () => {
+  const element = templateImport.adaptTemplateV2ComponentToElement({
+    id: "vector-component",
+    elements: [
+      {
+        type: "vector",
+        points: [
+          { x: 10, y: 20 },
+          { x: 50, y: 80 },
+          { x: "invalid", y: 30 },
+        ],
+        stroke: { color: "#101828", width: 2 },
+      },
+    ],
+  });
+
+  assert.deepEqual(element.position, { x: 10, y: 20 });
+  assert.deepEqual(element.size, { width: 40, height: 60 });
+  assert.deepEqual(element.children[0].points, [
+    { x: 0, y: 0 },
+    { x: 40, y: 60 },
+  ]);
+});
+
+test("does not synthesize vector bounds from incomplete point pairs", () => {
+  const element = templateImport.adaptTemplateV2ComponentToElement({
+    id: "invalid-vector-component",
+    elements: [
+      {
+        type: "vector",
+        points: [{ x: 10 }, { y: 20 }],
+        stroke: { color: "#101828", width: 2 },
+      },
+    ],
+  });
+
+  assert.equal(element, null);
+});
+
+test("keeps vector points relative to a positioned ancestor", () => {
+  const element = templateImport.adaptTemplateV2ComponentToElement({
+    id: "nested-vector-component",
+    elements: [
+      {
+        type: "group",
+        position: { x: 20, y: 30 },
+        children: [
+          {
+            type: "vector",
+            points: [
+              { x: 5, y: 6 },
+              { x: 45, y: 66 },
+            ],
+            stroke: { color: "#101828", width: 2 },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.deepEqual(element.position, { x: 25, y: 36 });
+  assert.deepEqual(element.children[0].position, { x: -5, y: -6 });
+  assert.deepEqual(element.children[0].children[0].points, [
+    { x: 5, y: 6 },
+    { x: 45, y: 66 },
+  ]);
+});


### PR DESCRIPTION
## What

Localize point-only vector coordinates when Template V2 derives a frame for a component without its own `position`.

`rawVectorFrame` correctly uses vector points to derive the group frame. The fallback path then moved ordinary child positions into that frame, but left vector points unchanged. Since vector adaptation keeps points rather than position/size, the group and the child coordinates both applied the same offset.

The resulting element now keeps:

- the derived group position
- the derived content size
- child vector points relative to the group origin

The frame calculation also accepts only complete numeric `(x, y)` pairs, so incomplete points cannot be combined into synthetic bounds.

Fixes #877.

## Why this is relevant to Electron

The changed frontend is packaged into the Electron application by `electron/scripts/build-nextjs-resources.cjs`; this fixes the editor data consumed by that packaged UI.

## Verification

- `npm test` — 21 tests passed
- `npx tsc --noEmit` — passed
- `npm run lint -- --quiet components/slide-editor/importing/template-v2-import.ts tests/template-v2-component-bounds.test.mjs` — passed

The new regression tests bundle the public Template V2 adapter with esbuild and verify direct localization, malformed point handling, and vectors beneath positioned ancestors.

## AI assistance

This PR was AI-assisted. I reviewed the generated diff, traced the adapter/frame data flow manually, and ran the full current Next.js test suite and TypeScript check locally.
