### PR TITLE
fix(admin): support clipboard fallback for API keys

### DIFF
--- a/servers/nextjs/app/(presentation-generator)/(dashboard)/admin/AdminPanel.tsx
+++ b/servers/nextjs/app/(presentation-generator)/(dashboard)/admin/AdminPanel.tsx
@@ -26,6 +26,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { notify } from "@/components/ui/sonner";
 import { sanitizeAnalyticsError } from "@/utils/analytics";
 import { formatFastApiDetail } from "@/utils/authErrors";
+import { copyTextToClipboard } from "@/utils/clipboard";
 import { MixpanelEvent, trackEvent } from "@/utils/mixpanel";
 
 type AdminUser = {
@@ -336,7 +337,7 @@ export default function AdminPanel({ embedded = false }: AdminPanelProps) {
         api_key_count_after: apiKeys.length + 1,
       });
       try {
-        await navigator.clipboard.writeText(token);
+        await copyTextToClipboard(token);
         notify.success("API key created", "The key is visible and was copied to your clipboard.");
       } catch {
         notify.success("API key created", "The key is visible below.");
@@ -387,7 +388,7 @@ export default function AdminPanel({ embedded = false }: AdminPanelProps) {
   const copyApiKey = async (apiKeyId: string) => {
     setBusy(`reveal-api-key:${apiKeyId}`);
     try {
-      await navigator.clipboard.writeText(await getApiKeyToken(apiKeyId));
+      await copyTextToClipboard(await getApiKeyToken(apiKeyId));
       notify.success("API key copied");
     } catch (copyError) {
       notify.error(

--- a/servers/nextjs/tests/clipboard.test.mjs
+++ b/servers/nextjs/tests/clipboard.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { build } from "esbuild";
+
+let copyTextToClipboard;
+let temporaryDirectory;
+
+test.before(async () => {
+  temporaryDirectory = await mkdtemp(path.join(tmpdir(), "presenton-clipboard-"));
+  const entryFile = path.join(temporaryDirectory, "entry.ts");
+  const outputFile = path.join(temporaryDirectory, "bundle.mjs");
+  await writeFile(
+    entryFile,
+    `export { copyTextToClipboard } from ${JSON.stringify(
+      path.resolve("utils/clipboard.ts"),
+    )};`,
+  );
+  await build({
+    entryPoints: [entryFile],
+    outfile: outputFile,
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    tsconfig: path.resolve("tsconfig.json"),
+    logLevel: "silent",
+  });
+  ({ copyTextToClipboard } = await import(
+    `${pathToFileURL(outputFile).href}?cache=${Date.now()}`
+  ));
+});
+
+test.after(async () => {
+  if (temporaryDirectory) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+function replaceGlobal(name, value) {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, name);
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+  return () => {
+    if (previous) Object.defineProperty(globalThis, name, previous);
+    else delete globalThis[name];
+  };
+}
+
+function createFallbackDocument({ succeeds = true } = {}) {
+  const state = {
+    appended: null,
+    command: null,
+    removed: false,
+    refocused: false,
+  };
+  const textArea = {
+    value: "",
+    style: {},
+    setAttribute() {},
+    focus() {},
+    select() {},
+    setSelectionRange() {},
+    remove() {
+      state.removed = true;
+    },
+  };
+  return {
+    state,
+    document: {
+      activeElement: {
+        focus() {
+          state.refocused = true;
+        },
+      },
+      body: {
+        appendChild(element) {
+          state.appended = element;
+        },
+      },
+      createElement(tagName) {
+        assert.equal(tagName, "textarea");
+        return textArea;
+      },
+      execCommand(command) {
+        state.command = command;
+        return succeeds;
+      },
+    },
+  };
+}
+
+test("uses the Clipboard API when it is available", async () => {
+  let copiedText;
+  const restoreNavigator = replaceGlobal("navigator", {
+    clipboard: {
+      async writeText(text) {
+        copiedText = text;
+      },
+    },
+  });
+  const restoreDocument = replaceGlobal("document", undefined);
+
+  try {
+    await copyTextToClipboard("secret-key");
+    assert.equal(copiedText, "secret-key");
+  } finally {
+    restoreDocument();
+    restoreNavigator();
+  }
+});
+
+test("falls back when navigator.clipboard is unavailable", async () => {
+  const fallback = createFallbackDocument();
+  const restoreNavigator = replaceGlobal("navigator", {});
+  const restoreDocument = replaceGlobal("document", fallback.document);
+
+  try {
+    await copyTextToClipboard("secret-key");
+    assert.equal(fallback.state.appended.value, "secret-key");
+    assert.equal(fallback.state.command, "copy");
+    assert.equal(fallback.state.removed, true);
+    assert.equal(fallback.state.refocused, true);
+  } finally {
+    restoreDocument();
+    restoreNavigator();
+  }
+});
+
+test("falls back when Clipboard API access is denied", async () => {
+  const fallback = createFallbackDocument();
+  const restoreNavigator = replaceGlobal("navigator", {
+    clipboard: {
+      async writeText() {
+        throw new Error("Clipboard permission denied");
+      },
+    },
+  });
+  const restoreDocument = replaceGlobal("document", fallback.document);
+
+  try {
+    await copyTextToClipboard("secret-key");
+    assert.equal(fallback.state.command, "copy");
+  } finally {
+    restoreDocument();
+    restoreNavigator();
+  }
+});
+
+test("reports a failure when neither copy mechanism is available", async () => {
+  const restoreNavigator = replaceGlobal("navigator", {});
+  const restoreDocument = replaceGlobal("document", undefined);
+
+  try {
+    await assert.rejects(
+      copyTextToClipboard("secret-key"),
+      /Clipboard access is not available/,
+    );
+  } finally {
+    restoreDocument();
+    restoreNavigator();
+  }
+});

--- a/servers/nextjs/utils/clipboard.ts
+++ b/servers/nextjs/utils/clipboard.ts
@@ -1,0 +1,46 @@
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (
+    typeof navigator !== "undefined" &&
+    typeof navigator.clipboard?.writeText === "function"
+  ) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Clipboard API access can be denied outside a secure context. Fall back
+      // to the synchronous browser copy command when it is available.
+    }
+  }
+
+  if (
+    typeof document === "undefined" ||
+    typeof document.execCommand !== "function"
+  ) {
+    throw new Error("Clipboard access is not available in this browser.");
+  }
+
+  const textArea = document.createElement("textarea");
+  const previouslyFocusedElement = document.activeElement as HTMLElement | null;
+  textArea.value = text;
+  textArea.setAttribute("readonly", "");
+  textArea.style.position = "fixed";
+  textArea.style.inset = "0 auto auto -9999px";
+  textArea.style.opacity = "0";
+  textArea.style.pointerEvents = "none";
+  document.body.appendChild(textArea);
+
+  let copied = false;
+  try {
+    textArea.focus();
+    textArea.select();
+    textArea.setSelectionRange(0, text.length);
+    copied = document.execCommand("copy");
+  } finally {
+    textArea.remove();
+    previouslyFocusedElement?.focus?.();
+  }
+
+  if (!copied) {
+    throw new Error("Clipboard access is not available in this browser.");
+  }
+}


### PR DESCRIPTION
## Summary

- copy admin API keys with the modern Clipboard API when available
- fall back to the browser copy command on insecure origins and embedded browsers
- cover unavailable and denied clipboard access with unit tests

## Testing

- `npm test` (33 tests passed)
- `npx eslint utils/clipboard.ts app/\(presentation-generator\)/\(dashboard\)/admin/AdminPanel.tsx tests/clipboard.test.mjs`