### PR TITLE
fix(templates): harden structured layout validation

### DIFF
--- a/servers/fastapi/templates/v2/certified_generation.py
+++ b/servers/fastapi/templates/v2/certified_generation.py
@@ -2085,38 +2085,38 @@ def _validate_flexible_plan(
                 item_indices,
                 annotated_elements,
             )
-            if flow.mode == "group":
+            if flow.mode != "group":
+                requested_mode = flow.mode
                 try:
                     if repeatable:
-                        _infer_repeat_geometry(item_indices, source_elements)
+                        inferred_mode, _inferred_detail = _infer_repeat_geometry(
+                            item_indices,
+                            source_elements,
+                        )
                     else:
-                        _infer_fixed_flow_geometry(item_indices, source_elements)
-                except ValueError:
-                    pass
+                        inferred_mode, _inferred_detail = _infer_fixed_flow_geometry(
+                            item_indices,
+                            source_elements,
+                        )
+                except ValueError as exc:
+                    LOGGER.info(
+                        "[templates.v2.generate] preserving flexible flow as group "
+                        "name=%s requested_mode=%s reason=%s",
+                        flow.name,
+                        requested_mode,
+                        exc,
+                    )
+                    flow.mode = "group"
                 else:
-                    raise ValueError(
-                        f"flexible flow {flow.name} must use an inferred flow mode"
-                    )
-            elif repeatable:
-                inferred_mode, _columns = _infer_repeat_geometry(
-                    item_indices,
-                    source_elements,
-                )
-                if inferred_mode != flow.mode:
-                    raise ValueError(
-                        f"flexible flow {flow.name} must use inferred mode "
-                        f"{inferred_mode}"
-                    )
-            else:
-                inferred_mode, _alignment = _infer_fixed_flow_geometry(
-                    item_indices,
-                    source_elements,
-                )
-                if inferred_mode != flow.mode:
-                    raise ValueError(
-                        f"flexible flow {flow.name} must use inferred mode "
-                        f"{inferred_mode}"
-                    )
+                    if inferred_mode != requested_mode:
+                        LOGGER.info(
+                            "[templates.v2.generate] preserving flexible flow as "
+                            "group name=%s requested_mode=%s inferred_mode=%s",
+                            flow.name,
+                            requested_mode,
+                            inferred_mode,
+                        )
+                        flow.mode = "group"
             return flattened
 
         root_indices = validate_flow(region.root_flow_id, ())
@@ -3718,6 +3718,9 @@ def _structured_output_repair_rules(
         ]
     if output_model is TextCapacityPlan:
         return [
+            "Return every adjustment as one complete object containing path, all "
+            "four growth fields, and both alignment fields; never split fields "
+            "across array entries.",
             "Omit every no-op adjustment whose growth values are all zero and whose alignments are both preserve.",
             "Return an empty adjustments list when no text box needs growth or an alignment change.",
         ]

--- a/servers/fastapi/templates/v2/models/layouts.py
+++ b/servers/fastapi/templates/v2/models/layouts.py
@@ -655,32 +655,5 @@ def flexible_slide_plan_llm_json_schema() -> dict:
 
 
 def text_capacity_plan_llm_json_schema() -> dict:
-    """Return an LLM contract that excludes zero-growth preserve no-ops."""
-    schema = TextCapacityPlan.model_json_schema()
-    adjustment_schema = schema["$defs"]["TextCapacityAdjustment"]
-    adjustment_schema["anyOf"] = [
-        {"properties": {field: {"minimum": 1}}}
-        for field in (
-            "left_characters",
-            "right_characters",
-            "top_lines",
-            "bottom_lines",
-        )
-    ]
-    adjustment_schema["anyOf"].extend(
-        [
-            {
-                "properties": {
-                    "horizontal_alignment": {
-                        "enum": ["left", "center", "right", "justify"]
-                    }
-                }
-            },
-            {
-                "properties": {
-                    "vertical_alignment": {"enum": ["top", "middle", "bottom"]}
-                }
-            },
-        ]
-    )
-    return schema
+    """Return a flat LLM contract; runtime validation rejects no-op adjustments."""
+    return TextCapacityPlan.model_json_schema()

--- a/servers/fastapi/tests/unit/test_templates_v2_certified_generation.py
+++ b/servers/fastapi/tests/unit/test_templates_v2_certified_generation.py
@@ -145,6 +145,71 @@ def test_certified_compiler_builds_dynamic_grid():
     )
 
 
