### PR TITLE
fix(mem0): serialize local Qdrant operations

### DIFF
--- a/servers/fastapi/services/chat/chat_memory_store.py
+++ b/servers/fastapi/services/chat/chat_memory_store.py
@@ -5,7 +5,10 @@ import os
 from typing import Any, Optional
 from uuid import UUID
 
-from services.mem0_oss_memory import get_shared_mem0_client
+from services.mem0_oss_memory import (
+    get_shared_mem0_client,
+    run_shared_mem0_operation,
+)
 
 LOGGER = logging.getLogger(__name__)
 CHAT_TURN_TAG = "[chat_turn]"
@@ -184,7 +187,7 @@ class ChatMemoryStore:
                 )
 
         try:
-            await asyncio.to_thread(_add)
+            await asyncio.to_thread(run_shared_mem0_operation, _add)
         except BaseException as exc:
             if not self._is_nonfatal_mem0_error(exc):
                 raise
@@ -232,7 +235,7 @@ class ChatMemoryStore:
                 )
 
         try:
-            response = await asyncio.to_thread(_search)
+            response = await asyncio.to_thread(run_shared_mem0_operation, _search)
         except BaseException as exc:
             if not self._is_nonfatal_mem0_error(exc):
                 raise
@@ -296,7 +299,7 @@ class ChatMemoryStore:
                         return client.get_all(user_id=scoped_user_id)
 
         try:
-            response = await asyncio.to_thread(_get_all)
+            response = await asyncio.to_thread(run_shared_mem0_operation, _get_all)
         except BaseException as exc:
             if not self._is_nonfatal_mem0_error(exc):
                 raise

--- a/servers/fastapi/services/mem0_oss_memory.py
+++ b/servers/fastapi/services/mem0_oss_memory.py
@@ -15,14 +15,31 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from collections.abc import Callable
 from importlib import import_module
-from typing import Any, Optional
+from typing import Any, Optional, TypeVar
 
 LOGGER = logging.getLogger(__name__)
 
 _memory_init_lock = threading.Lock()
+_memory_operation_lock = threading.RLock()
 _shared_client: Any | None = None
 _init_attempted = False
+
+_T = TypeVar("_T")
+
+
+def run_shared_mem0_operation(operation: Callable[[], _T]) -> _T:
+    """Serialize access to the process-wide local Qdrant/SQLite client.
+
+    Qdrant local mode keeps one SQLite connection on the shared Memory client.
+    The connection permits use from worker threads, but concurrent operations on
+    that same connection can fail during commit. Keep the blocking work in the
+    caller's worker thread while ensuring only one operation touches the client
+    at a time.
+    """
+    with _memory_operation_lock:
+        return operation()
 
 
 def _to_bool(value: Optional[str], default: bool = False) -> bool:

--- a/servers/fastapi/services/mem0_presentation_memory_service.py
+++ b/servers/fastapi/services/mem0_presentation_memory_service.py
@@ -5,7 +5,10 @@ import os
 from typing import Any, Optional
 from uuid import UUID
 
-from services.mem0_oss_memory import get_shared_mem0_client
+from services.mem0_oss_memory import (
+    get_shared_mem0_client,
+    run_shared_mem0_operation,
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -86,7 +89,7 @@ class Mem0PresentationMemoryService:
                 )
 
         try:
-            await asyncio.to_thread(_add)
+            await asyncio.to_thread(run_shared_mem0_operation, _add)
         except BaseException as exc:
             if not self._is_nonfatal_mem0_error(exc):
                 raise
@@ -201,7 +204,7 @@ class Mem0PresentationMemoryService:
                 )
 
         try:
-            response = await asyncio.to_thread(_search)
+            response = await asyncio.to_thread(run_shared_mem0_operation, _search)
         except BaseException as exc:
             if not self._is_nonfatal_mem0_error(exc):
                 raise

--- a/servers/fastapi/tests/test_mem0_presentation_memory_service.py
+++ b/servers/fastapi/tests/test_mem0_presentation_memory_service.py
@@ -1,8 +1,11 @@
 import asyncio
+import threading
+import time
 import uuid
 from unittest.mock import patch
 
 import services.mem0_oss_memory as mem0_oss
+from services.chat.chat_memory_store import ChatMemoryStore
 from services.mem0_presentation_memory_service import Mem0PresentationMemoryService
 
 
@@ -221,3 +224,61 @@ class TestMem0PresentationMemoryService:
             "user_id": f"presentation:{presentation_id}"
         }
         assert client.search_calls[0]["top_k"] == 5
+
+    def test_presentation_and_chat_operations_are_serialized(self):
+        class ConcurrentWriteClient(FakeMemoryClient):
+            def __init__(self):
+                super().__init__()
+                self.active_calls = 0
+                self.max_active_calls = 0
+                self.state_lock = threading.Lock()
+
+            def add(self, *args, **kwargs):
+                with self.state_lock:
+                    self.active_calls += 1
+                    self.max_active_calls = max(
+                        self.max_active_calls,
+                        self.active_calls,
+                    )
+                try:
+                    time.sleep(0.05)
+                    return super().add(*args, **kwargs)
+                finally:
+                    with self.state_lock:
+                        self.active_calls -= 1
+
+        client = ConcurrentWriteClient()
+        presentation_id = uuid.uuid4()
+        conversation_id = uuid.uuid4()
+
+        async def run_concurrent_writes():
+            presentation_memory = Mem0PresentationMemoryService()
+            chat_memory = ChatMemoryStore()
+            await asyncio.gather(
+                presentation_memory.store_generated_outlines(
+                    presentation_id,
+                    {"slides": [{"content": "One"}]},
+                ),
+                chat_memory.store_chat_turn(
+                    presentation_id=presentation_id,
+                    conversation_id=conversation_id,
+                    user_message="Tighten the copy",
+                    assistant_message="Done",
+                ),
+            )
+
+        with patch.dict(
+            "os.environ",
+            {"MEM0_ENABLED": "true"},
+            clear=False,
+        ), patch(
+            "services.mem0_presentation_memory_service.get_shared_mem0_client",
+            return_value=client,
+        ), patch(
+            "services.chat.chat_memory_store.get_shared_mem0_client",
+            return_value=client,
+        ):
+            asyncio.run(run_concurrent_writes())
+
+        assert len(client.add_calls) == 2
+        assert client.max_active_calls == 1


### PR DESCRIPTION
## Summary
- serialize all shared Mem0 operations through a process-wide reentrant lock
- cover presentation writes/searches and chat writes/searches/history reads
- add a concurrency regression test spanning presentation and chat memory

## Why
Qdrant local mode persists through one SQLite connection. Concurrent `asyncio.to_thread` operations could overlap on that connection and fail during `commit()` with `SystemError: error return without exception set`.

## Validation
- `pytest -q servers/fastapi/tests/test_mem0_presentation_memory_service.py servers/fastapi/tests/test_chat_memory_store.py` (7 passed)
- `git diff --check`