### PR TITLE
fix(template-v2): make fallback text editable

### DIFF
--- a/servers/fastapi/templates/v2/certified_generation.py
+++ b/servers/fastapi/templates/v2/certified_generation.py
@@ -3028,7 +3028,8 @@ def _fallback_semantic_manifest(source_layout: RawSlideLayout) -> SemanticSlideM
             "name": name,
             "decorative": (
                 False
-                if element_type in {"chart", "infographic", "table", "text-list"}
+                if element_type
+                in {"chart", "infographic", "table", "text", "text-list"}
                 else bool(element.get("decorative", True))
             ),
         }

--- a/servers/fastapi/tests/unit/test_templates_v2_certified_generation.py
+++ b/servers/fastapi/tests/unit/test_templates_v2_certified_generation.py
@@ -711,7 +711,10 @@ def test_generation_failure_falls_back_without_rewriting_source(monkeypatch):
     assert len(layout.components[0].elements) == len(raw_layout.elements)
     assert layout.components[0].elements[0].type == "vector"
     assert layout.components[0].elements[1].children[0].name == "metric_1"
-    assert layout.components[0].elements[1].children[0].decorative is True
+    assert all(
+        element.children[0].decorative is False
+        for element in layout.components[0].elements[1:]
+    )
 
 
 def test_structured_generation_honors_requested_validation_retries():


### PR DESCRIPTION
## Summary
- mark every text element as content when semantic categorization exhausts its retries
- preserve existing fallback behavior for non-text elements
- update the regression test to cover all fallback text elements

## Testing
- `servers/fastapi/.venv/bin/python -m pytest -q servers/fastapi/tests/unit/test_templates_v2_certified_generation.py` (23 passed)