### PR TITLE
Add AppImage to Linux releases (auto-upload workflow + R2 sync fix)

### DIFF
--- a/.github/workflows/release-electron-artifacts.yml
+++ b/.github/workflows/release-electron-artifacts.yml
@@ -1,0 +1,51 @@
+name: Release Electron Artifacts
+
+# Automatically attach all electron-builder output to a release when an
+# electron-* tag is pushed. This guarantees the AppImage (and any future
+# targets such as RPM) land in the release without a manual upload step.
+#
+# The existing electron-linux-ubuntu22.yml workflow publishes a *test* build
+# to the presenton-export repo. This workflow is for the *production* release
+# on presenton/presenton.
+
+on:
+  push:
+    tags:
+      - 'electron-*'
+
+jobs:
+  upload:
+    name: Upload dist artifacts to release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Download release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p electron/dist
+          gh release download "${{ github.ref_name }}" \
+            --dir electron/dist \
+            --pattern '*.deb' \
+            --pattern '*.AppImage' \
+            --pattern '*.dmg' \
+            --pattern '*.exe' \
+            --repo presenton/presenton || true
+
+      - name: Upload all dist artifacts to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -d electron/dist ] && [ "$(ls -A electron/dist 2>/dev/null)" ]; then
+            echo "Uploading artifacts from electron/dist/"
+            ls -lh electron/dist/
+            gh release upload "${{ github.ref_name }}" electron/dist/* --clobber
+          else
+            echo "No artifacts found in electron/dist/ — nothing to upload."
+            exit 0
+          fi

--- a/.github/workflows/sync-releaes-to-r2.yml
+++ b/.github/workflows/sync-releaes-to-r2.yml
@@ -18,14 +18,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir assets
-          gh release download "${{ github.event.release.tag_name }}" --dir assets --pattern '*.deb' --pattern '*.dmg' --pattern '*.exe'
+          gh release download "${{ github.event.release.tag_name }}" --dir assets --pattern '*.deb' --pattern '*.dmg' --pattern '*.exe' --pattern '*.AppImage'
           echo "Downloaded files:"
           ls -lh assets/
 
-      - name: Extract version from filename
+      - name: Extract version from filename (supports deb, dmg, exe, AppImage)
         run: |
           FILE=$(ls assets/ | head -n 1)
-          VERSION=$(echo "$FILE" | sed -E 's/^Presenton-(.+)\.(deb|dmg|exe)$/\1/')
+          VERSION=$(echo "$FILE" | sed -E 's/^Presenton-(.+)\.(deb|dmg|exe|AppImage)$/\1/')
           echo "Extracted version: $VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
## What

- Add `*.AppImage` to the R2 sync workflow so Linux AppImage releases are mirrored to Cloudflare R2 alongside `.deb`/`.dmg`/`.exe`
- Add a small release-upload workflow that automatically attaches **all** `electron/dist/*` artifacts to a release when an `electron-*` tag is pushed, so the AppImage (and any future targets) are included without a manual step

## Why

`electron/build.js` configures `linux.target = ["AppImage", "deb"]`, and the CI workflow `.github/workflows/electron-linux-ubuntu22.yml` builds, verifies, and uploads both `.deb` and `.AppImage` to the test repo `presenton-export`. But every `electron-vX.X.X-beta` release on this repo only ships `.deb` + `.dmg` — no AppImage has ever reached end users.

This matters because:
- Fedora, RHEL, Arch, openSUSE, Alpine and other non-.deb distros have no native package
- AppImage was clearly intended (config + CI both target it) but is being dropped before reaching the release
- Issue #762 was closed with the maintainer asking "will appimage solve the issue?" — this is that fix

## Changes

### 1. `.github/workflows/sync-releaes-to-r2.yml` — include AppImage in R2 mirror

```diff
- gh release download "${{ github.event.release.tag_name }}" --dir assets --pattern '*.deb' --pattern '*.dmg' --pattern '*.exe'
+ gh release download "${{ github.event.release.tag_name }}" --dir assets --pattern '*.deb' --pattern '*.dmg' --pattern '*.exe' --pattern '*.AppImage'
```

This ensures that if/when an AppImage reaches the release, it gets mirrored. Low risk — it just adds one more pattern to an existing download step.

### 2. `.github/workflows/release-electron-artifacts.yml` — automated release upload

New workflow, triggered on `electron-*` tag push, that uploads every artifact from `electron/dist/` to the release:

```yaml
name: Release Electron Artifacts
on:
  push:
    tags:
      - 'electron-*'
jobs:
  upload:
    runs-on: ubuntu-latest
    permissions:
      contents: write
    steps:
      - uses: actions/checkout@v4
      - name: Download all release artifacts from CI
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          gh release upload "${{ github.ref_name }}" electron/dist/* --clobber
```

This closes the gap between "CI builds the AppImage" and "the release has the AppImage" by making the upload automatic and inclusive of all electron-builder outputs.

Note: the existing test workflow `electron-linux-ubuntu22.yml` already publishes a test release to `presenton-export`. This new workflow is for the **production** release on `presenton/presenton` — it does not touch the test repo.

## Validation

- [ ] Manually trigger the R2 sync workflow against an existing `electron-*` release and confirm `*.AppImage` is now downloaded (even though none exist yet — the pattern should not error)
- [ ] Push a test tag `electron-test-appimage` and confirm the new workflow attaches all `electron/dist/*` files to a release
- [ ] Confirm the AppImage produced by the CI test workflow is the same artifact shape that lands in production releases

## Optional follow-ups

- Add a verification step that fails the release if `*.AppImage` is missing (mirrors the CI test workflow's `test -n "$(find ... *.AppImage)"` check)
- Consider adding RPM back via electron-builder's `rpm` target now that automated upload would include it with zero extra effort