+def test_flexible_validation_preserves_explicit_group_for_regular_geometry():
+    raw_layout = _raw_layout()
+    manifest = _manifest()
+    flexible_plan = _flexible_plan()
+    flexible_plan.regions[0].flows[0].mode = "group"
+    source_elements = raw_layout.model_dump(mode="json")["elements"]
+
+    generation._validate_flexible_plan(
+        flexible_plan,
+        manifest=manifest,
+        source_elements=source_elements,
+    )
+
+    assert flexible_plan.regions[0].flows[0].mode == "group"
+    layout = generation._compile_semantic_layout(
+        raw_layout,
+        manifest,
+        flexible_plan,
+        generation.TextCapacityPlan(adjustments=[]),
+    )
+    assert layout.components[1].elements[0].type == "group"
+
+
+def test_flexible_validation_downgrades_invalid_geometry_to_group():
+    raw_layout = _raw_layout()
+    manifest = _manifest()
+    flexible_plan = generation.FlexibleSlidePlan.model_validate(
+        {
+            "regions": [
+                {
+                    "component_id": "metrics",
+                    "root_flow_id": "metric_cards",
+                    "flows": [
+                        {
+                            "id": "metric_cards",
+                            "name": "metric_cards",
+                            "mode": "row",
+                            "items": [
+                                {"indices": [1], "flow_id": None},
+                                {"indices": [2, 3, 4], "flow_id": None},
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    source_elements = raw_layout.model_dump(mode="json")["elements"]
+
+    generation._validate_flexible_plan(
+        flexible_plan,
+        manifest=manifest,
+        source_elements=source_elements,
+    )
+
+    assert flexible_plan.regions[0].flows[0].mode == "group"
+    layout = generation._compile_semantic_layout(
+        raw_layout,
+        manifest,
+        flexible_plan,
+        generation.TextCapacityPlan(adjustments=[]),
+    )
+    assert layout.components[1].elements[0].type == "group"
+
+
 def test_certified_compiler_preserves_source_stack_across_components():
     raw_layout = generation.RawSlideLayout.model_validate(
         {
@@ -860,24 +925,20 @@ def test_flexible_retry_prompt_repeats_tree_correction_contract():
     assert "omit the region instead of guessing" in prompt
 
 
-def test_text_capacity_llm_schema_excludes_no_op_adjustments():
+def test_text_capacity_llm_schema_requires_complete_flat_adjustments():
     schema = generation._llm_output_json_schema(generation.TextCapacityPlan)
     adjustment_schema = schema["$defs"]["TextCapacityAdjustment"]
 
-    alternatives = adjustment_schema["anyOf"]
-    assert {"properties": {"bottom_lines": {"minimum": 1}}} in alternatives
-    assert {
-        "properties": {
-            "horizontal_alignment": {
-                "enum": ["left", "center", "right", "justify"]
-            }
-        }
-    } in alternatives
-    assert {
-        "properties": {
-            "vertical_alignment": {"enum": ["top", "middle", "bottom"]}
-        }
-    } in alternatives
+    assert "anyOf" not in adjustment_schema
+    assert adjustment_schema["required"] == [
+        "path",
+        "left_characters",
+        "right_characters",
+        "top_lines",
+        "bottom_lines",
+        "horizontal_alignment",
+        "vertical_alignment",
+    ]
 
 
 def test_text_capacity_retry_prompt_forbids_no_op_adjustments():
@@ -907,5 +968,7 @@ def test_text_capacity_retry_prompt_forbids_no_op_adjustments():
 
     prompt = retry_messages[-1].content
     assert "Task-specific correction rules:" in prompt
+    assert "one complete object" in prompt
+    assert "never split fields across array entries" in prompt
     assert "Omit every no-op adjustment" in prompt
     assert "Return an empty adjustments list" in prompt


### PR DESCRIPTION
## Summary
- preserve explicit group flows and downgrade mismatched or invalid inferred flow geometry to groups
- simplify the text-capacity LLM schema so adjustments remain complete flat objects
- strengthen retry guidance and add regression coverage for flow fallback and adjustment schemas

## Testing
- `.venv/bin/pytest tests/unit/test_templates_v2_certified_generation.py` (23 passed)