### PR TITLE
Use Manrope as the default presentation font

### DIFF
--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/admin/AdminPanel.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/admin/AdminPanel.tsx
@@ -432,7 +432,7 @@ export default function AdminPanel({ embedded = false }: AdminPanelProps) {
     >
       <div className={embedded ? "max-w-5xl" : "mx-auto max-w-5xl"}>
         {!embedded ? (
-          <h1 className="font-syne font-medium text-[28px] font-normal tracking-[-0.84px] text-black">
+          <h1 className="font-syne font-medium text-[28px] tracking-[-0.84px] text-black">
             Admin
           </h1>
         ) : null}

--- a/servers/nextjs/app/globals.css
+++ b/servers/nextjs/app/globals.css
@@ -1,20 +1,4 @@
 @font-face {
-  font-family: "Inter";
-  font-style: normal;
-  font-weight: 100 900;
-  font-display: swap;
-  src: url("/vendor/fonts/sans_serif/inter/Inter[opsz,wght].ttf") format("truetype");
-}
-
-@font-face {
-  font-family: "Inter";
-  font-style: italic;
-  font-weight: 100 900;
-  font-display: swap;
-  src: url("/vendor/fonts/sans_serif/inter/Inter-Italic[opsz,wght].ttf") format("truetype");
-}
-
-@font-face {
   font-family: "Manrope";
   font-style: normal;
   font-weight: 200 800;

--- a/servers/nextjs/components/slide-editor/charts/TemplateV2ChartJsElement.tsx
+++ b/servers/nextjs/components/slide-editor/charts/TemplateV2ChartJsElement.tsx
@@ -68,7 +68,7 @@ const DEFAULT_CHART_COLORS = [
   "#64748B",
 ];
 
-const CHART_FONT_FAMILY = "Inter, Arial, sans-serif";
+const CHART_FONT_FAMILY = "Manrope, Arial, sans-serif";
 const DATA_LABEL_POSITIONS = new Set(["base", "mid", "top", "outside"]);
 const CHART_TITLE_DISPLAY_MAX_LENGTH = 44;
 const CHART_AXIS_TITLE_DISPLAY_MAX_LENGTH = 36;

--- a/servers/nextjs/components/slide-editor/insert/insert-elements.ts
+++ b/servers/nextjs/components/slide-editor/insert/insert-elements.ts
@@ -182,7 +182,7 @@ function makeTableCell({
 function makeBulletListElement(marker: Marker): SlideElement {
   const baseFont = {
     size: 18,
-    family: "Inter",
+    family: "Manrope",
     color: "#111111",
     bold: false,
     italic: false,
@@ -1544,7 +1544,7 @@ function createDefaultInfographicInsertElements(kind?: string): SlideElement[] {
 
 function makeSimpleTableElement(): SlideElement {
   const baseFont: Font = {
-    family: "Inter",
+    family: "Manrope",
     size: 14,
     color: "#344054",
     line_height: 1.2,

--- a/servers/nextjs/lib/template-v2-json-to-html.ts
+++ b/servers/nextjs/lib/template-v2-json-to-html.ts
@@ -133,7 +133,7 @@ const DEFAULT_CHART_COLORS = [
   "#64748B",
 ];
 
-const CHART_FONT_FAMILY = "Inter, Arial, sans-serif";
+const CHART_FONT_FAMILY = "Manrope, Arial, sans-serif";
 const TEMPLATE_V2_MATH_CSS = `
 .presenton-math{line-height:normal;overflow:visible}
 .presenton-math>.katex{color:inherit;font:inherit;line-height:inherit;white-space:nowrap}

--- a/servers/nextjs/local-font-loading-validation.test.mjs
+++ b/servers/nextjs/local-font-loading-validation.test.mjs
@@ -61,7 +61,6 @@ test("the local font catalog points to checked-in vendor assets", async () => {
 
   await Promise.all(
     [
-      "sans_serif/inter/Inter[opsz,wght].ttf",
       "sans_serif/manrope/Manrope[wght].ttf",
       "sans_serif/montserrat/Montserrat[wght].ttf",
       "serif/playfairdisplay/PlayfairDisplay[wght].ttf",


### PR DESCRIPTION
## Summary
- remove the unused Inter font-face declarations
- use Manrope for chart rendering and newly inserted slide elements
- update local font validation to match the active font catalog
- clean up the duplicate Admin heading font-weight class
