### PR TITLE
feat(template-v2): improve visual fidelity

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/presentation.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/presentation.py
@@ -492,6 +492,7 @@ GENERATED_VALUE_ELEMENT_TYPES = {
     "text-list",
     "table",
     "chart",
+    "infographic",
 }
 GENERATED_TABLE_TEXT_FONT = {
     "family": "Sniglet",
@@ -849,7 +850,38 @@ def _apply_template_content_value(element: dict[str, Any], value: Any) -> dict[s
         return _apply_template_table_content(element, value)
     if element_type == "chart":
         return _apply_template_chart_content(element, value)
+    if element_type == "infographic":
+        return _apply_template_infographic_content(element, value)
     return copy.deepcopy(element)
+
+
+def _apply_template_infographic_content(
+    element: dict[str, Any],
+    value: Any,
+) -> dict[str, Any]:
+    updated = copy.deepcopy(element)
+    if not isinstance(value, dict):
+        return updated
+
+    data = value.get("data")
+    if isinstance(data, dict):
+        current_data = updated.get("data")
+        if isinstance(current_data, dict):
+            incoming_data = copy.deepcopy(data)
+            current_type = current_data.get("type")
+            if isinstance(current_type, str):
+                incoming_data["type"] = current_type
+            updated["data"] = {
+                **copy.deepcopy(current_data),
+                **incoming_data,
+            }
+        else:
+            updated["data"] = copy.deepcopy(data)
+
+    colors = value.get("colors")
+    if isinstance(colors, list) and colors:
+        updated["colors"] = copy.deepcopy(colors)
+    return updated
 
 
 def _apply_template_math_content(

--- a/servers/fastapi/pyproject.toml
+++ b/servers/fastapi/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pillow>=12.2.0",
     "psycopg[binary]>=3.2.0",
     "sqlmodel>=0.0.24",
-    "llmai==0.3.9",
+    "llmai==0.3.10",
     "jsonschema>=4.26.0",
     "python-pptx>=1.0.2",
     "fonttools>=4.55.0",

--- a/servers/fastapi/services/chat/memory_layer.py
+++ b/servers/fastapi/services/chat/memory_layer.py
@@ -35,6 +35,7 @@ from utils.asset_directory_utils import (
     normalize_slide_asset_url,
 )
 from utils.icon_weights import DEFAULT_ICON_WEIGHT, extract_icon_type_from_settings
+from utils.infographic_catalog import normalize_infographic_data
 from utils.latex_text import normalize_latex, replace_text_runs, text_runs_to_tagged_text
 from utils.outline_utils import get_presentation_title_from_presentation_outline
 from utils.outline_limits import normalize_outline_content
@@ -4064,14 +4065,20 @@ class PresentationChatMemoryLayer:
         value: dict[str, Any],
     ) -> None:
         data = value.get("data")
-        if isinstance(data, dict) and data.get("type") in {"progress_bar", "gauge"}:
-            next_data: dict[str, Any] = {"type": data["type"]}
-            for key in ("min_value", "max_value", "value"):
-                raw = data.get(key)
-                if isinstance(raw, (int, float)):
-                    next_data[key] = float(raw)
-            if {"min_value", "max_value", "value"}.issubset(next_data):
-                element["data"] = next_data
+        if isinstance(data, dict):
+            current_data = element.get("data")
+            if isinstance(current_data, dict):
+                incoming_data = copy.deepcopy(data)
+                current_type = current_data.get("type")
+                if isinstance(current_type, str):
+                    incoming_data["type"] = current_type
+                data = {**copy.deepcopy(current_data), **incoming_data}
+            infographic_type = data.get("type")
+            if isinstance(infographic_type, str):
+                element["data"] = normalize_infographic_data(
+                    infographic_type,
+                    data,
+                )
 
         colors = value.get("colors")
         if isinstance(colors, list):
@@ -4080,6 +4087,9 @@ class PresentationChatMemoryLayer:
                 for color in colors
                 if isinstance(color, str) and color.strip()
             ]
+        text_color = value.get("text_color")
+        if isinstance(text_color, str) and text_color.strip():
+            element["text_color"] = text_color
 
     @classmethod
     def _set_template_runs_text(cls, element: dict[str, Any], text: str) -> None:

--- a/servers/fastapi/templates/v2/certified_generation.py
+++ b/servers/fastapi/templates/v2/certified_generation.py
@@ -41,6 +41,8 @@ from templates.v2.models.layouts import (
     VisualChartReplacement,
     VisualDataReplacement,
     VisualDataReplacementPlan,
+    VisualInfographicReplacement,
+    VisualTextListReplacement,
     flexible_slide_plan_llm_json_schema,
     semantic_slide_manifest_llm_json_schema,
     slide_layout_llm_json_schema,
@@ -48,13 +50,14 @@ from templates.v2.models.layouts import (
     visual_data_replacement_plan_llm_json_schema,
 )
 from templates.v2.models.elements import Image as SlideImageElement
-from templates.v2.models.elements import ImageFit
+from templates.v2.models.elements import ImageFit, InfographicType
 from utils.asset_directory_utils import resolve_image_path_to_filesystem
 from utils.icon_weights import DEFAULT_ICON_TYPE
 
 DEFAULT_VALIDATION_RETRIES = 5
 MAX_PARALLEL_SLIDE_LAYOUTS = 10
 TEMPLATE_GENERATION_MAX_COMPLETION_TOKENS = 16000
+TEXT_CAPACITY_SAFETY_FACTOR = 0.85
 CONTENT_IMAGE_PLACEHOLDER_URL = "/static/images/replaceable_template_image.png"
 CONTENT_ICON_PLACEHOLDER_URL = "/static/icons/placeholder.svg"
 
@@ -169,7 +172,7 @@ Identify existing visual regions that should become structured data or list elem
 
 # Steps:
 1. Compare the reference slide image with the supplied image and grouped-region candidates.
-2. Find candidates whose pixels or child elements collectively render exactly one chart, progress bar, gauge, table, or text list.
+2. Find candidates whose pixels or child elements collectively render exactly one chart, infographic, table, or text list.
 3. Extract the visible data and styling into one typed replacement for each confident match.
 4. Return one complete VisualDataReplacementPlan JSON object.
 
@@ -177,43 +180,60 @@ Identify existing visual regions that should become structured data or list elem
 - Return a VisualDataReplacementPlan JSON object only.
 - Return every replacement, including tables, with its typed fields directly on the replacement object.
 - Reference only paths listed in visual_region_candidates.
+- Return position and size for every chart, infographic, and table replacement in the same coordinate space as its selected candidate.
+- Fit those bounds tightly around the complete structured visual, including axes, labels, legends, and table cells, while excluding transparent or unrelated padding.
+- Keep those replacement bounds inside the selected candidate. Copy the candidate bounds exactly when the structured visual uses the full candidate area.
+- Do not return position or size for text-list replacements; they reuse the selected candidate's original bounds.
 - Return an empty replacements list when there is no confident match.
 - Never replace an existing structured chart, infographic, table, or text-list; those are extracted deterministically.
 - A replacement target may be an image, or a group/container whose children collectively draw one structured region.
 - Treat a candidate as a chart only when it primarily communicates quantitative values through bars, lines, areas, slices, points, bubbles, or a radar/polar plot.
 - Treat a candidate as a progress bar only when it shows one value advancing through a bounded linear track.
 - Treat a candidate as a gauge only when it shows one value on a bounded dial, arc, ring, or meter.
-- Only progress_bar and gauge replacements may produce infographic elements; never classify another visual structure as an infographic.
+- Treat an image candidate as an infographic when the whole image is one cohesive infographic and its headings, labels, descriptions, or values are baked into that same image. Replace the complete image, including all of its embedded text, as one infographic rather than extracting a separate text-list or leaving it as an ordinary image.
+- Use kind=infographic for either a complete infographic image or a standalone progress-bar/gauge image or grouped region. Other infographic types must target one image containing the complete infographic; do not use them for a group/container assembled from independently editable shapes or text.
+- For kind=infographic, choose the closest supported data.type: progress_bar, gauge, gantt, timeline, roadmap, milestone_timeline, staircase, supply_chain, stair_step_blocks, maturity_model, pillar_framework, transformation_hub, diagonal_circles, risk_matrix, chevron_process, radial_cycle, conversion_funnel, vertical_funnel, pyramid, segmented_wheel, customer_journey, before_after, impact_effort_matrix, comparison_matrix, org_chart, decision_tree, or mind_map. Extract all legible embedded text into the selected data shape. Use vertical_funnel for vertically stacked, value-proportional funnel bands; preserve conversion_funnel for the horizontal staged funnel.
 - Treat a candidate as a table only when its content forms a clear rectangular row-and-column grid. Use the first visible row as columns and preserve every remaining row in rows.
 - Treat a candidate as a text-list only when it contains a coherent sequence of list items. Use marker=bullet for unordered/bulleted lists, marker=number for ordered/numbered lists, and marker=none only for a visibly unmarked list.
-- Do not replace timelines, process diagrams, org charts, maps, decorative geometry, photos, logos, screenshots of whole dashboards, or regions containing multiple independent structures.
+- Do not replace maps, decorative geometry, photos, logos, screenshots of whole dashboards, or regions containing multiple independent structures. A timeline, process diagram, org chart, or other supported infographic is replaceable only when one image contains the whole infographic and its text.
 - Prefer the smallest complete candidate that contains the visualization, including its internal axes, legend, and labels.
 - Do not return both a parent region and one of its descendants.
 - Transcribe visible titles, category labels, series names, numeric values, range bounds, and source text faithfully when legible.
 - When exact chart values are not printed but relative values are visually clear, use simple normalized numeric values that preserve the visible proportions; do not invent factual precision.
 - Use short generic category or series labels only when the source labels are illegible; generated slide content will replace them later.
-- Extract chart_type, palette colors, title and legend colors, axis presence and titles, axis color, gridline visibility and color, data-label position, legend visibility, categories, series, and source.
+- Extract chart_type, renderer-ordered palette colors, title, title color, legend color, general/data-label text color, axis presence and titles, axis color, gridline visibility and color, data-label position, legend visibility, categories, series, and source.
 - For pie and donut charts, return exactly one series with one value per category.
 - For every chart, each series values array must have exactly one value per category.
 - Set x_axis and y_axis false for pie, donut, polar_area, and radar charts unless explicit axes are visible.
 - Set grid colors to null when no gridlines are visible and text colors to null when they cannot be determined confidently.
-- Return colors as six-digit hexadecimal RGB strings sampled from the visible visualization, in series or slice order.
-- Preserve the visible progress/gauge minimum, maximum, value, and foreground/background palette. Use 0 and 100 only when the display is clearly percentage-based or no other scale is visible.
+- Return every color as a six-digit hexadecimal RGB string sampled from the visible visualization. Treat each colors array as renderer slots, never as an unordered palette.
+- For chart colors: pie and donut colors[i] is category/slice i. In any other multi-series chart, colors[i] is series i. In a single-series bar, horizontal bar, stacked bar, horizontal stacked bar, polar-area, scatter, or bubble chart, colors[i] is category/data point i. For a single-series line or area chart, colors[0] controls the line and area fill and later colors, when present, control successive point fills. Colors repeat cyclically only when fewer slots are returned than visible categories or series.
+- For chart text and strokes: title_color controls the chart title; legend_color controls legend labels; text_color controls data labels and general chart text; axis_color controls axis lines, ticks, tick labels, and axis-title text; grid_color controls gridlines. Return null for a role only when it is not visible or cannot be sampled confidently.
+- For infographic data.type=progress_bar or data.type=gauge, preserve the visible minimum, maximum, and value. colors[0] is the inactive track/base arc and colors[1] is the filled progress/value arc. For gauges, text_color is the center value-label color; use null for progress bars. Use 0 and 100 only when the display is clearly percentage-based or no other scale is visible.
+- For qualitative infographics, preserve visible item order and hierarchy and always order colors as [base, accent_1, accent_2, ...]. colors[0] is the visual's background/base surface; colors[1:] is the palette applied to visible items in order and cycled when necessary. For org_chart and decision_tree, colors[1 + depth] is the node color for that hierarchy depth. text_color controls shared external headings, body copy, and labels where supported; text placed inside colored nodes may use renderer-selected black or white contrast. Use null only when a shared text color cannot be determined confidently.
 - For tables, transcribe every visible cell and preserve styling through color, font_family, font_size, font_color, bold, italic, underline, and alignment. Keep rows rectangular and use null for styling that cannot be determined.
 - For text lists, transcribe each visible item without its bullet or number. Preserve the shared font styling when confidently visible and use the marker field for the list marker itself.
+- For text lists, estimate gap as the vertical empty space in pixels between consecutive item content boxes, excluding line spacing within a wrapped item.
+- Estimate marker_gap as the horizontal empty space in pixels from the visible right edge of each bullet or number to the left edge of its item text. Use 0 when marker=none.
+- Use the representative shared spacing when measurements vary slightly across items; both gap and marker_gap must be non-negative pixel values.
 """
 
 GEMINI_VISUAL_DATA_TABLE_ENCODING_PROMPT = """
-# Gemini table response encoding:
-- This section overrides the table response shape above for Gemini only. Chart, progress_bar, gauge, and text-list replacements still use their typed fields directly.
-- For a table replacement, return exactly `kind`, `path`, and `data_json`. Do not return `columns` or `rows` beside `data_json`.
+# Gemini complex visual-data response encoding:
+- This section overrides the table and infographic response shapes above for Gemini only. Chart and text-list replacements still use their typed fields directly.
+- For a table replacement, return exactly `kind`, `path`, `position`, `size`, and `data_json`. Do not return `columns` or `rows` beside `data_json`.
 - `data_json` is a JSON string whose decoded value has this exact shape:
   `{"columns": [CELL, ...], "rows": [[CELL, ...], ...]}`
 - Every `CELL` has this exact shape:
   `{"text": string, "color": null | {"color": "#RRGGBB", "opacity": number | null}, "font": null | {"size": number | null, "family": string | null, "color": "#RRGGBB" | null, "bold": boolean | null, "italic": boolean | null, "underline": boolean | null, "line_height": number | null, "letter_spacing": number | null, "ellipsis": boolean | null, "opacity": number | null}, "alignment": null | "left" | "center" | "right" | "justify"}`
 - `columns` is the first visible table row. Each entry in `rows` is one remaining visible row and must contain exactly the same number of cells as `columns`.
 - Because `data_json` is itself a string inside the response JSON, escape its inner double quotes correctly. Do not wrap it in Markdown fences.
-- Do not include `kind` or `path` inside the decoded `data_json` object.
+- Do not include `kind`, `path`, `position`, or `size` inside the decoded `data_json` object.
+- For an infographic replacement, return exactly `kind`, `path`, `position`, `size`, and `data_json`.
+- For kind=infographic, `data_json` is a JSON string whose decoded value has this exact outer shape:
+  `{"data": INFOGRAPHIC_DATA, "colors": ["#RRGGBB", ...], "text_color": "#RRGGBB" | null}`
+- INFOGRAPHIC_DATA must follow the exact selected infographic data.type schema from the response contract and include all text visible inside the source image.
+- Do not include `kind`, `path`, `position`, or `size` inside the decoded infographic `data_json` object.
 """
 
 GENERATE_FLEXIBLE_REGIONS_SYSTEM_PROMPT = """
@@ -242,6 +262,8 @@ Identify meaningful fixed flow groups and repeatable dynamic regions inside the 
 - Declare only flows referenced by the root tree. Delete orphan, superseded, and exploratory helper flows before returning.
 - Use fixed flow for semantically bound but different items whose spacing or alignment should survive content changes.
 - Put an aligned title, subtitle or badge, and description in one fixed column when shared alignment and spacing make them one visible block.
+- A fixed text column must reserve enough height for every child's declared text capacity.
+- A flex wrapper does not make an undersized title or subtitle safe; preserve enough total stack height to prevent text overlap.
 - When a badge or label background overlaps its text, nest that inseparable pair in a group and use the group as one row or column item.
 - Name compact background-and-text groups by their visible structural role; text alignment is decided in the text-layout pass.
 - Model a shared footer as one outer row containing nested rows for its independent label/value pairs.
@@ -250,6 +272,8 @@ Identify meaningful fixed flow groups and repeatable dynamic regions inside the 
 - Use a repeatable region only when every item has the same semantic field hierarchy and substantially similar visual geometry.
 - Include each repeatable item's fixed card surface, local connector, icon frame, local marker or node, and editable content together.
 - A connector is shared only when one line spans or branches across multiple items; otherwise attach it to the item whose frame, marker, or node it terminates at.
+- For a sequence separated as `A | B | C`, attach each divider to the upcoming item: B owns the first divider and C owns the second. The first item has no leading divider.
+- Never collect one-to-one item dividers in a separate scaffold; only a line that genuinely spans or branches across multiple items is shared.
 - When icons hang from separate lines, create one child group per icon node containing that node's connector, circular frame, and replaceable content icon.
 - Keep those hanging icon child groups in one parent group flow so irregular positions and overlaps remain fixed while the nodes retain one repeated item structure.
 - Connector direction or length, frame rotation, and decorative container/group wrapper differences do not prevent grouping when every node has the same connector-frame-icon roles.
@@ -321,6 +345,8 @@ Decide safe capacity growth and alignment for editable text boxes without changi
 - Expand dates and other metadata values horizontally through clear aligned space; use zero top_lines and bottom_lines to preserve their line count.
 - Give aligned metadata fields compatible horizontal expansion when they share a visual block and safe edge.
 - Allow titles, subtitles, body text, and card descriptions to expand when unused aligned space exists.
+- Count the lines required by the current text at its actual font size and width.
+- If a title or subtitle needs more lines than its declared height can hold, request missing vertical capacity; a later flex wrapper will not contain overflow.
 - Preserve width when widening would change intentional wrapping, gutters, columns, or alignment; vertical growth may still be safe.
 - Let a final body or description in a vertical content region expand downward through clear aligned space for longer content.
 - Do not treat clear space after a final body field as intentional merely because the reference copy is short.
@@ -952,7 +978,9 @@ _SEMANTIC_ELEMENT_TYPES = {
     "chart",
     "infographic",
 }
-_SUPPORTED_TEMPLATE_INFOGRAPHIC_TYPES = {"progress_bar", "gauge"}
+_SUPPORTED_TEMPLATE_INFOGRAPHIC_TYPES = {
+    infographic_type.value for infographic_type in InfographicType
+}
 _VISUAL_DATA_REGION_TYPES = {"container", "group", "image"}
 _SCHEMA_LIMIT_PAIRS = (
     ("min_length", "max_length"),
@@ -1048,8 +1076,40 @@ def _validate_visual_data_replacement_plan(
             raise ValueError(
                 f"visual data replacement has no usable bounds: {replacement.path}"
             )
+        if isinstance(replacement, VisualTextListReplacement):
+            replacement_bounds = bounds
+        else:
+            replacement_bounds = {
+                "x": replacement.position.x,
+                "y": replacement.position.y,
+                "width": replacement.size.width,
+                "height": replacement.size.height,
+            }
+            _require_finite_numbers(replacement_bounds, label="replacement bounds")
+            if (
+                replacement_bounds["width"] <= 0
+                or replacement_bounds["height"] <= 0
+            ):
+                raise ValueError(
+                    "visual data replacement must have positive size: "
+                    f"{replacement.path}"
+                )
+            if not _bounds_contains(bounds, replacement_bounds):
+                raise ValueError(
+                    "visual data replacement bounds must stay inside candidate: "
+                    f"{replacement.path}"
+                )
+        if (
+            isinstance(replacement, VisualInfographicReplacement)
+            and replacement.data.type not in {"progress_bar", "gauge"}
+            and target.get("type") != "image"
+        ):
+            raise ValueError(
+                "complete infographic replacements must target one image: "
+                f"{replacement.path}"
+            )
         if isinstance(replacement, VisualChartReplacement) and (
-            bounds["width"] < 80 or bounds["height"] < 60
+            replacement_bounds["width"] < 80 or replacement_bounds["height"] < 60
         ):
             raise ValueError(
                 f"chart replacement must be at least 80x60 px: {replacement.path}"
@@ -1074,13 +1134,23 @@ def _visual_data_replacement_element(
     target: dict[str, Any],
     replacement: VisualDataReplacement,
 ) -> dict[str, Any]:
-    bounds = _element_bounds(target)
-    if bounds is None:
+    target_bounds = _element_bounds(target)
+    if target_bounds is None:
         raise ValueError(f"replacement target has no bounds: {replacement.path}")
 
+    if isinstance(replacement, VisualTextListReplacement):
+        position = {"x": target_bounds["x"], "y": target_bounds["y"]}
+        size = {
+            "width": target_bounds["width"],
+            "height": target_bounds["height"],
+        }
+    else:
+        position = replacement.position.model_dump(mode="json")
+        size = replacement.size.model_dump(mode="json")
+
     common: dict[str, Any] = {
-        "position": {"x": bounds["x"], "y": bounds["y"]},
-        "size": {"width": bounds["width"], "height": bounds["height"]},
+        "position": position,
+        "size": size,
         "name": str(target.get("name") or replacement.kind),
         "decorative": False,
     }
@@ -1091,6 +1161,8 @@ def _visual_data_replacement_element(
     replacement_data = replacement.model_dump(mode="json")
     replacement_data.pop("kind", None)
     replacement_data.pop("path", None)
+    replacement_data.pop("position", None)
+    replacement_data.pop("size", None)
     if replacement.kind == "chart":
         return {
             "type": "chart",
@@ -1129,25 +1201,13 @@ def _visual_data_replacement_element(
             "min_item_length": (max_item_length + 1) // 2,
             "max_item_length": max_item_length,
         }
-
-    if replacement.kind not in _SUPPORTED_TEMPLATE_INFOGRAPHIC_TYPES:
-        raise ValueError(
-            f"unsupported infographic replacement kind: {replacement.kind}"
-        )
-    min_value = replacement_data.pop("min_value")
-    max_value = replacement_data.pop("max_value")
-    value = replacement_data.pop("value")
-    return {
-        "type": "infographic",
-        **common,
-        "data": {
-            "type": replacement.kind,
-            "min_value": min_value,
-            "max_value": max_value,
-            "value": value,
-        },
-        **replacement_data,
-    }
+    if replacement.kind == "infographic":
+        return {
+            "type": "infographic",
+            **common,
+            **replacement_data,
+        }
+    raise ValueError(f"unsupported visual data replacement kind: {replacement.kind}")
 
 
 def _visual_table_cell_element(cell: dict[str, Any]) -> dict[str, Any]:
@@ -1411,6 +1471,11 @@ def _validate_text_capacity_plan(
         and _element_at_semantic_path(source_elements, annotation.path).get("type")
         == "text"
     }
+    vertical_reflow_paths = _fixed_column_vertical_reflow_paths(
+        flexible_plan,
+        manifest,
+        source_elements,
+    )
     unsupported_growth_paths: set[str] = set()
     for adjustment in plan.adjustments:
         if adjustment.path not in editable_text_paths:
@@ -1430,6 +1495,11 @@ def _validate_text_capacity_plan(
                     adjustment=adjustment,
                 )
             except _TextCapacityGrowthNotApplicable as exc:
+                if (
+                    adjustment.path in vertical_reflow_paths
+                    and (adjustment.top_lines or adjustment.bottom_lines)
+                ):
+                    continue
                 unsupported_growth_paths.add(adjustment.path)
                 LOGGER.info(
                     "[templates.v2.generate] ignoring unsupported text-capacity "
@@ -1562,19 +1632,53 @@ def _semantic_path_sort_key(path: str) -> tuple[tuple[int, int | str], ...]:
 def _apply_text_capacity_plan(
     source_elements: list[dict[str, Any]],
     plan: TextCapacityPlan,
-) -> None:
+    *,
+    vertical_reflow_paths: set[str] | None = None,
+) -> set[str]:
+    vertical_reflow_paths = vertical_reflow_paths or set()
+    pending_vertical_reflow_paths: set[str] = set()
     for adjustment in plan.adjustments:
         element, siblings, boundary = _element_context_at_semantic_path(
             source_elements,
             adjustment.path,
         )
+        original_position = element.get("position") or {}
+        original_size = element.get("size") or {}
+        requested_flow_reflow = (
+            adjustment.path in vertical_reflow_paths
+            and bool(adjustment.top_lines or adjustment.bottom_lines)
+        )
+        expanded: dict[str, float] | None = None
+        max_length: int | None = None
         if _text_adjustment_requests_growth(adjustment):
-            expanded, max_length = _planned_text_capacity(
-                element,
-                siblings=siblings,
-                boundary=boundary,
-                adjustment=adjustment,
-            )
+            try:
+                expanded, max_length = _planned_text_capacity(
+                    element,
+                    siblings=siblings,
+                    boundary=boundary,
+                    adjustment=adjustment,
+                )
+            except _TextCapacityGrowthNotApplicable:
+                if not requested_flow_reflow:
+                    raise
+                geometry_adjustment = _geometry_text_capacity_adjustment(
+                    adjustment,
+                    vertical_reflow_paths=vertical_reflow_paths,
+                )
+                if _text_adjustment_requests_growth(geometry_adjustment):
+                    try:
+                        expanded, max_length = _planned_text_capacity(
+                            element,
+                            siblings=siblings,
+                            boundary=boundary,
+                            adjustment=geometry_adjustment,
+                        )
+                    except _TextCapacityGrowthNotApplicable:
+                        expanded = None
+                        max_length = None
+                pending_vertical_reflow_paths.add(adjustment.path)
+
+        if expanded is not None and max_length is not None:
             element["position"] = {"x": expanded["x"], "y": expanded["y"]}
             element["size"] = {
                 "width": expanded["width"],
@@ -1587,7 +1691,17 @@ def _apply_text_capacity_plan(
                 element,
                 max_lines=_existing_text_box_line_capacity(element),
             )
+            if requested_flow_reflow:
+                vertical_growth_applied = (
+                    expanded["height"]
+                    > float(original_size.get("height") or 0) + 0.5
+                    or expanded["y"]
+                    < float(original_position.get("y") or 0) - 0.5
+                )
+                if not vertical_growth_applied:
+                    pending_vertical_reflow_paths.add(adjustment.path)
         _apply_text_alignment_adjustment(element, adjustment)
+    return pending_vertical_reflow_paths
 
 
 def _text_adjustment_requests_growth(
@@ -1956,7 +2070,10 @@ def _estimated_text_capacity(element: dict[str, Any], *, max_lines: int) -> int:
         for run in element.get("runs", [])
         if isinstance(run, dict)
     )
-    return max(len(current_text), math.floor(capacity_units * 0.85))
+    return max(
+        len(current_text),
+        math.floor(capacity_units * TEXT_CAPACITY_SAFETY_FACTOR),
+    )
 
 
 def _normalize_existing_text_box_limits(elements: list[dict[str, Any]]) -> None:
@@ -2150,6 +2267,8 @@ def _repeat_item_structure_signature(
         element_type = element.get("type")
         if isinstance(element_type, str):
             decorative = bool(element.get("decorative", True))
+            if decorative and _is_straight_divider_vector(element):
+                return
             name = str(element.get("name") or "")
             normalized_name = _repeatable_base_name(name) if not decorative else ""
             fields.append(f"{element_type}:{decorative}:{normalized_name}")
@@ -2431,12 +2550,41 @@ def _compile_semantic_layout(
                 element["color"] = annotation.color
             if annotation.is_icon and annotation.icon_type is not None:
                 element["icon_type"] = annotation.icon_type
+    _reserve_single_line_text_overflow_space(
+        source_elements,
+        manifest,
+        text_capacity_plan,
+    )
     _normalize_existing_text_box_limits(source_elements)
     geometry_elements = copy.deepcopy(source_elements)
-    _apply_text_capacity_plan(source_elements, text_capacity_plan)
+    vertical_reflow_paths = _fixed_column_vertical_reflow_paths(
+        flexible_plan,
+        manifest,
+        source_elements,
+    )
+    pending_vertical_reflow_paths = _apply_text_capacity_plan(
+        source_elements,
+        text_capacity_plan,
+        vertical_reflow_paths=vertical_reflow_paths,
+    )
+    vertical_growth_lines = {
+        int(adjustment.path.split(".")[1]): (
+            adjustment.top_lines + adjustment.bottom_lines
+        )
+        for adjustment in text_capacity_plan.adjustments
+        if adjustment.path in pending_vertical_reflow_paths
+        and (adjustment.top_lines or adjustment.bottom_lines)
+    }
 
     regions = {region.component_id: region for region in flexible_plan.regions}
     components: list[Component] = []
+    original_component_bounds = {
+        component.id: _bounds_for_indices(
+            geometry_elements,
+            component.element_indices,
+        )
+        for component in manifest.components
+    }
     # Components render as atomic groups in list order. The semantic model may
     # return those groups in visual-reading order (for example, a title before
     # an image panel), which can move an early full-slide background above the
@@ -2468,6 +2616,7 @@ def _compile_semantic_layout(
                     source_elements,
                     component_bounds=component_bounds,
                     geometry_elements=geometry_elements,
+                    vertical_growth_lines=vertical_growth_lines,
                 )
             ]
 
@@ -2486,6 +2635,15 @@ def _compile_semantic_layout(
             )
         )
 
+    _reflow_components_after_vertical_capacity(
+        components,
+        original_bounds=original_component_bounds,
+        vertically_growing_component_ids={
+            component.id
+            for component in manifest.components
+            if set(component.element_indices).intersection(vertical_growth_lines)
+        },
+    )
     layout = SlideLayout(
         id=manifest.id,
         description=manifest.description,
@@ -2545,6 +2703,7 @@ def _compile_flexible_region(
     *,
     component_bounds: dict[str, float],
     geometry_elements: list[dict[str, Any]] | None = None,
+    vertical_growth_lines: dict[int, int] | None = None,
 ) -> dict[str, Any]:
     flow_by_id = {flow.id: flow for flow in region.flows}
     return _compile_flow_node(
@@ -2553,6 +2712,7 @@ def _compile_flexible_region(
         source_elements,
         node_bounds=component_bounds,
         geometry_elements=geometry_elements or source_elements,
+        vertical_growth_lines=vertical_growth_lines or {},
     )
 
 
@@ -2563,8 +2723,10 @@ def _compile_flow_node(
     *,
     node_bounds: dict[str, float],
     geometry_elements: list[dict[str, Any]] | None = None,
+    vertical_growth_lines: dict[int, int] | None = None,
 ) -> dict[str, Any]:
     geometry_elements = geometry_elements or source_elements
+    vertical_growth_lines = vertical_growth_lines or {}
     flow_items = _flow_node_item_indices(flow, flow_by_id)
     repeatable = _region_items_are_structurally_equivalent(
         flow_items,
@@ -2604,6 +2766,10 @@ def _compile_flow_node(
     ordered_plans = [flow.items[index] for index in item_order]
     ordered_items = [flow_items[index] for index in item_order]
     ordered_bounds = [item_bounds[index] for index in item_order]
+    geometry_item_bounds = [
+        _bounds_for_indices(geometry_elements, item) for item in flow_items
+    ]
+    ordered_geometry_bounds = [geometry_item_bounds[index] for index in item_order]
     children: list[dict[str, Any]] = []
     fluid_capable: list[bool] = []
     first_editable_names: list[str] | None = None
@@ -2620,6 +2786,7 @@ def _compile_flow_node(
                 source_elements,
                 node_bounds=bounds,
                 geometry_elements=geometry_elements,
+                vertical_growth_lines=vertical_growth_lines,
             )
             if mode == "group":
                 child["position"] = {
@@ -2708,7 +2875,9 @@ def _compile_flow_node(
             ordered_bounds,
             fluid_capable,
             mode=mode,
-            cross_size=node_bounds["width"] if mode == "column" else node_bounds["height"],
+            cross_size=node_bounds["width"]
+            if mode == "column"
+            else node_bounds["height"],
             align_items=align_items,
         )
         if (
@@ -2718,6 +2887,34 @@ def _compile_flow_node(
         ):
             align_items = "stretch"
 
+    main_axis_gap = (
+        _axis_gap(
+            ordered_bounds,
+            axis="x" if mode == "row" else "y",
+        )
+        if mode in {"row", "column"}
+        else 0.0
+    )
+    compiled_height = node_bounds["height"]
+    if not repeatable and mode == "column":
+        _apply_requested_fixed_column_vertical_growth(
+            children,
+            ordered_plans,
+            ordered_geometry_bounds,
+            vertical_growth_lines=vertical_growth_lines,
+        )
+        child_heights = [
+            float(size["height"])
+            for child in children
+            if isinstance((size := child.get("size")), dict)
+            and isinstance(size.get("height"), (int, float))
+        ]
+        if len(child_heights) == len(children):
+            compiled_height = max(
+                compiled_height,
+                sum(child_heights) + main_axis_gap * max(0, len(children) - 1),
+            )
+
     min_children = max(1, (len(children) + 1) // 2) if repeatable else len(children)
     base: dict[str, Any] = {
         "type": "group" if mode == "group" else "grid" if mode == "grid" else "flex",
@@ -2725,7 +2922,7 @@ def _compile_flow_node(
         "position": {"x": 0.0, "y": 0.0},
         "size": {
             "width": node_bounds["width"],
-            "height": node_bounds["height"],
+            "height": round(compiled_height, 2),
         },
         "children": children,
     }
@@ -2747,10 +2944,7 @@ def _compile_flow_node(
         base.update(
             {
                 "direction": mode,
-                "gap": _axis_gap(
-                    ordered_bounds,
-                    axis="x" if mode == "row" else "y",
-                ),
+                "gap": main_axis_gap,
             }
         )
         if align_items is not None:
@@ -3318,6 +3512,265 @@ def _strip_decorative_fields(value: Any) -> Any:
     if isinstance(value, list):
         return [_strip_decorative_fields(item) for item in value]
     return value
+
+
+def _is_straight_divider_vector(element: dict[str, Any]) -> bool:
+    if element.get("type") != "vector" or element.get("closed") is True:
+        return False
+    points = element.get("points")
+    if not isinstance(points, list) or len(points) != 2:
+        return False
+    if any(not isinstance(point, dict) for point in points):
+        return False
+    try:
+        delta_x = abs(float(points[1]["x"]) - float(points[0]["x"]))
+        delta_y = abs(float(points[1]["y"]) - float(points[0]["y"]))
+    except (KeyError, TypeError, ValueError):
+        return False
+    return (delta_x <= 1.0 < delta_y) or (delta_y <= 1.0 < delta_x)
+
+
+def _apply_requested_fixed_column_vertical_growth(
+    children: list[dict[str, Any]],
+    plans: list[FlexibleFlowItemPlan],
+    original_bounds: list[dict[str, float]],
+    *,
+    vertical_growth_lines: dict[int, int],
+) -> None:
+    """Grow only text leaves with explicit vertical capacity instructions."""
+    for child, plan, bounds in zip(children, plans, original_bounds):
+        if child.get("type") != "text" or plan.indices is None:
+            continue
+        requested_lines = max(
+            (vertical_growth_lines.get(index, 0) for index in plan.indices),
+            default=0,
+        )
+        if requested_lines < 1:
+            continue
+        size = child.get("size")
+        if not isinstance(size, dict):
+            continue
+
+        original = copy.deepcopy(child)
+        original["size"] = {
+            "width": float(size.get("width") or bounds["width"]),
+            "height": bounds["height"],
+        }
+        original_lines = _existing_text_box_line_capacity(original)
+        _width, height, _font_size, line_height = _text_capacity_geometry(child)
+        target_lines = min(12, original_lines + requested_lines)
+        requested_height = target_lines * line_height
+        if requested_height > height + 0.5:
+            size["height"] = round(requested_height, 2)
+        _raise_text_limits_for_geometry(child, max_lines=target_lines)
+
+
+def _component_rendered_bounds(component: Component) -> dict[str, float]:
+    elements = [
+        element.model_dump(mode="json", exclude_none=True)
+        for element in component.elements
+    ]
+    bounds = _bounds_for_indices(elements, list(range(len(elements))))
+    return {
+        "x": component.position.x + bounds["x"],
+        "y": component.position.y + bounds["y"],
+        "width": bounds["width"],
+        "height": bounds["height"],
+    }
+
+
+def _fixed_column_vertical_reflow_paths(
+    flexible_plan: FlexibleSlidePlan,
+    manifest: SemanticSlideManifest,
+    source_elements: list[dict[str, Any]],
+) -> set[str]:
+    """Return top-level text leaves whose column can absorb vertical growth."""
+    editable_paths = {
+        annotation.path
+        for annotation in manifest.annotations
+        if not annotation.decorative
+    }
+    paths: set[str] = set()
+    for region in flexible_plan.regions:
+        for flow in region.flows:
+            if flow.mode != "column":
+                continue
+            for item in flow.items:
+                if item.indices is None or len(item.indices) != 1:
+                    continue
+                index = item.indices[0]
+                path = f"elements.{index}"
+                if (
+                    path in editable_paths
+                    and source_elements[index].get("type") == "text"
+                ):
+                    paths.add(path)
+    return paths
+
+
+def _geometry_text_capacity_adjustment(
+    adjustment: TextCapacityAdjustment,
+    *,
+    vertical_reflow_paths: set[str],
+) -> TextCapacityAdjustment:
+    if (
+        adjustment.path not in vertical_reflow_paths
+        or not (adjustment.top_lines or adjustment.bottom_lines)
+    ):
+        return adjustment
+    return adjustment.model_copy(
+        update={
+            "top_lines": 0,
+            "bottom_lines": 0,
+        }
+    )
+
+
+def _reflow_components_after_vertical_capacity(
+    components: list[Component],
+    *,
+    original_bounds: dict[str, dict[str, float]],
+    vertically_growing_component_ids: set[str],
+) -> None:
+    """Preserve spacing below wrappers enlarged by explicit vertical requests."""
+    if not vertically_growing_component_ids:
+        return
+
+    components_by_id = {component.id: component for component in components}
+    affected_component_ids = set(vertically_growing_component_ids)
+    ordered_ids = sorted(
+        vertically_growing_component_ids,
+        key=lambda component_id: original_bounds[component_id]["y"],
+    )
+    for component_id in ordered_ids:
+        component = components_by_id[component_id]
+        current = _component_rendered_bounds(component)
+        original = original_bounds[component_id]
+        growth = current["height"] - original["height"]
+        if growth <= 0.5:
+            continue
+        original_bottom = original["y"] + original["height"]
+        for other in components:
+            if other.id == component_id:
+                continue
+            other_original = original_bounds[other.id]
+            if other_original["y"] < original_bottom - 0.5:
+                continue
+            other_current = _component_rendered_bounds(other)
+            if not _ranges_overlap(
+                current["x"],
+                current["x"] + current["width"],
+                other_current["x"],
+                other_current["x"] + other_current["width"],
+            ):
+                continue
+            other.position.y = round(other.position.y + growth, 2)
+            affected_component_ids.add(other.id)
+
+    for component_id in affected_component_ids:
+        component = components_by_id[component_id]
+        bounds = _component_rendered_bounds(component)
+        if bounds["y"] < -0.5 or bounds["y"] + bounds["height"] > 720.5:
+            raise ValueError(
+                "explicit vertical text-capacity growth moves a component "
+                f"outside the slide: {component.id}"
+            )
+
+
+def _reserve_single_line_text_overflow_space(
+    elements: list[dict[str, Any]],
+    manifest: SemanticSlideManifest,
+    text_capacity_plan: TextCapacityPlan,
+) -> None:
+    """Give compact metric values physical substitution headroom."""
+    growth_adjusted_paths = {
+        adjustment.path
+        for adjustment in text_capacity_plan.adjustments
+        if _text_adjustment_requests_growth(adjustment)
+    }
+    for annotation in manifest.annotations:
+        name_tokens = set(annotation.name.lower().split("_"))
+        if (
+            annotation.decorative
+            or annotation.path in growth_adjusted_paths
+            or not {"metric", "value"}.issubset(name_tokens)
+        ):
+            continue
+        element, siblings, boundary = _element_context_at_semantic_path(
+            elements,
+            annotation.path,
+        )
+        if (
+            element.get("type") != "text"
+            or _existing_text_box_line_capacity(element) != 1
+            or abs(float(element.get("rotation") or 0)) > 0.1
+        ):
+            continue
+
+        position = element.get("position")
+        size = element.get("size")
+        if not isinstance(position, dict) or not isinstance(size, dict):
+            continue
+        width = float(size.get("width") or 0)
+        height = float(size.get("height") or 0)
+        if width <= 0 or height <= 0:
+            continue
+
+        horizontal_alignment = (element.get("alignment") or {}).get("horizontal")
+        if horizontal_alignment == "right":
+            directions = {"left"}
+        elif horizontal_alignment in {"center", "justify"}:
+            directions = {"left", "right"}
+        else:
+            directions = {"right"}
+
+        original = {
+            "x": float(position.get("x") or 0),
+            "y": float(position.get("y") or 0),
+            "width": width,
+            "height": height,
+        }
+        available = _expand_text_bounds(
+            original,
+            siblings=siblings,
+            boundary=boundary,
+            directions=directions,
+            target=element,
+        )
+        desired_width = width / TEXT_CAPACITY_SAFETY_FACTOR
+        extra_width = desired_width - width
+        if extra_width <= 0:
+            continue
+
+        original_right = original["x"] + width
+        if directions == {"left"}:
+            left = max(available["x"], original["x"] - extra_width)
+            right = original_right
+        elif directions == {"left", "right"}:
+            half_extra = extra_width / 2
+            left = max(available["x"], original["x"] - half_extra)
+            right = min(
+                available["x"] + available["width"],
+                original_right + half_extra,
+            )
+        else:
+            left = original["x"]
+            right = min(
+                available["x"] + available["width"],
+                original_right + extra_width,
+            )
+
+        expanded_width = right - left
+        if expanded_width <= width + 0.5:
+            continue
+        element["position"] = {
+            **position,
+            "x": round(left, 2),
+        }
+        element["size"] = {
+            **size,
+            "width": round(expanded_width, 2),
+        }
 
 
 def _openai_image_part(slide_image_url: str) -> ImageContentPart:

--- a/servers/fastapi/templates/v2/certified_generation.py
+++ b/servers/fastapi/templates/v2/certified_generation.py
@@ -142,7 +142,10 @@ Analyze the reference slide and return semantic metadata for its existing source
 - decorative=true means the value is fixed visual scaffolding and must remain unchanged.
 - Treat visible text and its apparent meaning as replaceable unless it is a logo or watermark.
 - Treat charts, tables, metrics, semantic images, and topic icons as replaceable content.
-- Only progress bars and gauges are supported as infographics; keep every other infographic or qualitative diagram as fixed visual scaffolding.
+- Treat each structured table as one atomic editable element; headers, cells, cell text, fills, borders, and grid lines are internal table data.
+- Treat each structured chart as one atomic editable element; its title, plot, labels, legend, gridlines, axes, ticks, and source are internal chart data.
+- Never split, separately name, annotate, or group a table or chart internal as another editable element; one table or chart maps to one annotation.
+- Treat supported structured infographics as replaceable content. Keep only unsupported qualitative diagrams as fixed visual scaffolding.
 - Treat connector and branching lines, rings, arcs, circle outlines, Venn-diagram circles, backgrounds, logos, frames, borders, and dividers as decorative.
 - Classify by whether the new slide's content generator should replace the value: a ring around a replaceable topic icon is decorative, while the icon is content.
 - Set is_icon for every image annotation: true for a compact symbolic icon intended for icon search, and false for a photo, screenshot, or illustration.
@@ -187,6 +190,13 @@ Identify existing visual regions that should become structured data or list elem
 - Return an empty replacements list when there is no confident match.
 - Never replace an existing structured chart, infographic, table, or text-list; those are extracted deterministically.
 - A replacement target may be an image, or a group/container whose children collectively draw one structured region.
+- Atomicity is mandatory: one recognized table or chart must become exactly one typed replacement containing all of its internal visual content.
+- For a table, include every header and body cell, all cell text, fills, borders, and row and column lines only in the single kind=table replacement.
+- Never emit table cells, rows, headers, borders, or their text as separate replacements, including text-list replacements.
+- For a chart, include its title, plot, marks, data labels, category and series labels, legend, gridlines, axes, ticks, axis titles, and source only in one kind=chart replacement.
+- Never emit or leave any chart internal listed above as a separate sibling or descendant element or replacement.
+- Select the smallest common candidate that contains the complete table or chart and no unrelated content.
+- If no candidate contains the complete table or chart without unrelated content, return no replacement for it instead of replacing only part of it.
 - Treat a candidate as a chart only when it primarily communicates quantitative values through bars, lines, areas, slices, points, bubbles, or a radar/polar plot.
 - Treat a candidate as a progress bar only when it shows one value advancing through a bounded linear track.
 - Treat a candidate as a gauge only when it shows one value on a bounded dial, arc, ring, or meter.

--- a/servers/fastapi/templates/v2/models/elements.py
+++ b/servers/fastapi/templates/v2/models/elements.py
@@ -248,6 +248,8 @@ class TextList(BaseModel):  # Konva Group
     rotation: Optional[float] = None
     font: Optional[Font] = None
     marker: Optional[Marker] = None
+    gap: Optional[float] = None
+    marker_gap: Optional[float] = None
     items: list[list[TextRunValue]]
 
     # Schema
@@ -329,6 +331,7 @@ class Chart(BaseModel):
     title: Optional[str] = None
     title_color: Optional[str] = None
     legend_color: Optional[str] = None
+    text_color: Optional[str] = None
 
     # PPTX chart model emitted by the template-v2 converter.
     colors: Optional[list[str]] = None
@@ -400,6 +403,7 @@ class InfographicType(str, Enum):
     CHEVRON_PROCESS = "chevron_process"
     RADIAL_CYCLE = "radial_cycle"
     CONVERSION_FUNNEL = "conversion_funnel"
+    VERTICAL_FUNNEL = "vertical_funnel"
     PYRAMID = "pyramid"
     SEGMENTED_WHEEL = "segmented_wheel"
     CUSTOMER_JOURNEY = "customer_journey"
@@ -412,17 +416,33 @@ class InfographicType(str, Enum):
 
 
 class ProgressBarInfographicData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     type: Literal["progress_bar"]
     max_value: float
     min_value: float
     value: float
 
+    @model_validator(mode="after")
+    def _validate_range(self) -> "ProgressBarInfographicData":
+        if self.max_value <= self.min_value:
+            raise ValueError("max_value must be greater than min_value")
+        return self
+
 
 class GaugeInfographicData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     type: Literal["gauge"]
     max_value: float
     min_value: float
     value: float
+
+    @model_validator(mode="after")
+    def _validate_range(self) -> "GaugeInfographicData":
+        if self.max_value <= self.min_value:
+            raise ValueError("max_value must be greater than min_value")
+        return self
 
 
 StructuralInfographicType = Literal[
@@ -441,6 +461,7 @@ StructuralInfographicType = Literal[
     "chevron_process",
     "radial_cycle",
     "conversion_funnel",
+    "vertical_funnel",
     "pyramid",
     "segmented_wheel",
     "customer_journey",
@@ -469,19 +490,22 @@ class StructuralInfographicData(BaseModel):
         return normalize_infographic_data(infographic_type, value)  # type: ignore[arg-type]
 
 
+InfographicData = Annotated[
+    Union[
+        ProgressBarInfographicData,
+        GaugeInfographicData,
+        StructuralInfographicData,
+    ],
+    Field(discriminator="type"),
+]
+
+
 class Infographic(BaseModel):
     type: Literal["infographic"]
     position: Optional[Position] = None
     size: Optional[Size] = None
     rotation: Optional[float] = None
-    data: Annotated[
-        Union[
-            ProgressBarInfographicData,
-            GaugeInfographicData,
-            StructuralInfographicData,
-        ],
-        Field(discriminator="type"),
-    ]
+    data: InfographicData
 
     # Design
     colors: List[str] = Field(default_factory=list)
@@ -581,6 +605,7 @@ __all__ = [
     "ImageFit",
     "IconType",
     "Infographic",
+    "InfographicData",
     "InfographicType",
     "GaugeInfographicData",
     "LayoutAlignment",

--- a/servers/fastapi/templates/v2/models/layouts.py
+++ b/servers/fastapi/templates/v2/models/layouts.py
@@ -13,8 +13,10 @@ from .elements import (
     Fill,
     Font,
     HorizontalAlignment,
+    InfographicData,
     Marker,
     Position,
+    Size,
     SlideElement,
 )
 
@@ -137,7 +139,16 @@ class SemanticElementAnnotation(BaseModel):
     )
 
 
-class VisualChartReplacement(BaseModel):
+class VisualReplacementGeometry(BaseModel):
+    """Detected structured-content bounds in the candidate's coordinate space."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    position: Position
+    size: Size
+
+
+class VisualChartReplacement(VisualReplacementGeometry):
     """One image or grouped visual region recognized as a quantitative chart."""
 
     model_config = ConfigDict(extra="forbid")
@@ -148,7 +159,17 @@ class VisualChartReplacement(BaseModel):
     title: str | None
     title_color: HexColor | None
     legend_color: HexColor | None
-    colors: list[HexColor] = Field(min_length=1, max_length=24)
+    text_color: HexColor | None = Field(
+        description="Data-label and general chart text color."
+    )
+    colors: list[HexColor] = Field(
+        min_length=1,
+        max_length=24,
+        description=(
+            "Renderer-ordered mark palette: slices/categories for category-colored "
+            "single-series charts, otherwise series order."
+        ),
+    )
     x_axis: bool
     y_axis: bool
     x_axis_title: str | None
@@ -175,45 +196,34 @@ class VisualChartReplacement(BaseModel):
         return self
 
 
-class VisualProgressBarReplacement(BaseModel):
-    """One image or grouped visual region recognized as a progress bar."""
+class VisualInfographicReplacement(VisualReplacementGeometry):
+    """One complete infographic image or grouped bounded metric region."""
 
     model_config = ConfigDict(extra="forbid")
 
-    kind: Literal["progress_bar"]
+    kind: Literal["infographic"]
     path: SemanticElementPath
-    min_value: float
-    max_value: float
-    value: float
-    colors: list[HexColor] = Field(min_length=1, max_length=4)
+    data: InfographicData
+    colors: list[HexColor] = Field(
+        min_length=2,
+        max_length=24,
+        description=(
+            "Renderer order: metric inactive/fill slots or qualitative "
+            "base/background followed by ordered accents."
+        ),
+    )
+    text_color: HexColor | None = Field(
+        description="Shared external, heading, body, and label text color."
+    )
 
     @model_validator(mode="after")
-    def _value_must_fit_range(self) -> "VisualProgressBarReplacement":
-        if self.max_value <= self.min_value:
-            raise ValueError("progress bar max_value must exceed min_value")
-        if not self.min_value <= self.value <= self.max_value:
-            raise ValueError("progress bar value must fit its declared range")
-        return self
-
-
-class VisualGaugeReplacement(BaseModel):
-    """One image or grouped visual region recognized as a quantitative gauge."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    kind: Literal["gauge"]
-    path: SemanticElementPath
-    min_value: float
-    max_value: float
-    value: float
-    colors: list[HexColor] = Field(min_length=1, max_length=8)
-
-    @model_validator(mode="after")
-    def _value_must_fit_range(self) -> "VisualGaugeReplacement":
-        if self.max_value <= self.min_value:
-            raise ValueError("gauge max_value must exceed min_value")
-        if not self.min_value <= self.value <= self.max_value:
-            raise ValueError("gauge value must fit its declared range")
+    def _metric_fields_must_be_valid(self) -> "VisualInfographicReplacement":
+        if self.data.type not in {"progress_bar", "gauge"}:
+            return self
+        if not self.data.min_value <= self.data.value <= self.data.max_value:
+            raise ValueError("metric value must fit its declared range")
+        if len(self.colors) > 8:
+            raise ValueError("metric infographic colors cannot exceed eight slots")
         return self
 
 
@@ -228,7 +238,7 @@ class VisualTableCell(BaseModel):
     alignment: HorizontalAlignment | None
 
 
-class VisualTableReplacement(BaseModel):
+class VisualTableReplacement(VisualReplacementGeometry):
     """One image or grouped visual region recognized as a table."""
 
     model_config = ConfigDict(extra="forbid")
@@ -254,16 +264,31 @@ class VisualTextListReplacement(BaseModel):
     path: SemanticElementPath
     marker: Marker
     font: Font | None
+    gap: float = Field(
+        ge=0,
+        le=720,
+        description="Vertical pixel gap between consecutive list items.",
+    )
+    marker_gap: float = Field(
+        ge=0,
+        le=1280,
+        description="Horizontal pixel gap between each marker and its item text.",
+    )
     items: list[Annotated[str, Field(min_length=1, max_length=2000)]] = Field(
         min_length=1,
         max_length=40,
     )
 
+    @model_validator(mode="after")
+    def _unmarked_list_has_no_marker_gap(self) -> "VisualTextListReplacement":
+        if self.marker == Marker.NONE and self.marker_gap != 0:
+            raise ValueError("an unmarked text list must have marker_gap=0")
+        return self
+
 
 VisualDataReplacement = Annotated[
     VisualChartReplacement
-    | VisualProgressBarReplacement
-    | VisualGaugeReplacement
+    | VisualInfographicReplacement
     | VisualTableReplacement
     | VisualTextListReplacement,
     Field(discriminator="kind"),
@@ -578,19 +603,18 @@ def semantic_slide_manifest_llm_json_schema() -> dict:
 
 
 def visual_data_replacement_plan_llm_json_schema() -> dict:
-    """Return a Gemini-safe schema with only tables using a JSON envelope."""
+    """Return a Gemini-safe schema with complex payloads in JSON envelopes."""
     schema = VisualDataReplacementPlan.model_json_schema()
     definitions = schema["$defs"]
     typed_definition_names = [
         "VisualChartReplacement",
-        "VisualProgressBarReplacement",
-        "VisualGaugeReplacement",
         "VisualTextListReplacement",
     ]
     alternatives = []
     for definition_name in typed_definition_names:
         kind_schema = definitions[definition_name]["properties"]["kind"]
-        kind_schema["enum"] = [kind_schema.pop("const")]
+        if "const" in kind_schema:
+            kind_schema["enum"] = [kind_schema.pop("const")]
         alternatives.append({"$ref": f"#/$defs/{definition_name}"})
 
     alternatives.append(
@@ -604,24 +628,77 @@ def visual_data_replacement_plan_llm_json_schema() -> dict:
                     "minLength": 10,
                     "maxLength": 240,
                 },
+                "position": {"$ref": "#/$defs/Position"},
+                "size": {"$ref": "#/$defs/Size"},
                 "data_json": {
                     "type": "string",
                     "minLength": 2,
                     "maxLength": 120000,
                 },
             },
-            "required": ["kind", "path", "data_json"],
+            "required": ["kind", "path", "position", "size", "data_json"],
+        }
+    )
+    alternatives.append(
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "kind": {"type": "string", "enum": ["infographic"]},
+                "path": {
+                    "type": "string",
+                    "minLength": 10,
+                    "maxLength": 240,
+                },
+                "position": {"$ref": "#/$defs/Position"},
+                "size": {"$ref": "#/$defs/Size"},
+                "data_json": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 120000,
+                },
+            },
+            "required": ["kind", "path", "position", "size", "data_json"],
         }
     )
     schema["properties"]["replacements"]["items"] = {"anyOf": alternatives}
-    for definition_name in (
-        "VisualTableReplacement",
-        "VisualTableCell",
-        "Fill",
-        "HorizontalAlignment",
-    ):
-        definitions.pop(definition_name, None)
+    _prune_unused_schema_definitions(schema)
     return schema
+
+
+def _prune_unused_schema_definitions(schema: dict[str, Any]) -> None:
+    definitions = schema.get("$defs")
+    if not isinstance(definitions, dict):
+        return
+
+    referenced: set[str] = set()
+
+    def collect(value: Any) -> None:
+        if isinstance(value, dict):
+            reference = value.get("$ref")
+            if isinstance(reference, str) and reference.startswith("#/$defs/"):
+                referenced.add(reference.removeprefix("#/$defs/"))
+            for key, child in value.items():
+                if key != "$defs":
+                    collect(child)
+        elif isinstance(value, list):
+            for child in value:
+                collect(child)
+
+    collect(schema)
+    pending = list(referenced)
+    while pending:
+        definition_name = pending.pop()
+        definition = definitions.get(definition_name)
+        before = set(referenced)
+        collect(definition)
+        pending.extend(referenced - before)
+
+    schema["$defs"] = {
+        name: definition
+        for name, definition in definitions.items()
+        if name in referenced
+    }
 
 
 def flexible_slide_plan_llm_json_schema() -> dict:

--- a/servers/fastapi/templates/v2/schema.py
+++ b/servers/fastapi/templates/v2/schema.py
@@ -53,7 +53,9 @@ def extract_slide_schema_from_layout(layout: RawSlideLayout) -> dict[str, Any]:
     """
     Take slide layout and return content schema from slide layout.
     """
-    return _object_schema(_properties_schema(layout.elements))
+    return _hoist_nested_schema_definitions(
+        _object_schema(_properties_schema(layout.elements))
+    )
 
 
 def get_component_schema(component: Any | dict[str, Any]) -> dict[str, Any] | None:
@@ -69,15 +71,50 @@ def get_component_schema(component: Any | dict[str, Any]) -> dict[str, Any] | No
     if not properties:
         return None
 
-    return {
-        "$schema": JSON_SCHEMA_URI,
-        "type": "object",
-        "title": component_data.get("id", "component_content"),
-        "description": component_data.get("description"),
-        "additionalProperties": False,
-        "properties": properties,
-        "required": list(properties),
-    }
+    return _hoist_nested_schema_definitions(
+        {
+            "$schema": JSON_SCHEMA_URI,
+            "type": "object",
+            "title": component_data.get("id", "component_content"),
+            "description": component_data.get("description"),
+            "additionalProperties": False,
+            "properties": properties,
+            "required": list(properties),
+        }
+    )
+
+
+def _hoist_nested_schema_definitions(schema: dict[str, Any]) -> dict[str, Any]:
+    normalized = copy.deepcopy(schema)
+    root_definitions: dict[str, Any] = {}
+
+    def visit(value: Any, *, root: bool = False) -> None:
+        if isinstance(value, list):
+            for item in value:
+                visit(item)
+            return
+        if not isinstance(value, dict):
+            return
+
+        definitions = value.get("$defs")
+        if isinstance(definitions, dict):
+            if not root:
+                value.pop("$defs")
+            for name, definition in definitions.items():
+                existing = root_definitions.get(name)
+                if existing is not None and existing != definition:
+                    raise ValueError(f"conflicting JSON Schema definition: {name}")
+                root_definitions[name] = definition
+                visit(definition)
+
+        for key, child in list(value.items()):
+            if key != "$defs":
+                visit(child)
+
+    visit(normalized, root=True)
+    if root_definitions:
+        normalized["$defs"] = root_definitions
+    return normalized
 
 
 def get_repeated_top_level_group_schema_name(elements: list[Any]) -> str | None:
@@ -243,7 +280,7 @@ def _content_schema_for_element(element: dict[str, Any]) -> dict[str, Any]:
         return _chart_content_schema()
 
     if element_type == "infographic":
-        return _infographic_content_schema()
+        return _infographic_content_schema(element)
 
     raise ValueError(f"unsupported content element type: {element_type}")
 
@@ -628,28 +665,16 @@ def _component_schema_nodes_for_element(
             else []
             for index, child in enumerate(children)
         ]
-        child_nodes = [
-            node
-            for node_set in child_node_sets
-            for node in node_set
-        ]
+        child_nodes = [node for node_set in child_node_sets for node in node_set]
         if name is None or not child_nodes:
             return child_nodes
 
-        supports_repeated_children = element_type in {"flex", "grid"} or (
-            element_type == "group"
-            and all(
-                isinstance(child, dict) and child.get("type") == "group"
-                for child in children
-            )
+        array_schema = _component_array_schema_for_repeated_children(
+            element,
+            child_node_sets,
         )
-        if supports_repeated_children:
-            array_schema = _component_array_schema_for_repeated_children(
-                element,
-                child_node_sets,
-            )
-            if array_schema is not None:
-                return [(name, array_schema)]
+        if array_schema is not None:
+            return [(name, array_schema)]
 
         return [(name, _component_object_schema_from_nodes(child_nodes))]
 
@@ -751,9 +776,7 @@ def _component_repeated_children_schema_result(
             _component_normalized_repeated_item_schema(node_set, strategy=strategy)
             for node_set in populated_node_sets
         ]
-        merged_item_schema = _component_merge_repeated_schemas(
-            normalized_item_schemas
-        )
+        merged_item_schema = _component_merge_repeated_schemas(normalized_item_schemas)
         if merged_item_schema is not None:
             min_items, max_items = _component_repeated_item_limits(
                 element,
@@ -771,7 +794,107 @@ def _component_repeated_children_schema_result(
                 strategy,
             )
 
+    # Repeated visual items can use different layout-only wrappers. A leading
+    # divider, for example, may add an extra flex/group around every item after
+    # the first even though all items expose the same editable content. Keep the
+    # hierarchical schema when it agrees, then fall back to the editable leaves
+    # when the item wrappers are clearly repeated and the leaf names are unique.
+    if _component_repeated_root_names_match(populated_node_sets):
+        flattened_node_sets = [
+            _component_flattened_content_nodes(node_set)
+            for node_set in populated_node_sets
+        ]
+        for strategy in ("numeric", "none", "prefix"):
+            if not all(
+                _component_normalized_node_names_are_unique(
+                    node_set,
+                    strategy=strategy,
+                )
+                for node_set in flattened_node_sets
+            ):
+                continue
+            normalized_item_schemas = [
+                _component_normalized_repeated_item_schema(
+                    node_set,
+                    strategy=strategy,
+                )
+                for node_set in flattened_node_sets
+            ]
+            merged_item_schema = _component_merge_repeated_schemas(
+                normalized_item_schemas
+            )
+            if merged_item_schema is not None:
+                min_items, max_items = _component_repeated_item_limits(
+                    element,
+                    len(child_node_sets),
+                )
+                return (
+                    _without_none_values(
+                        {
+                            "type": "array",
+                            "minItems": min_items,
+                            "maxItems": max_items,
+                            "items": merged_item_schema,
+                        }
+                    ),
+                    strategy,
+                )
+
     return None
+
+
+def _component_flattened_content_nodes(
+    nodes: list[tuple[str, dict[str, Any]]],
+) -> list[tuple[str, dict[str, Any]]]:
+    flattened: list[tuple[str, dict[str, Any]]] = []
+
+    def visit(name: str, schema: dict[str, Any]) -> None:
+        if isinstance(schema.get("x-element-type"), str):
+            flattened.append((name, schema))
+            return
+
+        properties = schema.get("properties")
+        if not isinstance(properties, dict):
+            return
+        for child_name, child_schema in properties.items():
+            if isinstance(child_schema, dict):
+                visit(child_name, child_schema)
+
+    for name, schema in nodes:
+        visit(name, schema)
+    return flattened
+
+
+def _component_normalized_node_names_are_unique(
+    nodes: list[tuple[str, dict[str, Any]]],
+    *,
+    strategy: str,
+) -> bool:
+    if not nodes:
+        return False
+    token = _component_normalization_token_for_nodes(nodes, strategy=strategy)
+    names = [
+        _component_strip_repeated_suffix(name, token)
+        for name, _schema in nodes
+    ]
+    return len(names) == len(set(names))
+
+
+def _component_repeated_root_names_match(
+    node_sets: list[list[tuple[str, dict[str, Any]]]],
+) -> bool:
+    if not node_sets or any(len(node_set) != 1 for node_set in node_sets):
+        return False
+
+    names = [node_set[0][0] for node_set in node_sets]
+    if len(set(names)) == 1:
+        return True
+
+    normalized_names = [
+        _component_strip_repeated_suffix(name, _component_numeric_name_token(name))
+        for name in names
+    ]
+    return len(set(normalized_names)) == 1
 
 
 def _component_repeated_item_limits(
@@ -999,7 +1122,7 @@ def _component_content_field_schema(field: dict[str, Any]) -> dict[str, Any]:
     elif element_type == "chart":
         schema = _chart_content_schema()
     elif element_type == "infographic":
-        schema = _infographic_content_schema()
+        schema = _infographic_content_schema(element)
     else:
         schema = {}
 
@@ -1126,7 +1249,7 @@ def _infographic_data_content_schema(infographic_type: str) -> dict[str, Any]:
     else:
         hierarchy = infographic_type in {"org_chart", "decision_tree"}
         item_schema = _infographic_text_item_schema(hierarchy=hierarchy)
-        if infographic_type == "conversion_funnel":
+        if infographic_type in {"conversion_funnel", "vertical_funnel"}:
             item_schema["properties"]["value"] = {"type": "number"}
             item_schema["required"] = ["value", "heading"]
         if infographic_type == "mind_map":
@@ -1137,6 +1260,12 @@ def _infographic_data_content_schema(infographic_type: str) -> dict[str, Any]:
         properties["items"] = {
             "type": "array",
             "minItems": 1,
+            **(
+                {"maxItems": 8}
+                if infographic_type
+                in {"conversion_funnel", "vertical_funnel"}
+                else {}
+            ),
             "items": item_schema,
         }
         required.append("items")
@@ -1167,22 +1296,31 @@ def _infographic_data_content_schema(infographic_type: str) -> dict[str, Any]:
     }
 
 
-def _infographic_content_schema() -> dict[str, Any]:
+def _infographic_content_schema(
+    element: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    data = element.get("data") if isinstance(element, dict) else None
+    infographic_type = data.get("type") if isinstance(data, dict) else None
+    if infographic_type in INFOGRAPHIC_BY_TYPE:
+        return {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "data": _infographic_data_content_schema(infographic_type)
+            },
+            "required": ["data"],
+        }
+
     return {
         "type": "object",
         "additionalProperties": False,
         "properties": {
             "data": {
                 "oneOf": [
-                    _infographic_data_content_schema(infographic_type)
-                    for infographic_type in INFOGRAPHIC_BY_TYPE
+                    _infographic_data_content_schema("progress_bar"),
+                    _infographic_data_content_schema("gauge"),
                 ]
-            },
-            "colors": {
-                "type": "array",
-                "items": {"type": "string"},
-                "minItems": 1,
-            },
+            }
         },
         "required": ["data"],
     }

--- a/servers/fastapi/templates/v2/schema.py
+++ b/servers/fastapi/templates/v2/schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import math
 import re
 from typing import Any
 
@@ -43,10 +44,140 @@ COMPONENT_SCHEMA_METADATA_KEYS = {
     "x-element-type",
     "x-element-path",
 }
+TABLE_CELL_HORIZONTAL_PADDING = 12.0
+TABLE_CELL_VERTICAL_PADDING = 6.0
+TABLE_DEFAULT_FONT_SIZE = 14.0
+TABLE_TEXT_CAPACITY_SAFETY_FACTOR = 0.85
 
 
 def _is_editable_element(element: dict[str, Any]) -> bool:
     return element.get("decorative") is False
+
+
+def _table_text_limits(
+    element: dict[str, Any],
+) -> tuple[tuple[int | None, int | None], tuple[int | None, int | None]]:
+    size = element.get("size")
+    if not isinstance(size, dict):
+        return (None, None), (None, None)
+
+    width = _positive_number(size.get("width"))
+    height = _positive_number(size.get("height"))
+    if width is None or height is None:
+        return (None, None), (None, None)
+
+    columns = [cell for cell in element.get("columns", []) if isinstance(cell, dict)]
+    rows = [row for row in element.get("rows", []) if isinstance(row, list)]
+    body_cells = [cell for row in rows for cell in row if isinstance(cell, dict)]
+
+    column_count = element.get("max_columns")
+    if not isinstance(column_count, int) or isinstance(column_count, bool):
+        column_count = len(columns)
+    column_count = max(1, column_count)
+
+    row_count = element.get("max_rows")
+    if not isinstance(row_count, int) or isinstance(row_count, bool):
+        row_count = len(rows)
+    row_count = max(0, row_count)
+
+    cell_width = max(
+        1.0,
+        width / column_count - 2 * TABLE_CELL_HORIZONTAL_PADDING,
+    )
+    cell_height = max(
+        1.0,
+        height / (row_count + 1) - 2 * TABLE_CELL_VERTICAL_PADDING,
+    )
+    return (
+        _table_section_text_limits(
+            columns,
+            cell_width=cell_width,
+            cell_height=cell_height,
+        ),
+        _table_section_text_limits(
+            body_cells,
+            cell_width=cell_width,
+            cell_height=cell_height,
+            fallback_cells=columns,
+        ),
+    )
+
+
+def _table_section_text_limits(
+    cells: list[dict[str, Any]],
+    *,
+    cell_width: float,
+    cell_height: float,
+    fallback_cells: list[dict[str, Any]] | None = None,
+) -> tuple[int, int]:
+    glyph_width, line_height = _table_cell_typography(cells or fallback_cells or [])
+    characters_per_line = max(1, math.floor(cell_width / glyph_width))
+    line_count = max(1, math.floor(cell_height / line_height + 0.15))
+    estimated_maximum = max(
+        1,
+        math.floor(
+            characters_per_line * line_count * TABLE_TEXT_CAPACITY_SAFETY_FACTOR
+        ),
+    )
+    texts = [_table_cell_text(cell) for cell in cells]
+    observed_maximum = max((len(text) for text in texts), default=0)
+    minimum = 1 if texts and all(text.strip() for text in texts) else 0
+    return minimum, max(estimated_maximum, observed_maximum)
+
+
+def _table_cell_typography(cells: list[dict[str, Any]]) -> tuple[float, float]:
+    fonts: list[dict[str, Any]] = []
+    for cell in cells:
+        cell_font = cell.get("font")
+        if isinstance(cell_font, dict):
+            fonts.append(cell_font)
+        for run in cell.get("runs", []):
+            if not isinstance(run, dict):
+                continue
+            run_font = run.get("font")
+            if isinstance(run_font, dict):
+                fonts.append(run_font)
+
+    if not fonts:
+        fonts = [{}]
+
+    glyph_widths: list[float] = []
+    line_heights: list[float] = []
+    for font in fonts:
+        font_size = _positive_number(font.get("size")) or TABLE_DEFAULT_FONT_SIZE
+        width_factor = 0.62 if font.get("bold") is True else 0.58
+        letter_spacing = _nonnegative_number(font.get("letter_spacing")) or 0.0
+        glyph_widths.append(font_size * width_factor + letter_spacing)
+
+        raw_line_height = _positive_number(font.get("line_height"))
+        if raw_line_height is None:
+            line_heights.append(font_size * 1.2)
+        elif raw_line_height > 2:
+            line_heights.append(raw_line_height)
+        else:
+            line_heights.append(font_size * raw_line_height)
+
+    return max(glyph_widths), max(line_heights)
+
+
+def _table_cell_text(cell: dict[str, Any]) -> str:
+    return "".join(
+        str(run.get("text") or run.get("latex") or "")
+        for run in cell.get("runs", [])
+        if isinstance(run, dict)
+    )
+
+
+def _positive_number(value: Any) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        return float(value)
+    return None
+
+
+def _nonnegative_number(value: Any) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value >= 0:
+        return float(value)
+    return None
 
 
 def extract_slide_schema_from_layout(layout: RawSlideLayout) -> dict[str, Any]:
@@ -260,6 +391,7 @@ def _content_schema_for_element(element: dict[str, Any]) -> dict[str, Any]:
         )
 
     if element_type == "table":
+        _, body_limits = _table_text_limits(element)
         return _compact(
             {
                 "type": "array",
@@ -270,14 +402,20 @@ def _content_schema_for_element(element: dict[str, Any]) -> dict[str, Any]:
                         "type": "array",
                         "minItems": element.get("min_columns"),
                         "maxItems": element.get("max_columns"),
-                        "items": {"type": "string"},
+                        "items": _compact(
+                            {
+                                "type": "string",
+                                "minLength": body_limits[0],
+                                "maxLength": body_limits[1],
+                            }
+                        ),
                     }
                 ),
             }
         )
 
     if element_type == "chart":
-        return _chart_content_schema()
+        return _chart_content_schema(element)
 
     if element_type == "infographic":
         return _infographic_content_schema(element)
@@ -1095,13 +1233,18 @@ def _component_content_field_schema(field: dict[str, Any]) -> dict[str, Any]:
             "maxItems": element.get("max_items"),
         }
     elif element_type == "table":
+        header_limits, body_limits = _table_text_limits(element)
         schema = {
             "type": "object",
             "additionalProperties": False,
             "properties": {
                 "columns": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {
+                        "type": "string",
+                        "minLength": header_limits[0],
+                        "maxLength": header_limits[1],
+                    },
                     "minItems": element.get("min_columns"),
                     "maxItems": element.get("max_columns"),
                 },
@@ -1109,7 +1252,11 @@ def _component_content_field_schema(field: dict[str, Any]) -> dict[str, Any]:
                     "type": "array",
                     "items": {
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {
+                            "type": "string",
+                            "minLength": body_limits[0],
+                            "maxLength": body_limits[1],
+                        },
                         "minItems": element.get("min_columns"),
                         "maxItems": element.get("max_columns"),
                     },
@@ -1120,7 +1267,7 @@ def _component_content_field_schema(field: dict[str, Any]) -> dict[str, Any]:
             "required": ["columns", "rows"],
         }
     elif element_type == "chart":
-        schema = _chart_content_schema()
+        schema = _chart_content_schema(element)
     elif element_type == "infographic":
         schema = _infographic_content_schema(element)
     else:
@@ -1338,16 +1485,20 @@ def _without_none_values(value: Any) -> Any:
     return value
 
 
-def _chart_content_schema() -> dict[str, Any]:
-    return {
-        "type": "object",
-        "additionalProperties": False,
-        "properties": {
-            "chart_type": {
-                "type": "string",
-                "enum": CHART_TYPE_VALUES,
-            },
-            "title": {"type": ["string", "null"]},
+def _chart_content_schema(element: dict[str, Any]) -> dict[str, Any]:
+    properties: dict[str, Any] = {
+        "chart_type": {
+            "type": "string",
+            "enum": CHART_TYPE_VALUES,
+        }
+    }
+
+    title = element.get("title")
+    if isinstance(title, str) and title.strip():
+        properties["title"] = {"type": "string"}
+
+    properties.update(
+        {
             "categories": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -1370,8 +1521,14 @@ def _chart_content_schema() -> dict[str, Any]:
                 },
                 "maxItems": 12,
             },
-        },
-        "required": ["chart_type", "categories", "series"],
+        }
+    )
+
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": properties,
+        "required": list(properties),
     }
 
 

--- a/servers/fastapi/templates/v2/theme.py
+++ b/servers/fastapi/templates/v2/theme.py
@@ -491,6 +491,7 @@ def _collect_element_profile(
     named_color_categories = {
         "title_color": "text",
         "legend_color": "text",
+        "text_color": "text",
         "axis_color": "stroke",
         "grid_color": "stroke",
     }

--- a/servers/fastapi/tests/unit/test_generate_slide_content.py
+++ b/servers/fastapi/tests/unit/test_generate_slide_content.py
@@ -132,4 +132,5 @@ def test_slide_content_generation_normalizes_object_schema_and_calls_llm(
     assert captured["json_schema"]["type"] == "object"
     assert "__speaker_note__" in captured["json_schema"]["properties"]
     assert captured["response_format"].json_schema == captured["json_schema"]
+    assert captured["response_format"].strict is True
     assert "# Slide Number:\n2" in captured["messages"][1].content

--- a/servers/fastapi/tests/unit/test_infographic_catalog.py
+++ b/servers/fastapi/tests/unit/test_infographic_catalog.py
@@ -13,10 +13,15 @@ from utils.infographic_catalog import (
 
 
 def test_catalog_exposes_all_native_infographic_families():
-    assert len(INFOGRAPHIC_BY_TYPE) == 26
-    assert {"gantt", "timeline", "risk_matrix", "org_chart", "mind_map"} <= set(
-        INFOGRAPHIC_BY_TYPE
-    )
+    assert len(INFOGRAPHIC_BY_TYPE) == 27
+    assert {
+        "gantt",
+        "timeline",
+        "risk_matrix",
+        "vertical_funnel",
+        "org_chart",
+        "mind_map",
+    } <= set(INFOGRAPHIC_BY_TYPE)
 
     hierarchy_matches = search_infographic_catalog(query="hierarchy")
     assert {item["type"] for item in hierarchy_matches} >= {
@@ -32,6 +37,15 @@ def test_catalog_normalizes_and_validates_structural_data():
         {"items": [{"heading": "Discover", "description": "Research"}]},
     )
     assert data["type"] == "timeline"
+
+    funnel = normalize_infographic_data(
+        "vertical_funnel",
+        {"items": [{"value": 47.9, "heading": "Interest"}]},
+    )
+    assert funnel == {
+        "type": "vertical_funnel",
+        "items": [{"value": 47.9, "heading": "Interest"}],
+    }
 
     with pytest.raises(ValueError, match="exactly four items"):
         normalize_infographic_data(

--- a/servers/fastapi/tests/unit/test_presentation_template_v2_ui.py
+++ b/servers/fastapi/tests/unit/test_presentation_template_v2_ui.py
@@ -1024,7 +1024,7 @@ def test_chat_template_image_content_stores_prompt():
     assert icon["prompt"] == "success check"
 
 
-def test_chat_template_infographic_content_updates_new_element_type():
+def test_chat_template_infographic_content_preserves_layout_element_type():
     infographic = {
         "type": "infographic",
         "decorative": False,
@@ -1051,12 +1051,53 @@ def test_chat_template_infographic_content_updates_new_element_type():
     )
 
     assert infographic["data"] == {
-        "type": "gauge",
+        "type": "progress_bar",
         "min_value": 20.0,
         "max_value": 80.0,
         "value": 64.0,
     }
     assert infographic["colors"] == ["F2F4F7", "12B76A"]
+
+
+def test_apply_template_content_to_ui_hydrates_vertical_funnel_data():
+    ui = {
+        "components": [
+            {
+                "id": "funnel",
+                "elements": [
+                    {
+                        "type": "infographic",
+                        "decorative": False,
+                        "name": "stages",
+                        "data": {
+                            "type": "vertical_funnel",
+                            "items": [{"value": 100, "heading": "Awareness"}],
+                        },
+                        "colors": ["FFFFFF", "102E79"],
+                    }
+                ],
+            }
+        ]
+    }
+
+    hydrated = presentation_endpoint._apply_template_content_to_ui(
+        ui,
+        {
+            "funnel": {
+                "stages": {
+                    "data": {
+                        "type": "conversion_funnel",
+                        "items": [{"value": 42, "heading": "Qualified"}],
+                    }
+                }
+            }
+        },
+    )
+
+    assert hydrated["components"][0]["elements"][0]["data"] == {
+        "type": "vertical_funnel",
+        "items": [{"value": 42, "heading": "Qualified"}],
+    }
 
 
 def test_apply_template_image_content_avoids_stretching_generated_photos():
@@ -1638,3 +1679,85 @@ def test_chat_template_content_hydrates_direct_repeated_images():
     image = ui["components"][0]["elements"][0]["children"][0]
     assert image["data"] == "/app_data/images/landscape.png"
     assert image["prompt"] == "Generated landscape"
+
+
+def test_layout_only_repeated_item_wrappers_hydrate_from_flat_array_items():
+    def text(name, value):
+        return {
+            "type": "text",
+            "name": name,
+            "decorative": False,
+            "runs": [{"text": value}],
+        }
+
+    def fields(value, heading):
+        return [text("metric_value", value), text("metric_heading", heading)]
+
+    divider = {
+        "type": "vector",
+        "decorative": True,
+        "points": [{"x": 0, "y": 0}, {"x": 200, "y": 0}],
+    }
+    ui = {
+        "components": [
+            {
+                "id": "metrics_panel",
+                "elements": [
+                    {
+                        "type": "group",
+                        "name": "metric_items",
+                        "children": [
+                            {
+                                "type": "flex",
+                                "name": "metric_item_1",
+                                "children": fields("68%", "Mobile-first"),
+                            },
+                            {
+                                "type": "flex",
+                                "name": "metric_item_2",
+                                "children": [
+                                    divider,
+                                    {
+                                        "type": "group",
+                                        "name": "metric_content",
+                                        "children": fields("74%", "Research"),
+                                    },
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    content = {
+        "metrics_panel": {
+            "metric_items": [
+                {"metric_value": "10%", "metric_heading": "First"},
+                {"metric_value": "20%", "metric_heading": "Second"},
+            ]
+        }
+    }
+
+    hydrated = presentation_endpoint._apply_template_content_to_ui(ui, content)
+    items = hydrated["components"][0]["elements"][0]["children"]
+
+    def editable_text(item, name):
+        stack = [item]
+        while stack:
+            current = stack.pop()
+            if current.get("type") == "text" and current.get("name") == name:
+                return current["runs"][0]["text"]
+            stack.extend(
+                child
+                for child in current.get("children", [])
+                if isinstance(child, dict)
+            )
+        raise AssertionError(f"missing editable text field: {name}")
+
+    assert [editable_text(item, "metric_value") for item in items] == ["10%", "20%"]
+    assert [editable_text(item, "metric_heading") for item in items] == [
+        "First",
+        "Second",
+    ]
+    assert items[1]["children"][0]["type"] == "vector"

--- a/servers/fastapi/tests/unit/test_templates_v2_certified_generation.py
+++ b/servers/fastapi/tests/unit/test_templates_v2_certified_generation.py
@@ -795,14 +795,55 @@ def test_visual_data_llm_schema_uses_table_envelope_only_for_gemini():
 
     assert "discriminator" not in replacement_schema
     assert "oneOf" not in replacement_schema
-    assert len(replacement_schema["anyOf"]) == 5
-    table_schema = replacement_schema["anyOf"][-1]
+    assert len(replacement_schema["anyOf"]) == 4
+    table_schema = next(
+        alternative
+        for alternative in replacement_schema["anyOf"]
+        if alternative.get("properties", {}).get("kind", {}).get("enum") == ["table"]
+    )
     assert table_schema["properties"]["kind"]["enum"] == ["table"]
-    assert table_schema["required"] == ["kind", "path", "data_json"]
+    assert table_schema["required"] == [
+        "kind",
+        "path",
+        "position",
+        "size",
+        "data_json",
+    ]
+    assert table_schema["properties"]["position"] == {"$ref": "#/$defs/Position"}
+    assert table_schema["properties"]["size"] == {"$ref": "#/$defs/Size"}
+    infographic_schema = next(
+        alternative
+        for alternative in replacement_schema["anyOf"]
+        if alternative.get("properties", {}).get("kind", {}).get("enum")
+        == ["infographic"]
+    )
+    assert infographic_schema["required"] == [
+        "kind",
+        "path",
+        "position",
+        "size",
+        "data_json",
+    ]
+    assert "VisualInfographicReplacement" not in schema["$defs"]
 
     runtime_items = canonical_schema["properties"]["replacements"]["items"]
     assert "discriminator" in runtime_items
     assert "oneOf" in runtime_items
+    runtime_definition_names = {
+        alternative["$ref"].rsplit("/", 1)[-1]
+        for alternative in runtime_items["oneOf"]
+    }
+    assert runtime_definition_names == {
+        "VisualChartReplacement",
+        "VisualInfographicReplacement",
+        "VisualTableReplacement",
+        "VisualTextListReplacement",
+    }
+    infographic_runtime_schema = canonical_schema["$defs"][
+        "VisualInfographicReplacement"
+    ]
+    assert infographic_runtime_schema["properties"]["colors"]["minItems"] == 2
+    assert "track_height" not in str(infographic_runtime_schema)
 
     assert generation._response_schema_for_model(
         model="gpt-5.4",
@@ -826,7 +867,7 @@ def test_visual_data_table_encoding_prompt_is_only_added_for_gemini():
     )
     gemini_system_prompt = gemini_messages[0].content
     assert isinstance(gemini_system_prompt, str)
-    assert "# Gemini table response encoding:" in gemini_system_prompt
+    assert "# Gemini complex visual-data response encoding:" in gemini_system_prompt
     assert '`data_json` is a JSON string' in gemini_system_prompt
     assert '"columns": [CELL, ...]' in gemini_system_prompt
     assert '"alignment": null | "left" | "center" | "right" | "justify"' in (
@@ -850,6 +891,8 @@ def test_visual_data_table_cells_are_normalized_before_runtime_validation():
             {
                 "kind": "table",
                 "path": "elements.1",
+                "position": {"x": 120, "y": 160},
+                "size": {"width": 640, "height": 320},
                 "data_json": json.dumps(
                     {
                         "columns": [
@@ -975,3 +1018,242 @@ def test_text_capacity_retry_prompt_forbids_no_op_adjustments():
     assert "never split fields across array entries" in prompt
     assert "Omit every no-op adjustment" in prompt
     assert "Return an empty adjustments list" in prompt
+
+
+def test_repeat_signature_allows_leading_divider_on_upcoming_items():
+    source_elements = [
+        {
+            "type": "text",
+            "position": {"x": 0, "y": 0},
+            "size": {"width": 80, "height": 30},
+            "runs": [{"text": "42%"}],
+            "decorative": False,
+            "name": "metric_value_1",
+        },
+        {
+            "type": "vector",
+            "points": [{"x": 100, "y": 0}, {"x": 100, "y": 60}],
+            "closed": False,
+            "stroke": {"color": "#000000", "width": 1},
+            "decorative": True,
+        },
+        {
+            "type": "text",
+            "position": {"x": 120, "y": 0},
+            "size": {"width": 80, "height": 30},
+            "runs": [{"text": "74K"}],
+            "decorative": False,
+            "name": "metric_value_2",
+        },
+    ]
+
+    assert generation._region_items_are_structurally_equivalent(
+        [[0], [1, 2]],
+        source_elements,
+    )
+
+
+def test_layout_compilation_reserves_single_line_text_overflow_space():
+    raw_layout = generation.RawSlideLayout.model_validate(
+        {
+            "id": "metric_card",
+            "description": "A compact metric card with a one-line editable value.",
+            "elements": [
+                {
+                    "type": "group",
+                    "name": "source_metric_card",
+                    "position": {"x": 40, "y": 100},
+                    "size": {"width": 222.64, "height": 121.37},
+                    "children": [
+                        {
+                            "type": "container",
+                            "position": {"x": 0, "y": 0},
+                            "size": {"width": 222.64, "height": 121.37},
+                            "fill": {"color": "#FFFFFF"},
+                            "decorative": True,
+                        },
+                        {
+                            "type": "text",
+                            "position": {"x": 18.93, "y": 33.05},
+                            "size": {"width": 142.63, "height": 38.8},
+                            "font": {"size": 38.04, "line_height": 0.98},
+                            "runs": [{"text": "2.40M"}],
+                            "decorative": True,
+                            "name": "source_metric",
+                            "min_length": 2,
+                            "max_length": 5,
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+    manifest = generation.SemanticSlideManifest.model_validate(
+        {
+            "id": "metric_card",
+            "description": "A compact metric card with a one-line editable value.",
+            "components": [
+                {
+                    "id": "metric_card",
+                    "description": "A card containing one prominent metric value.",
+                    "element_indices": [0],
+                    "repeated_items": None,
+                }
+            ],
+            "annotations": [
+                {
+                    "path": "elements.0.children.1",
+                    "name": "metric_value",
+                    "decorative": False,
+                }
+            ],
+        }
+    )
+
+    layout = generation._compile_semantic_layout(
+        raw_layout,
+        manifest,
+        generation.FlexibleSlidePlan(regions=[]),
+        generation.TextCapacityPlan(adjustments=[]),
+    )
+    metric = layout.components[0].elements[0].children[1]
+
+    assert metric.size.width == pytest.approx(
+        142.63 / generation.TEXT_CAPACITY_SAFETY_FACTOR,
+        abs=0.01,
+    )
+    assert metric.max_length == 5
+
+
+def test_visual_data_plan_rejects_bounds_outside_candidate():
+    raw_layout = generation.RawSlideLayout.model_validate(
+        {
+            "id": "padded_table_image",
+            "description": "A table inside a larger padded source image.",
+            "elements": [
+                {
+                    "type": "image",
+                    "position": {"x": 100, "y": 120},
+                    "size": {"width": 400, "height": 240},
+                    "data": "https://example.com/list.png",
+                    "decorative": True,
+                    "name": "table_image",
+                    "is_icon": False,
+                }
+            ],
+        }
+    )
+    plan = generation.VisualDataReplacementPlan.model_validate(
+        {
+            "replacements": [
+                {
+                    "kind": "table",
+                    "path": "elements.0",
+                    "position": {"x": 90, "y": 140},
+                    "size": {"width": 300, "height": 180},
+                    "columns": [
+                        {
+                            "text": "Heading",
+                            "color": None,
+                            "font": None,
+                            "alignment": None,
+                        }
+                    ],
+                    "rows": [],
+                }
+            ]
+        }
+    )
+    _, candidate_paths = generation._visual_data_generation_payload(raw_layout)
+
+    with pytest.raises(ValueError, match="bounds must stay inside candidate"):
+        generation._validate_visual_data_replacement_plan(
+            plan,
+            candidate_paths=candidate_paths,
+            source_elements=raw_layout.model_dump(mode="json")["elements"],
+        )
+
+
+def test_visual_data_plan_rejects_marker_gap_for_unmarked_text_list():
+    with pytest.raises(ValueError, match="unmarked text list must have marker_gap=0"):
+        generation.VisualDataReplacementPlan.model_validate(
+            {
+                "replacements": [
+                    {
+                        "kind": "text-list",
+                        "path": "elements.0",
+                        "marker": "none",
+                        "font": None,
+                        "gap": 12,
+                        "marker_gap": 6,
+                        "items": ["First", "Second"],
+                    }
+                ]
+            }
+        )
+
+
+@pytest.mark.parametrize("kind", ["progress_bar", "gauge"])
+def test_visual_data_pass_converts_group_to_infographic(kind):
+    raw_layout = generation.RawSlideLayout.model_validate(
+        {
+            "id": f"{kind}_group",
+            "description": "A grouped shape-based quantitative status indicator.",
+            "elements": [
+                {
+                    "type": "group",
+                    "position": {"x": 200, "y": 220},
+                    "size": {"width": 360, "height": 140},
+                    "name": "status_visual",
+                    "children": [
+                        {
+                            "type": "vector",
+                            "points": [
+                                {"x": 0, "y": 0},
+                                {"x": 300, "y": 0},
+                                {"x": 300, "y": 24},
+                                {"x": 0, "y": 24},
+                            ],
+                            "closed": True,
+                            "fill": {"color": "#2563EB"},
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    plan = generation.VisualDataReplacementPlan.model_validate(
+        {
+            "replacements": [
+                {
+                    "kind": "infographic",
+                    "path": "elements.0",
+                    "position": {"x": 200, "y": 220},
+                    "size": {"width": 360, "height": 140},
+                    "data": {
+                        "type": kind,
+                        "min_value": 0,
+                        "max_value": 100,
+                        "value": 64,
+                    },
+                    "colors": ["#E5E7EB", "#2563EB"],
+                    "text_color": "#111827" if kind == "gauge" else None,
+                }
+            ]
+        }
+    )
+
+    _, candidate_paths = generation._visual_data_generation_payload(raw_layout)
+    generation._validate_visual_data_replacement_plan(
+        plan,
+        candidate_paths=candidate_paths,
+        source_elements=raw_layout.model_dump(mode="json")["elements"],
+    )
+    converted = generation._apply_visual_data_replacement_plan(raw_layout, plan)
+
+    infographic = converted.elements[0]
+    assert infographic.type == "infographic"
+    assert infographic.data.type == kind
+    assert infographic.data.value == 64
+    assert infographic.colors == ["#E5E7EB", "#2563EB"]
+    assert infographic.text_color == ("#111827" if kind == "gauge" else None)

--- a/servers/fastapi/tests/unit/test_templates_v2_elements.py
+++ b/servers/fastapi/tests/unit/test_templates_v2_elements.py
@@ -663,3 +663,30 @@ def test_flow_layout_children_can_omit_geometry():
     grid = flex.children[0]
     assert flex.position is None
     assert grid.size is None
+
+def test_text_list_preserves_item_and_marker_gaps():
+    layout = RawSlideLayout.model_validate(
+        {
+            "id": "spaced_list",
+            "description": "A list with explicit spacing between items.",
+            "elements": [
+                {
+                    "type": "text-list",
+                    "decorative": False,
+                    "name": "key_points",
+                    "gap": 12.5,
+                    "marker_gap": 6.25,
+                    "items": [[{"text": "First"}], [{"text": "Second"}]],
+                    "min_items": 1,
+                    "max_items": 2,
+                    "min_item_length": 3,
+                    "max_item_length": 6,
+                }
+            ],
+        }
+    )
+
+    text_list = layout.elements[0]
+    assert text_list.type == "text-list"
+    assert text_list.gap == 12.5
+    assert text_list.marker_gap == 6.25

--- a/servers/fastapi/tests/unit/test_templates_v2_generation.py
+++ b/servers/fastapi/tests/unit/test_templates_v2_generation.py
@@ -663,7 +663,9 @@ def test_certified_generation_prompts_split_flexible_and_visual_decisions():
     assert "Collapse unary nesting" in flexible_prompt
     assert "exactly the component's element_indices, once each" in flexible_prompt
     assert "Always invalid" in flexible_prompt
-    assert "progress bar, gauge, table, or text list" in visual_prompt
+    assert "chart, infographic, table, or text list" in visual_prompt
+    assert "Use kind=infographic for either a complete infographic image" in visual_prompt
+    assert "data.type=progress_bar or data.type=gauge" in visual_prompt
     assert "capacity growth" in capacity_prompt.lower()
     assert "Never return a no-op adjustment" in capacity_prompt
     assert "previewSlide" not in flexible_prompt

--- a/servers/fastapi/tests/unit/test_templates_v2_generation.py
+++ b/servers/fastapi/tests/unit/test_templates_v2_generation.py
@@ -666,6 +666,16 @@ def test_certified_generation_prompts_split_flexible_and_visual_decisions():
     assert "chart, infographic, table, or text list" in visual_prompt
     assert "Use kind=infographic for either a complete infographic image" in visual_prompt
     assert "data.type=progress_bar or data.type=gauge" in visual_prompt
+    assert "Atomicity is mandatory" in visual_prompt
+    assert "exactly one typed replacement" in visual_prompt
+    assert "Never emit table cells, rows, headers, borders" in visual_prompt
+    assert "Never emit or leave any chart internal" in visual_prompt
+    assert "structured table as one atomic editable element" in (
+        certified_generation.GENERATE_SLIDE_LAYOUT_SYSTEM_PROMPT
+    )
+    assert "structured chart as one atomic editable element" in (
+        certified_generation.GENERATE_SLIDE_LAYOUT_SYSTEM_PROMPT
+    )
     assert "capacity growth" in capacity_prompt.lower()
     assert "Never return a no-op adjustment" in capacity_prompt
     assert "previewSlide" not in flexible_prompt

--- a/servers/fastapi/tests/unit/test_templates_v2_schema.py
+++ b/servers/fastapi/tests/unit/test_templates_v2_schema.py
@@ -456,13 +456,37 @@ def test_get_component_schema_extracts_infographic_content_without_vector_conten
 
     assert list(properties) == ["progress"]
     assert properties["progress"]["x-element-type"] == "infographic"
-    assert properties["progress"]["properties"]["data"]["oneOf"][0]["properties"][
-        "type"
-    ] == {"const": "progress_bar"}
-    assert properties["progress"]["properties"]["data"]["oneOf"][1]["properties"][
-        "type"
-    ] == {"const": "gauge"}
+    assert properties["progress"]["properties"]["data"]["properties"]["type"] == {
+        "const": "progress_bar"
+    }
+    assert "colors" not in properties["progress"]["properties"]
     assert properties["progress"]["required"] == ["data"]
+
+
+def test_get_component_schema_preserves_vertical_funnel_type_and_item_limits():
+    component = {
+        "id": "funnel",
+        "description": "A vertically stacked conversion funnel.",
+        "elements": [
+            {
+                "type": "infographic",
+                "decorative": False,
+                "name": "stages",
+                "data": {
+                    "type": "vertical_funnel",
+                    "items": [{"value": 100, "heading": "Awareness"}],
+                },
+                "colors": ["FFFFFF", "102E79"],
+            }
+        ],
+    }
+
+    schema = get_component_schema(component)
+    data_schema = schema["properties"]["stages"]["properties"]["data"]
+
+    assert data_schema["properties"]["type"] == {"const": "vertical_funnel"}
+    assert data_schema["properties"]["items"]["minItems"] == 1
+    assert data_schema["properties"]["items"]["maxItems"] == 8
 
 
 def test_get_component_schema_collapses_repeated_component_children_to_array():
@@ -789,3 +813,99 @@ def test_get_template_schema_numbers_duplicate_component_fields_from_zero():
     assert list(schema["properties"]) == ["metric_card_0", "metric_card_1"]
     assert schema["required"] == ["metric_card_0", "metric_card_1"]
     assert schema["properties"]["metric_card_0"] == schema["properties"]["metric_card_1"]
+
+
+def _metrics_with_layout_only_wrapper_differences():
+    def text(name, value):
+        return {
+            "type": "text",
+            "name": name,
+            "decorative": False,
+            "min_length": 1,
+            "max_length": 60,
+            "runs": [{"text": value}],
+        }
+
+    def content_children(value, heading, description):
+        return [
+            text("metric_value", value),
+            {
+                "type": "flex",
+                "name": "metric_text_stack",
+                "direction": "column",
+                "children": [
+                    text("metric_heading", heading),
+                    text("metric_description", description),
+                ],
+            },
+        ]
+
+    divider = {
+        "type": "vector",
+        "decorative": True,
+        "points": [{"x": 0, "y": 0}, {"x": 200, "y": 0}],
+    }
+    return {
+        "id": "metrics_panel",
+        "elements": [
+            {
+                "type": "group",
+                "name": "metric_items",
+                "children": [
+                    {
+                        "type": "flex",
+                        "name": "metric_item_1",
+                        "direction": "row",
+                        "children": content_children(
+                            "68%", "Mobile-first", "Primarily uses mobile"
+                        ),
+                    },
+                    {
+                        "type": "flex",
+                        "name": "metric_item_2",
+                        "direction": "column",
+                        "children": [
+                            divider,
+                            {
+                                "type": "flex",
+                                "name": "metric_content",
+                                "direction": "row",
+                                "children": content_children(
+                                    "74%", "Research", "Compares products"
+                                ),
+                            },
+                        ],
+                    },
+                    {
+                        "type": "flex",
+                        "name": "metric_item_3",
+                        "direction": "column",
+                        "children": [
+                            divider,
+                            {
+                                "type": "group",
+                                "name": "metric_content",
+                                "children": content_children(
+                                    "32%", "Engagement", "Prefers personalized content"
+                                ),
+                            },
+                        ],
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def test_component_schema_flattens_layout_only_repeated_item_wrappers():
+    schema = get_component_schema(_metrics_with_layout_only_wrapper_differences())
+
+    metric_items = schema["properties"]["metric_items"]
+    assert metric_items["type"] == "array"
+    assert metric_items["minItems"] == 1
+    assert metric_items["maxItems"] == 3
+    assert list(metric_items["items"]["properties"]) == [
+        "metric_value",
+        "metric_heading",
+        "metric_description",
+    ]

--- a/servers/fastapi/tests/unit/test_templates_v2_schema.py
+++ b/servers/fastapi/tests/unit/test_templates_v2_schema.py
@@ -139,7 +139,6 @@ def test_extract_slide_schema_from_layout_extracts_editable_content():
                                     "stacked_bar",
                                 ],
                             },
-                            "title": {"type": ["string", "null"]},
                             "categories": {
                                 "type": "array",
                                 "items": {"type": "string"},
@@ -386,7 +385,6 @@ def test_get_component_schema_extracts_generated_component_content():
                             "stacked_bar",
                         ],
                     },
-                    "title": {"type": ["string", "null"]},
                     "categories": {
                         "type": "array",
                         "items": {"type": "string"},
@@ -487,6 +485,73 @@ def test_get_component_schema_preserves_vertical_funnel_type_and_item_limits():
     assert data_schema["properties"]["type"] == {"const": "vertical_funnel"}
     assert data_schema["properties"]["items"]["minItems"] == 1
     assert data_schema["properties"]["items"]["maxItems"] == 8
+
+
+def test_component_table_schema_derives_header_and_body_text_limits():
+    def cell(text: str, *, size: int = 14) -> dict:
+        font = {"size": size, "color": "#111111"}
+        return {"font": font, "runs": [{"text": text, "font": font}]}
+
+    component = {
+        "id": "comparison",
+        "elements": [
+            {
+                "type": "table",
+                "decorative": False,
+                "name": "metrics",
+                "min_columns": 2,
+                "max_columns": 3,
+                "min_rows": 1,
+                "max_rows": 4,
+                "size": {"width": 600, "height": 300},
+                "columns": [cell("Metric"), cell("Value")],
+                "rows": [[cell("Activation"), cell("71%")]],
+            }
+        ],
+    }
+
+    schema = get_component_schema(component)
+    table_schema = schema["properties"]["metrics"]
+    header_schema = table_schema["properties"]["columns"]["items"]
+    body_schema = table_schema["properties"]["rows"]["items"]["items"]
+
+    assert header_schema["minLength"] == body_schema["minLength"] == 1
+    assert header_schema["maxLength"] >= len("Metric")
+    assert body_schema["maxLength"] >= len("Activation")
+
+
+def test_chart_content_schema_tracks_layout_title_presence():
+    without_title = get_component_schema(
+        {
+            "id": "chart_component",
+            "elements": [
+                {
+                    "type": "chart",
+                    "title": None,
+                    "decorative": False,
+                    "name": "proportion_chart",
+                }
+            ],
+        }
+    )["properties"]["proportion_chart"]
+    assert "title" not in without_title["properties"]
+    assert without_title["required"] == list(without_title["properties"])
+
+    with_title = get_component_schema(
+        {
+            "id": "chart_component",
+            "elements": [
+                {
+                    "type": "chart",
+                    "title": "Revenue by quarter",
+                    "decorative": False,
+                    "name": "revenue_chart",
+                }
+            ],
+        }
+    )["properties"]["revenue_chart"]
+    assert with_title["properties"]["title"] == {"type": "string"}
+    assert with_title["required"] == list(with_title["properties"])
 
 
 def test_get_component_schema_collapses_repeated_component_children_to_array():

--- a/servers/fastapi/utils/infographic_catalog.py
+++ b/servers/fastapi/utils/infographic_catalog.py
@@ -19,6 +19,7 @@ InfographicType = Literal[
     "chevron_process",
     "radial_cycle",
     "conversion_funnel",
+    "vertical_funnel",
     "pyramid",
     "segmented_wheel",
     "customer_journey",
@@ -302,6 +303,23 @@ INFOGRAPHIC_CATALOG: tuple[dict[str, Any], ...] = (
         },
     },
     {
+        "type": "vertical_funnel",
+        "name": "Vertical funnel",
+        "category": "funnel",
+        "best_for": "Vertically stacked funnel stages whose widths follow percentage values.",
+        "required_data": [
+            "items: array of {value:number, heading:string, description?}"
+        ],
+        "default_size": {"width": 720, "height": 480},
+        "example_data": {
+            "items": [
+                {"value": 100, "heading": "Awareness"},
+                {"value": 60, "heading": "Interest"},
+                {"value": 20, "heading": "Conversion"},
+            ]
+        },
+    },
+    {
         "type": "pyramid",
         "name": "Pyramid",
         "category": "hierarchy",
@@ -566,7 +584,7 @@ def normalize_infographic_data(
         raise ValueError(f"{infographic_type} requires exactly four items.")
     if infographic_type == "before_after" and (len(items) < 2 or len(items) % 2):
         raise ValueError("before_after requires an even number of at least two items.")
-    if infographic_type == "conversion_funnel" and not all(
+    if infographic_type in {"conversion_funnel", "vertical_funnel"} and not all(
         isinstance(item, dict)
         and isinstance(item.get("heading"), str)
         and not isinstance(item.get("value"), bool)
@@ -574,7 +592,7 @@ def normalize_infographic_data(
         for item in items
     ):
         raise ValueError(
-            "Every conversion_funnel item requires a heading and numeric value."
+            f"Every {infographic_type} item requires a heading and numeric value."
         )
     if infographic_type == "comparison_matrix":
         criteria = normalized.get("criteria")

--- a/servers/fastapi/utils/llm_calls/edit_slide.py
+++ b/servers/fastapi/utils/llm_calls/edit_slide.py
@@ -141,7 +141,7 @@ async def get_edited_slide_content(
         response_format = JSONSchemaResponse(
             name="response",
             json_schema=response_schema,
-            strict=False,
+            strict=True,
         )
         messages = get_messages(
             prompt,

--- a/servers/fastapi/utils/llm_calls/generate_slide_content.py
+++ b/servers/fastapi/utils/llm_calls/generate_slide_content.py
@@ -248,7 +248,7 @@ async def get_slide_content_from_type_and_outline(
         response_format = JSONSchemaResponse(
             name="response",
             json_schema=response_schema,
-            strict=False,
+            strict=True,
         )
         messages = get_messages(
             outline.content,

--- a/servers/fastapi/uv.lock
+++ b/servers/fastapi/uv.lock
@@ -1403,7 +1403,7 @@ wheels = [
 
 [[package]]
 name = "llmai"
-version = "0.3.9"
+version = "0.3.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
@@ -1412,9 +1412,9 @@ dependencies = [
     { name = "httpx" },
     { name = "openai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/1a/1c40f40c7ae11fc8414ddce76720b49a928e5884541c7c30aba45850e72f/llmai-0.3.9.tar.gz", hash = "sha256:6d55616f9839b42e1a28c89a079511927bb2e69d737809790d3a19d2f786074d", size = 542949, upload-time = "2026-08-25T06:18:19.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/8a/b4f2e36e119d5b461cd22691fcb816bc1c8708d21d7f747bcbafc45ffdc2/llmai-0.3.10.tar.gz", hash = "sha256:b0cbafe98043fb1cab681ab77359bdc1f318d3b4b473626876aa55d09247c6f8", size = 543575, upload-time = "2026-09-03T12:58:04.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/42/57db1980d58f37aa36b5ef214968fbb400916ea368cf8b68a9e702ab6f2f/llmai-0.3.9-py3-none-any.whl", hash = "sha256:cf29793a09c944d6849ea53705367fd266cf77286db0cbeae4fb22619f2a388d", size = 556863, upload-time = "2026-08-25T06:18:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2d/688adf58e88ea96cda6a0922507702c3d39707666dd1202a7a22c82e5b58/llmai-0.3.10-py3-none-any.whl", hash = "sha256:657daae25350f48194faaaaf3f4a32c40792eb6350d4ebec12e328895a90e993", size = 557490, upload-time = "2026-09-03T12:58:02.633Z" },
 ]
 
 [[package]]
@@ -1954,7 +1954,7 @@ requires-dist = [
     { name = "greenlet", specifier = ">=3.0.3" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "jsonschema", specifier = ">=4.26.0" },
-    { name = "llmai", specifier = "==0.3.9" },
+    { name = "llmai", specifier = "==0.3.10" },
     { name = "mem0ai", extras = ["nlp"], specifier = ">=0.1.115" },
     { name = "nltk", specifier = ">=3.9.1" },
     { name = "openai", specifier = ">=1.98.0" },

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/PresentationActions.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/PresentationActions.tsx
@@ -281,6 +281,7 @@ export const infographicItems = [
   { id: "chevron_process", label: "Chevron Process", icon: ChevronsRight },
   { id: "radial_cycle", label: "Radial Cycle", icon: Circle },
   { id: "conversion_funnel", label: "Conversion Funnel", icon: AreaChart },
+  { id: "vertical_funnel", label: "Vertical Funnel", icon: AreaChart },
   { id: "pyramid", label: "Pyramid", icon: Triangle },
   { id: "segmented_wheel", label: "Segmented Wheel", icon: Circle },
   { id: "customer_journey", label: "Customer Journey", icon: Move },

--- a/servers/nextjs/app/(presentation-generator)/template-preview/components/TemplatePreviewClient.tsx
+++ b/servers/nextjs/app/(presentation-generator)/template-preview/components/TemplatePreviewClient.tsx
@@ -61,6 +61,7 @@ import {
   cloneLayout,
   collectSchemaFields,
   extractCreatedLayouts,
+  hasLayoutContentDensityTargets,
   mergeDensityPreviewCanvasEdits,
   readLayoutId,
   updateLayoutSchemaConstraint,
@@ -415,17 +416,10 @@ const GroupLayoutPreview = ({
 
   const applyContentDensity = useCallback((nextDensity: Density) => {
     if (!nextDensity || !canEditTemplate || !activeLayout) return;
-    const hasEditableContent = schemaFields.some(
-      (field) =>
-        !field.decorative &&
-        (field.type === "text" ||
-          field.type === "text-list" ||
-          field.type === "image"),
-    );
-    if (!hasEditableContent) {
+    if (!hasLayoutContentDensityTargets(activeLayout)) {
       notify.warning(
-        "No editable content",
-        "Mark a schema field as non-decorative before testing content density.",
+        "No variable content",
+        "Add editable text or a repeatable schema array before testing content density.",
       );
       return;
     }
@@ -441,7 +435,6 @@ const GroupLayoutPreview = ({
     activeLayout,
     activeLayoutIndex,
     canEditTemplate,
-    schemaFields,
     templateId,
   ]);
 

--- a/servers/nextjs/app/(presentation-generator)/template-preview/components/editor/TemplatePreviewSidePanels.tsx
+++ b/servers/nextjs/app/(presentation-generator)/template-preview/components/editor/TemplatePreviewSidePanels.tsx
@@ -446,8 +446,9 @@ export function SchemaPanel({
         <div className="mt-[10px] flex min-h-[62px] gap-[10px] rounded-[6px] bg-[#F3F6FB] px-[16px] py-[10px] text-[12px] leading-[14px] text-[#5F6470]">
           <Info className="mt-[2px] h-[14px] w-[14px] shrink-0 text-[#1F5FBF]" />
           <p>
-            Preview realistic content lengths without changing your saved
-            template. Reset restores the original content.
+            Preview schema-driven text lengths and repeatable item counts
+            without changing your saved template. Reset restores the original
+            content.
           </p>
         </div>
       </div>

--- a/servers/nextjs/app/(presentation-generator)/template-preview/components/editor/templatePreviewUtils.ts
+++ b/servers/nextjs/app/(presentation-generator)/template-preview/components/editor/templatePreviewUtils.ts
@@ -41,6 +41,11 @@ export type SchemaField = {
   maxItems?: number;
 };
 
+type DensityLengthField = Pick<
+  SchemaField,
+  "label" | "minChars" | "maxChars"
+>;
+
 const CONTENT_ELEMENT_TYPES = new Set([
   "text",
   "image",
@@ -150,6 +155,8 @@ function applyDensityToElement(
     setElementRunsText(element, exactDensityText(name, targetLength, density));
   } else if (isEditableContent && type === "text-list") {
     applyTextListDensity(element, name, density);
+  } else if (isEditableContent && type === "table") {
+    Object.assign(element, applyTableDensity(element, density));
   }
 
   resizeRepeatedChildren(element, density);
@@ -209,6 +216,69 @@ function densityTargetCount(
   return clampCount(minCount + (maxCount - minCount) / 2);
 }
 
+function densityTargetLength(
+  field: DensityLengthField,
+  density: Exclude<Density, "">,
+  currentLength: number,
+) {
+  const clampPreviewLength = (length: number) =>
+    Math.min(2_000, Math.max(1, Math.round(length)));
+  const contentLength = Math.max(1, currentLength || field.label.length);
+  const hasMin = typeof field.minChars === "number";
+  const hasMax = typeof field.maxChars === "number";
+
+  if (!hasMin && !hasMax) {
+    if (density === "Low") {
+      return clampPreviewLength(Math.max(12, contentLength * 0.55));
+    }
+    if (density === "Medium") {
+      return clampPreviewLength(Math.max(24, contentLength * 1.2));
+    }
+    return clampPreviewLength(Math.max(48, contentLength * 1.8));
+  }
+
+  const minLength = Math.max(
+    1,
+    field.minChars ??
+      Math.min(field.maxChars ?? contentLength, Math.max(12, contentLength)),
+  );
+  const maxLength = Math.max(
+    minLength,
+    field.maxChars ??
+      Math.max(minLength * 2, Math.round(contentLength * 1.6)),
+  );
+
+  if (density === "Low") return clampPreviewLength(minLength);
+  if (density === "High") return clampPreviewLength(maxLength);
+  return clampPreviewLength(minLength + (maxLength - minLength) / 2);
+}
+
+function textAtTargetLength(
+  value: string,
+  label: string,
+  targetLength: number,
+) {
+  const normalizedValue = value.replace(/\s+/g, " ").trim();
+  const fallback = `${label} provides a clear supporting point.`;
+  const source = normalizedValue || fallback;
+  const supportingDetail =
+    "This supporting detail adds useful context and helps explain the key message clearly.";
+  let expanded = source;
+
+  while (expanded.length < targetLength) {
+    expanded = `${expanded} ${supportingDetail}`;
+  }
+
+  if (expanded.length <= targetLength) return expanded;
+
+  const clipped = expanded.slice(0, targetLength).trimEnd();
+  const finalSpace = clipped.lastIndexOf(" ");
+  if (finalSpace >= Math.floor(targetLength * 0.72)) {
+    return clipped.slice(0, finalSpace).trimEnd();
+  }
+  return clipped;
+}
+
 function comparableContentSchema(element: UnknownRecord): UnknownRecord {
   const type = readString(element.type);
 
@@ -241,12 +311,17 @@ function comparableContentSchema(element: UnknownRecord): UnknownRecord {
   }
 
   if (type === "table") {
+    const limits = tableTextLimits(element);
     return {
       type: "table",
       minRows: readNumber(element.min_rows),
       maxRows: readNumber(element.max_rows),
       minColumns: readNumber(element.min_columns),
       maxColumns: readNumber(element.max_columns),
+      headerMinimum: limits.header.minimum,
+      headerMaximum: limits.header.maximum,
+      bodyMinimum: limits.body.minimum,
+      bodyMaximum: limits.body.maximum,
     };
   }
 
@@ -527,8 +602,244 @@ function repeatedItemsAtDensity(
   });
 }
 
+function tableCellAtDensity(
+  value: unknown,
+  density: Exclude<Density, "">,
+  label: string,
+  minChars?: number,
+  maxChars?: number,
+) {
+  const cell = isRecord(value) ? cloneLayout(value) : { runs: [] };
+  const currentText = textRunsToString(cell.runs);
+  const targetLength = densityTargetLength(
+    { label, minChars, maxChars },
+    density,
+    currentText.length,
+  );
+  updateTextRuns(
+    cell,
+    textAtTargetLength(currentText, label, targetLength),
+  );
+  return cell;
+}
+
+function tableCellsAtDensity(
+  values: unknown[],
+  targetCount: number,
+  fallbackValues: unknown[],
+) {
+  if (targetCount === 0) return [];
+  const source =
+    values.length > 0
+      ? values
+      : fallbackValues.length > 0
+        ? [fallbackValues[0]]
+        : [{ runs: [{ text: "" }] }];
+  return repeatedItemsAtDensity(source, targetCount, false);
+}
+
+type TableTextLimit = { minimum?: number; maximum?: number };
+
+function tableTextLimits(value: UnknownRecord): {
+  header: TableTextLimit;
+  body: TableTextLimit;
+} {
+  const size = isRecord(value.size) ? value.size : {};
+  const width = readNumber(size.width);
+  const height = readNumber(size.height);
+  if (!width || width <= 0 || !height || height <= 0) {
+    return { header: {}, body: {} };
+  }
+
+  const columns = readArray(value.columns).filter(isRecord);
+  const rows = readArray(value.rows).map(readArray);
+  const bodyCells = rows.flat().filter(isRecord);
+  const columnCount = Math.max(
+    1,
+    Math.round((readNumber(value.max_columns) ?? columns.length) || 1),
+  );
+  const rowCount = Math.max(
+    0,
+    Math.round(readNumber(value.max_rows) ?? rows.length),
+  );
+  const cellWidth = Math.max(1, width / columnCount - 24);
+  const cellHeight = Math.max(1, height / (rowCount + 1) - 12);
+
+  return {
+    header: tableSectionTextLimit(columns, cellWidth, cellHeight),
+    body: tableSectionTextLimit(
+      bodyCells,
+      cellWidth,
+      cellHeight,
+      columns,
+    ),
+  };
+}
+
+function tableSectionTextLimit(
+  cells: UnknownRecord[],
+  cellWidth: number,
+  cellHeight: number,
+  fallbackCells: UnknownRecord[] = [],
+): TableTextLimit {
+  const { glyphWidth, lineHeight } = tableCellTypography(
+    cells.length > 0 ? cells : fallbackCells,
+  );
+  const charactersPerLine = Math.max(1, Math.floor(cellWidth / glyphWidth));
+  const lineCount = Math.max(1, Math.floor(cellHeight / lineHeight + 0.15));
+  const estimatedMaximum = Math.max(
+    1,
+    Math.floor(charactersPerLine * lineCount * 0.85),
+  );
+  const texts = cells.map((cell) => textRunsToString(cell.runs));
+  const observedMaximum = texts.reduce(
+    (maximum, text) => Math.max(maximum, text.length),
+    0,
+  );
+  return {
+    minimum: texts.length > 0 && texts.every((text) => text.trim()) ? 1 : 0,
+    maximum: Math.max(estimatedMaximum, observedMaximum),
+  };
+}
+
+function tableCellTypography(cells: UnknownRecord[]) {
+  const fonts: UnknownRecord[] = [];
+  cells.forEach((cell) => {
+    if (isRecord(cell.font)) fonts.push(cell.font);
+    readArray(cell.runs).filter(isRecord).forEach((run) => {
+      if (isRecord(run.font)) fonts.push(run.font);
+    });
+  });
+  if (fonts.length === 0) fonts.push({});
+
+  const glyphWidths = fonts.map((font) => {
+    const fontSize = readNumber(font.size) ?? 14;
+    const widthFactor = font.bold === true ? 0.62 : 0.58;
+    return fontSize * widthFactor + Math.max(0, readNumber(font.letter_spacing) ?? 0);
+  });
+  const lineHeights = fonts.map((font) => {
+    const fontSize = readNumber(font.size) ?? 14;
+    const lineHeight = readNumber(font.line_height);
+    if (!lineHeight || lineHeight <= 0) return fontSize * 1.2;
+    return lineHeight > 2 ? lineHeight : fontSize * lineHeight;
+  });
+  return {
+    glyphWidth: Math.max(...glyphWidths),
+    lineHeight: Math.max(...lineHeights),
+  };
+}
+
+function applyTableDensity(
+  value: UnknownRecord,
+  density: Exclude<Density, "">,
+) {
+  const next = cloneLayout(value);
+  if (next.decorative !== false) return next;
+
+  const sourceColumns = readArray(next.columns);
+  const sourceRows = readArray(next.rows);
+  const targetColumnCount = Math.max(
+    1,
+    densityTargetCount(
+      density,
+      sourceColumns.length,
+      readNumber(next.min_columns),
+      readNumber(next.max_columns),
+    ),
+  );
+  const targetRowCount = densityTargetCount(
+    density,
+    sourceRows.length,
+    readNumber(next.min_rows),
+    readNumber(next.max_rows),
+  );
+  const limits = tableTextLimits(next);
+  const hasHeaderLengthLimits =
+    limits.header.minimum !== undefined || limits.header.maximum !== undefined;
+  const hasCellLengthLimits =
+    limits.body.minimum !== undefined || limits.body.maximum !== undefined;
+
+  const columns = tableCellsAtDensity(
+    sourceColumns,
+    targetColumnCount,
+    [],
+  ).map((cell, columnIndex) =>
+    hasHeaderLengthLimits
+      ? tableCellAtDensity(
+          cell,
+          density,
+          `Column ${columnIndex + 1}`,
+          limits.header.minimum,
+          limits.header.maximum,
+        )
+      : cloneLayout(cell),
+  );
+  next.columns = columns;
+
+  const fallbackRow = columns.map((column) => {
+    const cell = cloneLayout(column);
+    if (isRecord(cell)) updateTextRuns(cell, "");
+    return cell;
+  });
+  const rowSource = sourceRows.length > 0 ? sourceRows : [fallbackRow];
+  next.rows = repeatedItemsAtDensity(rowSource, targetRowCount, false).map(
+    (row, rowIndex) =>
+      tableCellsAtDensity(readArray(row), targetColumnCount, fallbackRow).map(
+        (cell, columnIndex) =>
+          hasCellLengthLimits
+            ? tableCellAtDensity(
+                cell,
+                density,
+                `Cell ${rowIndex + 1}-${columnIndex + 1}`,
+                limits.body.minimum,
+                limits.body.maximum,
+              )
+            : cloneLayout(cell),
+      ),
+  );
+  return next;
+}
+
+function tableDensityCanChange(value: UnknownRecord) {
+  if (readString(value.type) !== "table" || value.decorative !== false) {
+    return false;
+  }
+
+  const currentColumns = readArray(value.columns).length;
+  const currentRows = readArray(value.rows).length;
+  const columnMinimum = readNumber(value.min_columns);
+  const columnMaximum = readNumber(value.max_columns);
+  const rowMinimum = readNumber(value.min_rows);
+  const rowMaximum = readNumber(value.max_rows);
+  if (
+    densityTargetCount(
+      "Low",
+      currentColumns,
+      columnMinimum,
+      columnMaximum,
+    ) !==
+      densityTargetCount(
+        "High",
+        currentColumns,
+        columnMinimum,
+        columnMaximum,
+      ) ||
+    densityTargetCount("Low", currentRows, rowMinimum, rowMaximum) !==
+      densityTargetCount("High", currentRows, rowMinimum, rowMaximum)
+  ) {
+    return true;
+  }
+
+  const limits = tableTextLimits(value);
+  return (
+    limits.header.minimum !== limits.header.maximum ||
+    limits.body.minimum !== limits.body.maximum
+  );
+}
+
 function structuralArrayCanChange(value: unknown): boolean {
   if (!isRecord(value)) return false;
+  if (tableDensityCanChange(value)) return true;
   const type = readString(value.type);
   const children = readArray(value.children);
 

--- a/servers/nextjs/app/(presentation-generator)/template-preview/components/editor/templatePreviewUtils.ts
+++ b/servers/nextjs/app/(presentation-generator)/template-preview/components/editor/templatePreviewUtils.ts
@@ -37,6 +37,22 @@ export type SchemaField = {
   value: string;
   minChars?: number;
   maxChars?: number;
+  minItems?: number;
+  maxItems?: number;
+};
+
+const CONTENT_ELEMENT_TYPES = new Set([
+  "text",
+  "image",
+  "text-list",
+  "table",
+  "chart",
+  "infographic",
+]);
+
+type ComparableSchemaNode = {
+  name: string;
+  schema: UnknownRecord;
 };
 
 function isRecord(value: unknown): value is UnknownRecord {
@@ -91,6 +107,7 @@ export function applyTemplateContentDensity(
   readArray(layoutRecord.components).forEach((component) => {
     if (isRecord(component)) {
       applyDensityToElements(component.elements, density);
+      resizeRepeatedComponentElements(component, density);
     }
   });
 
@@ -133,15 +150,6 @@ function applyDensityToElement(
     setElementRunsText(element, exactDensityText(name, targetLength, density));
   } else if (isEditableContent && type === "text-list") {
     applyTextListDensity(element, name, density);
-  } else if (isEditableContent && type === "image") {
-    const promptLabel = element.is_icon === true ? `${name} icon` : `${name} image`;
-    element.prompt = exactDensityText(
-      promptLabel,
-      densityTextLength({}, density),
-      density,
-    );
-  } else if (isEditableContent && type === "table") {
-    applyTableDensity(element, name, density);
   }
 
   resizeRepeatedChildren(element, density);
@@ -185,53 +193,405 @@ function applyTextListDensity(
   });
 }
 
-function applyTableDensity(
-  element: UnknownRecord,
-  name: string,
-  density: ContentDensity,
+function densityTargetCount(
+  density: Exclude<Density, "">,
+  currentCount: number,
+  minimum?: number,
+  maximum?: number,
 ) {
-  const columnCount = densityCount(
-    element.min_columns,
-    element.max_columns,
-    density,
-  );
-  const rowCount = densityCount(
-    element.min_rows,
-    element.max_rows,
-    density,
-  );
-  const cellTextLength = densityTextLength({}, density);
-  const currentColumns = readArray(element.columns);
-  const currentRows = readArray(element.rows);
+  const clampCount = (value: number) =>
+    Math.min(100, Math.max(0, Math.round(value)));
+  const minCount = clampCount(minimum ?? currentCount);
+  const maxCount = clampCount(Math.max(minCount, maximum ?? currentCount));
 
-  element.columns = Array.from({ length: columnCount }, (_, columnIndex) =>
-    cellWithText(
-      currentColumns[columnIndex] ??
-        currentColumns[currentColumns.length - 1],
-      exactDensityText(
-        `${name} column ${columnIndex + 1}`,
-        cellTextLength,
-        density,
-      ),
+  if (density === "Low") return minCount;
+  if (density === "High") return maxCount;
+  return clampCount(minCount + (maxCount - minCount) / 2);
+}
+
+function comparableContentSchema(element: UnknownRecord): UnknownRecord {
+  const type = readString(element.type);
+
+  if (type === "text") {
+    return {
+      type: "string",
+      minLength: readNumber(element.min_length),
+      maxLength: readNumber(element.max_length),
+    };
+  }
+
+  if (type === "image") {
+    return {
+      type: "image",
+      promptKey: element.is_icon === true ? "icon_query" : "image_prompt",
+    };
+  }
+
+  if (type === "text-list") {
+    return {
+      type: "array",
+      minItems: readNumber(element.min_items),
+      maxItems: readNumber(element.max_items),
+      items: {
+        type: "string",
+        minLength: readNumber(element.min_item_length),
+        maxLength: readNumber(element.max_item_length),
+      },
+    };
+  }
+
+  if (type === "table") {
+    return {
+      type: "table",
+      minRows: readNumber(element.min_rows),
+      maxRows: readNumber(element.max_rows),
+      minColumns: readNumber(element.min_columns),
+      maxColumns: readNumber(element.max_columns),
+    };
+  }
+
+  if (type === "chart") {
+    return {
+      type: "chart",
+      hasTitle: readString(element.title).trim().length > 0,
+    };
+  }
+
+  if (type === "infographic") {
+    const data = isRecord(element.data) ? element.data : {};
+    return {
+      type: "infographic",
+      infographicType: readString(data.type),
+    };
+  }
+
+  return { type };
+}
+
+function comparableObjectSchema(nodes: ComparableSchemaNode[]): UnknownRecord {
+  const properties: UnknownRecord = {};
+  nodes.forEach((node) => {
+    let key = node.name;
+    let suffix = 2;
+    while (Object.prototype.hasOwnProperty.call(properties, key)) {
+      key = `${node.name}_${suffix}`;
+      suffix += 1;
+    }
+    properties[key] = node.schema;
+  });
+
+  return {
+    type: "object",
+    properties,
+  };
+}
+
+function numericNameToken(value: string) {
+  return value.match(/_\d+(?=_|$)/)?.[0] ?? null;
+}
+
+function prefixNameToken(value: string) {
+  const separatorIndex = value.indexOf("_");
+  return separatorIndex > 0 ? value.slice(0, separatorIndex + 1) : null;
+}
+
+function normalizationTokenForNodes(
+  nodes: ComparableSchemaNode[],
+  strategy: "numeric" | "none" | "prefix",
+) {
+  if (strategy === "none") return null;
+  const tokenForName =
+    strategy === "numeric" ? numericNameToken : prefixNameToken;
+  const tokens = nodes.map((node) => tokenForName(node.name)).filter(Boolean);
+  if (tokens.length === 0) return null;
+  return tokens.every((token) => token === tokens[0]) ? tokens[0] : null;
+}
+
+function normalizeComparableSchema(value: unknown, token: string | null): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeComparableSchema(item, token));
+  }
+  if (!isRecord(value)) return value;
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [
+      token ? key.replace(token, "") : key,
+      normalizeComparableSchema(child, token),
+    ]),
+  );
+}
+
+function stableComparableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableComparableValue);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, stableComparableValue(value[key])]),
+  );
+}
+
+function normalizedRepeatedItemSchema(
+  nodes: ComparableSchemaNode[],
+  strategy: "numeric" | "none" | "prefix",
+) {
+  const token = normalizationTokenForNodes(nodes, strategy);
+  const itemSchema =
+    nodes.length === 1 && nodes[0].schema.type === "object"
+      ? nodes[0].schema
+      : comparableObjectSchema(nodes);
+  return stableComparableValue(normalizeComparableSchema(itemSchema, token));
+}
+
+function repeatedRootNamesMatch(nodeSets: ComparableSchemaNode[][]) {
+  if (
+    nodeSets.length === 0 ||
+    nodeSets.some((nodes) => nodes.length !== 1)
+  ) {
+    return false;
+  }
+
+  const names = nodeSets.map((nodes) => nodes[0].name);
+  if (names.every((name) => name === names[0])) return true;
+  const normalizedNames = names.map((name) => {
+    const token = numericNameToken(name);
+    return token ? name.replace(token, "") : name;
+  });
+  return normalizedNames.every((name) => name === normalizedNames[0]);
+}
+
+function flattenedContentNodes(nodes: ComparableSchemaNode[]) {
+  const flattened: ComparableSchemaNode[] = [];
+  const visit = (node: ComparableSchemaNode) => {
+    const properties = isRecord(node.schema.properties)
+      ? node.schema.properties
+      : null;
+    if (node.schema.type !== "object" || !properties) {
+      flattened.push(node);
+      return;
+    }
+
+    Object.entries(properties).forEach(([name, schema]) => {
+      if (isRecord(schema)) visit({ name, schema });
+    });
+  };
+  nodes.forEach(visit);
+  return flattened;
+}
+
+function normalizedNodeNamesAreUnique(
+  nodes: ComparableSchemaNode[],
+  strategy: "numeric" | "none" | "prefix",
+) {
+  if (nodes.length === 0) return false;
+  const token = normalizationTokenForNodes(nodes, strategy);
+  const names = nodes.map((node) =>
+    token ? node.name.replace(token, "") : node.name,
+  );
+  return new Set(names).size === names.length;
+}
+
+function repeatedChildrenSchema(
+  element: UnknownRecord,
+  childNodeSets: ComparableSchemaNode[][],
+) {
+  if (childNodeSets.some((nodes) => nodes.length === 0)) return null;
+
+  const childCount = childNodeSets.length;
+  const maxChildren = readNumber(element.max_children);
+  if (childCount < 2 && !(maxChildren != null && maxChildren > childCount)) {
+    return null;
+  }
+
+  for (const strategy of ["numeric", "none", "prefix"] as const) {
+    const itemSchemas = childNodeSets.map((nodes) =>
+      normalizedRepeatedItemSchema(nodes, strategy),
+    );
+    const first = JSON.stringify(itemSchemas[0]);
+    if (itemSchemas.every((schema) => JSON.stringify(schema) === first)) {
+      const isGroup = readString(element.type) === "group";
+      return {
+        type: "array",
+        minItems: isGroup
+          ? Math.floor(childCount / 2)
+          : readNumber(element.min_children),
+        maxItems: isGroup ? childCount : maxChildren,
+        items: itemSchemas[0],
+      } satisfies UnknownRecord;
+    }
+  }
+
+  if (repeatedRootNamesMatch(childNodeSets)) {
+    const flattenedNodeSets = childNodeSets.map(flattenedContentNodes);
+    for (const strategy of ["numeric", "none", "prefix"] as const) {
+      if (
+        !flattenedNodeSets.every((nodes) =>
+          normalizedNodeNamesAreUnique(nodes, strategy),
+        )
+      ) {
+        continue;
+      }
+
+      const itemSchemas = flattenedNodeSets.map((nodes) =>
+        normalizedRepeatedItemSchema(nodes, strategy),
+      );
+      const first = JSON.stringify(itemSchemas[0]);
+      if (itemSchemas.every((schema) => JSON.stringify(schema) === first)) {
+        const isGroup = readString(element.type) === "group";
+        return {
+          type: "array",
+          minItems: isGroup
+            ? Math.floor(childCount / 2)
+            : readNumber(element.min_children),
+          maxItems: isGroup ? childCount : maxChildren,
+          items: itemSchemas[0],
+        } satisfies UnknownRecord;
+      }
+    }
+  }
+
+  return null;
+}
+
+function comparableSchemaNodesForElement(
+  value: unknown,
+): ComparableSchemaNode[] {
+  if (!isRecord(value)) return [];
+  const type = readString(value.type);
+  const name = readString(value.name).trim();
+
+  if (
+    CONTENT_ELEMENT_TYPES.has(type) &&
+    value.decorative === false &&
+    name
+  ) {
+    return [{ name, schema: comparableContentSchema(value) }];
+  }
+
+  if (type === "container") {
+    const childNodes = comparableSchemaNodesForElement(value.child);
+    if (!name || childNodes.length === 0) return childNodes;
+    return [{ name, schema: comparableObjectSchema(childNodes) }];
+  }
+
+  if (type !== "flex" && type !== "grid" && type !== "group") return [];
+  const children = readArray(value.children);
+  const childNodeSets = children.map(comparableSchemaNodesForElement);
+  const childNodes = childNodeSets.flat();
+  if (!name || childNodes.length === 0) return childNodes;
+
+  const arraySchema = repeatedChildrenSchema(value, childNodeSets);
+
+  return [
+    {
+      name,
+      schema: arraySchema ?? comparableObjectSchema(childNodes),
+    },
+  ];
+}
+
+function isRepeatableStructuralElement(element: UnknownRecord) {
+  const type = readString(element.type);
+  const children = readArray(element.children);
+  if (type !== "flex" && type !== "grid" && type !== "group") return false;
+
+  return Boolean(
+    repeatedChildrenSchema(
+      element,
+      children.map(comparableSchemaNodesForElement),
     ),
   );
-  element.rows = Array.from({ length: rowCount }, (_, rowIndex) => {
-    const sourceRow = readArray(
-      currentRows[rowIndex] ?? currentRows[currentRows.length - 1],
-    );
-    return Array.from({ length: columnCount }, (_, columnIndex) =>
-      cellWithText(
-        sourceRow[columnIndex] ??
-          sourceRow[sourceRow.length - 1] ??
-          currentColumns[columnIndex],
-        exactDensityText(
-          `${name} row ${rowIndex + 1} column ${columnIndex + 1}`,
-          cellTextLength,
-          density,
-        ),
-      ),
-    );
+}
+
+function repeatedItemsAtDensity(
+  items: unknown[],
+  targetCount: number,
+  centerWhenReduced: boolean,
+) {
+  if (items.length === 0 || targetCount === 0) return [];
+  const start =
+    centerWhenReduced && targetCount < items.length
+      ? Math.floor((items.length - targetCount) / 2)
+      : 0;
+
+  return Array.from({ length: targetCount }, (_, index) => {
+    const sourceIndex =
+      targetCount < items.length
+        ? start + index
+        : Math.min(index, items.length - 1);
+    const source = cloneLayout(items[sourceIndex]);
+    if (!isRecord(source)) return source;
+    delete source.__presenton_manual_position;
+    if (index >= items.length) normalizeRepeatedNames(source, index);
+    return source;
   });
+}
+
+function structuralArrayCanChange(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const type = readString(value.type);
+  const children = readArray(value.children);
+
+  if (isRepeatableStructuralElement(value)) {
+    const currentCount = children.length;
+    const minimum =
+      type === "group"
+        ? Math.floor(currentCount / 2)
+        : readNumber(value.min_children);
+    const maximum =
+      type === "group" ? currentCount : readNumber(value.max_children);
+    if (
+      densityTargetCount("Low", currentCount, minimum, maximum) !==
+      densityTargetCount("High", currentCount, minimum, maximum)
+    ) {
+      return true;
+    }
+  }
+
+  return (
+    structuralArrayCanChange(value.child) ||
+    children.some(structuralArrayCanChange)
+  );
+}
+
+function componentArrayCanChange(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const elements = readArray(value.elements);
+  if (elements.some(structuralArrayCanChange)) return true;
+
+  const allTopLevelGroups =
+    elements.length >= 2 &&
+    elements.every(
+      (element) => isRecord(element) && readString(element.type) === "group",
+    );
+  if (!allTopLevelGroups) return false;
+
+  return Boolean(
+    repeatedChildrenSchema(
+      { type: "group", children: elements },
+      elements.map(comparableSchemaNodesForElement),
+    ),
+  );
+}
+
+export function hasLayoutContentDensityTargets(layout: TemplateV2Layout) {
+  const fields = collectSchemaFields(layout);
+  if (
+    fields.some(
+      (field) =>
+        !field.decorative &&
+        (field.type === "text" ||
+          field.type === "text-list"),
+    )
+  ) {
+    return true;
+  }
+
+  const layoutRecord = layout as UnknownRecord;
+  return (
+    readArray(layoutRecord.elements).some(structuralArrayCanChange) ||
+    readArray(layoutRecord.components).some(componentArrayCanChange)
+  );
 }
 
 function resizeRepeatedChildren(
@@ -239,103 +599,60 @@ function resizeRepeatedChildren(
   density: ContentDensity,
 ) {
   const type = readString(element.type);
-  if (type !== "flex" && type !== "grid") return;
+  if (type !== "flex" && type !== "grid" && type !== "group") return;
 
   const children = readArray(element.children);
-  const minChildren = readNumber(element.min_children);
-  const maxChildren = readNumber(element.max_children);
-  if (minChildren === undefined && maxChildren === undefined) return;
+  if (!isRepeatableStructuralElement(element)) return;
 
-  const targetCount = densityCount(minChildren, maxChildren, density);
+  const minimum =
+    type === "group"
+      ? Math.floor(children.length / 2)
+      : readNumber(element.min_children);
+  const maximum =
+    type === "group" ? children.length : readNumber(element.max_children);
+  const targetCount = densityTargetCount(
+    density,
+    children.length,
+    minimum,
+    maximum,
+  );
   if (targetCount === children.length) return;
-  if (!childrenCanRepeat(children, maxChildren)) return;
 
-  const nextChildren = children.slice(0, targetCount).map(cloneLayout);
-  while (nextChildren.length < targetCount) {
-    const index = nextChildren.length;
-    const source =
-      children[index] ??
-      children[children.length - 1] ??
-      children[0] ??
-      { type: "group", children: [] };
-    const nextChild = cloneLayout(source);
-    normalizeRepeatedNames(nextChild, index);
-    nextChildren.push(nextChild);
-  }
-  element.children = nextChildren;
+  element.children = repeatedItemsAtDensity(
+    children,
+    targetCount,
+    type === "group",
+  );
 }
 
-function childrenCanRepeat(children: unknown[], maxChildren?: number) {
-  if (children.length === 0) return false;
-  if (children.length === 1) {
-    return maxChildren !== undefined && maxChildren > 1;
-  }
-
-  return (["none", "numeric"] as const).some((strategy) => {
-    const signatures = children.map((child) =>
-      JSON.stringify(contentShape(child, strategy)),
-    );
-    return (
-      signatures[0] !== "null" &&
-      signatures.every((signature) => signature === signatures[0])
-    );
-  });
-}
-
-function contentShape(
-  value: unknown,
-  nameStrategy: "none" | "numeric",
-): unknown {
-  if (!isRecord(value)) return null;
-
-  const type = readString(value.type);
-  const name = normalizedContentName(readString(value.name), nameStrategy);
-  if (
-    value.decorative === false &&
-    name &&
-    ["text", "image", "text-list", "table", "chart", "infographic"].includes(
-      type,
-    )
-  ) {
-    return {
-      type,
-      name,
-      min_length: value.min_length,
-      max_length: value.max_length,
-      min_items: value.min_items,
-      max_items: value.max_items,
-      min_item_length: value.min_item_length,
-      max_item_length: value.max_item_length,
-    };
-  }
-
-  const childShape = contentShape(value.child, nameStrategy);
-  const childrenShapes = readArray(value.children)
-    .map((child) => contentShape(child, nameStrategy))
-    .filter((shape) => shape !== null);
-  const elementShapes = readArray(value.elements)
-    .map((child) => contentShape(child, nameStrategy))
-    .filter((shape) => shape !== null);
-
-  if (!childShape && childrenShapes.length === 0 && elementShapes.length === 0) {
-    return null;
-  }
-  return {
-    type,
-    name: name || undefined,
-    child: childShape || undefined,
-    children: childrenShapes.length ? childrenShapes : undefined,
-    elements: elementShapes.length ? elementShapes : undefined,
-  };
-}
-
-function normalizedContentName(
-  name: string,
-  strategy: "none" | "numeric",
+function resizeRepeatedComponentElements(
+  component: UnknownRecord,
+  density: ContentDensity,
 ) {
-  const trimmedName = name.trim();
-  if (strategy === "none") return trimmedName;
-  return trimmedName.replace(/_\d+(?=_|$)/, "").replace(/_\d+$/, "");
+  const elements = readArray(component.elements);
+  const allTopLevelGroups =
+    elements.length > 0 &&
+    elements.every(
+      (element) => isRecord(element) && readString(element.type) === "group",
+    );
+  if (!allTopLevelGroups) return;
+
+  const repeatedSchema = repeatedChildrenSchema(
+    { type: "group", children: elements },
+    elements.map(comparableSchemaNodesForElement),
+  );
+  if (!repeatedSchema) return;
+
+  component.elements = repeatedItemsAtDensity(
+    elements,
+    densityTargetCount(
+      density,
+      elements.length,
+      Math.floor(elements.length / 2),
+      elements.length,
+    ),
+    true,
+  );
 }
 
 function normalizeRepeatedNames(value: unknown, index: number): void {
@@ -473,12 +790,6 @@ function setRunsTextOnValue(value: unknown, text: string) {
   if (!isRecord(value)) return;
   if (!Array.isArray(value.runs)) value.runs = [{ text }];
   setElementRunsText(value, text);
-}
-
-function cellWithText(source: unknown, text: string) {
-  const cell = cloneLayout(isRecord(source) ? source : { runs: [{ text: "" }] });
-  setElementRunsText(cell, text);
-  return cell;
 }
 
 function syncComponentCanvasFields(
@@ -696,6 +1007,8 @@ export function collectSchemaFields(layout: TemplateV2Layout) {
           value,
           minChars: readNumber(element.min_item_length),
           maxChars: readNumber(element.max_item_length),
+          minItems: readNumber(element.min_items),
+          maxItems: readNumber(element.max_items),
         });
       }
     }

--- a/servers/nextjs/components/slide-editor/importing/template-v2-import.ts
+++ b/servers/nextjs/components/slide-editor/importing/template-v2-import.ts
@@ -822,6 +822,8 @@ function adaptTextList(raw: UnknownRecord): SlideElement {
     type: "text-list",
     font,
     marker,
+    gap: clampOptional(readNumber(raw, "gap"), 0, 720),
+    marker_gap: clampOptional(readNumber(raw, "marker_gap"), 0, 720),
     items: adaptTextListItems(readArray(raw, "items")),
     max_items: readNumber(raw, "max_items"),
     min_items: readNumber(raw, "min_items"),
@@ -1047,6 +1049,7 @@ function adaptInfographic(raw: UnknownRecord): SlideElement {
         "chevron_process",
         "radial_cycle",
         "conversion_funnel",
+        "vertical_funnel",
         "pyramid",
         "segmented_wheel",
         "customer_journey",
@@ -1079,6 +1082,7 @@ function adaptInfographic(raw: UnknownRecord): SlideElement {
         "chevron_process",
         "radial_cycle",
         "conversion_funnel",
+        "vertical_funnel",
         "pyramid",
         "segmented_wheel",
         "customer_journey",
@@ -1149,6 +1153,7 @@ function adaptInfographicData(
     | "chevron_process"
     | "radial_cycle"
     | "conversion_funnel"
+    | "vertical_funnel"
     | "pyramid"
     | "segmented_wheel"
     | "customer_journey"
@@ -1271,7 +1276,7 @@ function adaptInfographicData(
     return { type, center_label: truncateString(readString(data.center_label) ?? "RISK", 4), items: defaults.map((heading, index) => items[index] ?? { heading }) };
   }
 
-  if (type === "conversion_funnel") {
+  if (type === "conversion_funnel" || type === "vertical_funnel") {
     const items = readArray(data, "items")
       .map(asRecord)
       .filter((item): item is UnknownRecord => Boolean(item))

--- a/servers/nextjs/components/slide-editor/infographics/InfographicEditorContent.tsx
+++ b/servers/nextjs/components/slide-editor/infographics/InfographicEditorContent.tsx
@@ -39,6 +39,7 @@ import type {
   RiskMatrixInfographicData,
   TimelineInfographicItem,
   TransformationHubInfographicData,
+  VerticalFunnelInfographicData,
 } from "@/components/slide-editor/types";
 import {
   appendInfographicColor,
@@ -75,6 +76,7 @@ const TYPE_LABELS: Record<InfographicType, string> = {
   chevron_process: "Chevron Process",
   radial_cycle: "Radial Cycle",
   conversion_funnel: "Conversion Funnel",
+  vertical_funnel: "Vertical Funnel",
   pyramid: "Pyramid",
   segmented_wheel: "Segmented Wheel",
   customer_journey: "Customer Journey",
@@ -329,8 +331,14 @@ export function InfographicDataEditorContent({
                 />
               ) : null}
               {type === "conversion_funnel" ? (
-                <ConversionFunnelEditor
+                <FunnelEditor
                   data={readConversionFunnelData(draft.data)}
+                  onChange={updateData}
+                />
+              ) : null}
+              {type === "vertical_funnel" ? (
+                <FunnelEditor
+                  data={readVerticalFunnelData(draft.data)}
                   onChange={updateData}
                 />
               ) : null}
@@ -1246,12 +1254,14 @@ function RadialCycleEditor({
   );
 }
 
-function ConversionFunnelEditor({
+function FunnelEditor({
   data,
   onChange,
 }: {
-  data: ConversionFunnelInfographicData;
-  onChange: (data: ConversionFunnelInfographicData) => void;
+  data: ConversionFunnelInfographicData | VerticalFunnelInfographicData;
+  onChange: (
+    data: ConversionFunnelInfographicData | VerticalFunnelInfographicData,
+  ) => void;
 }) {
   return (
     <ItemCollectionEditor<ConversionFunnelInfographicItem>
@@ -2548,6 +2558,10 @@ function readConversionFunnelData(
   };
 }
 
+function readVerticalFunnelData(value: unknown): VerticalFunnelInfographicData {
+  return { ...readConversionFunnelData(value), type: "vertical_funnel" };
+}
+
 function readMindMapData(value: unknown): MindMapInfographicData {
   const data = readRecord(value);
   const items = readArray(data.items).map(readMindMapNode);
@@ -2638,6 +2652,7 @@ function readInfographicType(value: unknown): InfographicType {
     value === "chevron_process" ||
     value === "radial_cycle" ||
     value === "conversion_funnel" ||
+    value === "vertical_funnel" ||
     value === "pyramid" ||
     value === "segmented_wheel" ||
     value === "customer_journey" ||

--- a/servers/nextjs/components/slide-editor/infographics/infographic-editing.ts
+++ b/servers/nextjs/components/slide-editor/infographics/infographic-editing.ts
@@ -590,6 +590,7 @@ function createInfographicToolbarItem(
       };
     }
     case "conversion_funnel":
+    case "vertical_funnel":
       return {
         value: Math.max(0, readInfographicNumber(previous?.value, 60) - 10),
         heading: `Stage ${index + 1}`,
@@ -629,7 +630,7 @@ function toolbarItemHeading(
   }
   if (type === "pillar_framework") return `Pillar ${index + 1}`;
   if (type === "transformation_hub") return `Capability ${index + 1}`;
-  if (type === "conversion_funnel") return `Stage ${index + 1}`;
+  if (type === "conversion_funnel" || type === "vertical_funnel") return `Stage ${index + 1}`;
   if (type === "roadmap") return `Stop ${index + 1}`;
   if (type === "pyramid") return `Level ${index + 1}`;
   if (type === "segmented_wheel") return `Segment ${index + 1}`;
@@ -647,6 +648,7 @@ function typeUsesToolbarIcons(type: InfographicType) {
     type === "chevron_process" ||
     type === "radial_cycle" ||
     type === "conversion_funnel" ||
+    type === "vertical_funnel" ||
     type === "transformation_hub"
   );
 }
@@ -700,7 +702,7 @@ function infographicType(value: unknown): InfographicType | null {
       "milestone_timeline", "staircase", "supply_chain",
       "stair_step_blocks", "maturity_model", "diagonal_circles",
       "pillar_framework", "transformation_hub", "risk_matrix",
-      "chevron_process", "radial_cycle", "conversion_funnel", "pyramid",
+      "chevron_process", "radial_cycle", "conversion_funnel", "vertical_funnel", "pyramid",
       "segmented_wheel", "customer_journey", "before_after",
       "impact_effort_matrix", "comparison_matrix", "org_chart",
       "decision_tree", "mind_map",

--- a/servers/nextjs/components/slide-editor/infographics/infographic-sizing.ts
+++ b/servers/nextjs/components/slide-editor/infographics/infographic-sizing.ts
@@ -154,6 +154,8 @@ export function infographicContentSize(
       return contentSize(380 + itemCount * 30, 340 + itemCount * 30);
     case "conversion_funnel":
       return contentSize(320 + itemCount * 100, 200 + itemCount * 30);
+    case "vertical_funnel":
+      return contentSize(620, 240 + itemCount * 60);
     case "pyramid":
       return contentSize(560 + itemCount * 40, 160 + itemCount * 60);
     case "segmented_wheel":

--- a/servers/nextjs/components/slide-editor/insert/insert-elements.ts
+++ b/servers/nextjs/components/slide-editor/insert/insert-elements.ts
@@ -656,6 +656,9 @@ function infographicTypeFromPaletteId(id?: string): InfographicType | null {
     case "conversion_funnel":
     case "conversion-funnel":
       return "conversion_funnel";
+    case "vertical_funnel":
+    case "vertical-funnel":
+      return "vertical_funnel";
     case "pyramid":
       return "pyramid";
     case "segmented_wheel":
@@ -1157,6 +1160,43 @@ function makeInfographicElement(infographicType: InfographicType): SlideElement 
       text_color: null,
       decorative: false,
       name: "conversion_funnel",
+    };
+  }
+
+  if (infographicType === "vertical_funnel") {
+    return {
+      type: "infographic",
+      position: { ...DEFAULT_INFOGRAPHIC_INSERT_POSITION },
+      size: { width: 720, height: 480 },
+      data: {
+        type: "vertical_funnel",
+        items: [
+          {
+            value: 100,
+            heading: "Awareness",
+            description: "The full audience entering the funnel.",
+          },
+          {
+            value: 60,
+            heading: "Interest",
+            description: "People engaging with the offering.",
+          },
+          {
+            value: 35,
+            heading: "Consideration",
+            description: "Prospects evaluating the solution.",
+          },
+          {
+            value: 20,
+            heading: "Conversion",
+            description: "People completing the target action.",
+          },
+        ],
+      },
+      colors: ["FFFFFF", "102E79", "24468E", "4D73BE", "7CA2E5"],
+      text_color: null,
+      decorative: false,
+      name: "vertical_funnel",
     };
   }
 

--- a/servers/nextjs/components/slide-editor/layout/InfographicToolbarControls.tsx
+++ b/servers/nextjs/components/slide-editor/layout/InfographicToolbarControls.tsx
@@ -329,6 +329,7 @@ function readInfographicType(value: unknown): InfographicType {
     value === "chevron_process" ||
     value === "radial_cycle" ||
     value === "conversion_funnel" ||
+    value === "vertical_funnel" ||
     value === "pyramid" ||
     value === "segmented_wheel" ||
     value === "customer_journey" ||

--- a/servers/nextjs/components/slide-editor/surface/nodes.tsx
+++ b/servers/nextjs/components/slide-editor/surface/nodes.tsx
@@ -3689,11 +3689,6 @@ function RawInfographicElement({
     );
   }
 
-  const value =
-    readNumber(data?.value) ??
-    readNumber(element.value) ??
-    0;
-
   if (infographicType === "progress_bar") {
     const radius = Math.min(height / 2, 8);
     return (
@@ -3752,19 +3747,6 @@ function RawInfographicElement({
           <Circle x={end.x} y={end.y} radius={capRadius} fill={highlightColor} />
         </>
       ) : null}
-      <Text
-        x={0}
-        y={height * 0.5}
-        width={width}
-        height={height * 0.3}
-        text={String(Math.round(value))}
-        fontFamily="Arial, Helvetica, sans-serif"
-        fontSize={Math.max(10, Math.min(width, height) * 0.22)}
-        fontStyle="bold"
-        align="center"
-        verticalAlign="middle"
-        fill={customTextColor ?? "#172033"}
-      />
     </Group>
   );
 }

--- a/servers/nextjs/components/slide-editor/surface/nodes.tsx
+++ b/servers/nextjs/components/slide-editor/surface/nodes.tsx
@@ -3593,6 +3593,20 @@ function RawInfographicElement({
     );
   }
 
+  if (infographicType === "vertical_funnel") {
+    return (
+      <RawVerticalFunnelInfographic
+        data={data}
+        width={width}
+        height={height}
+        interactive={interactive}
+        baseColor={baseColor}
+        palette={palette}
+        textColor={customTextColor}
+      />
+    );
+  }
+
   if (infographicType === "pyramid") {
     return (
       <RawPyramidInfographic
@@ -5270,6 +5284,111 @@ function RawConversionFunnelInfographic({
               fontFamily="Arial, Helvetica, sans-serif"
               fontSize={Math.max(8, Math.min(11, height * 0.033))}
               lineHeight={1.15}
+              fill={textColor}
+            />
+          </InfographicItemGroup>
+        );
+      })}
+    </Group>
+  );
+}
+
+function RawVerticalFunnelInfographic({
+  baseColor,
+  data,
+  height,
+  interactive,
+  palette,
+  textColor: customTextColor,
+  width,
+}: {
+  baseColor: string;
+  data: RawElement | null;
+  height: number;
+  interactive: boolean;
+  palette: string[];
+  textColor: string | null;
+  width: number;
+}) {
+  const items = readArray(data?.items).map(asRecord).filter(Boolean).slice(0, 8);
+  const safeItems = items.length > 0 ? items : [{ value: 50, heading: "Stage" }];
+  const darkBackground = isDarkInfographicColor(baseColor);
+  const textColor = customTextColor ?? (darkBackground ? "#F0F1F4" : "#111111");
+  const top = height * 0.08;
+  const bottom = height * 0.08;
+  const stageHeight = (height - top - bottom) / safeItems.length;
+  const centerX = width * 0.5;
+  const maxFunnelWidth = width * 0.42;
+  const valueAt = (index: number) =>
+    clamp(readNumber(safeItems[index]?.value) ?? 0, 0, 100);
+  const widthAt = (value: number) => Math.max(4, (value / 100) * maxFunnelWidth);
+
+  return (
+    <Group listening={interactive}>
+      {safeItems.map((item, index) => {
+        const y0 = top + index * stageHeight;
+        const y1 = y0 + stageHeight;
+        const topWidth = widthAt(valueAt(index));
+        const bottomWidth = widthAt(valueAt(Math.min(index + 1, safeItems.length - 1)));
+        const heading = readString(item?.heading) ?? `Stage ${index + 1}`;
+        const description = readString(item?.description) ?? "";
+        return (
+          <InfographicItemGroup
+            key={`vertical-funnel-stage-${index}`}
+            interactive={interactive}
+            item={item}
+            itemPath={[index]}
+          >
+            <Line
+              points={[width * 0.19, y0, width * 0.855, y0]}
+              stroke="#D1D5DB"
+              strokeWidth={1}
+            />
+            <Line
+              closed
+              points={[
+                centerX - topWidth / 2,
+                y0,
+                centerX + topWidth / 2,
+                y0,
+                centerX + bottomWidth / 2,
+                y1,
+                centerX - bottomWidth / 2,
+                y1,
+              ]}
+              fill={palette[index % palette.length] ?? "#2563EB"}
+            />
+            <Text
+              x={width * 0.025}
+              y={y0 - height * 0.026}
+              width={width * 0.255}
+              text={heading}
+              fontFamily="Arial, Helvetica, sans-serif"
+              fontSize={Math.max(11, Math.min(17, height * 0.032))}
+              fontStyle="bold"
+              fill={textColor}
+            />
+            {description ? (
+              <Text
+                x={width * 0.025}
+                y={y0 + height * 0.012}
+                width={width * 0.255}
+                height={stageHeight * 0.45}
+                text={description}
+                fontFamily="Arial, Helvetica, sans-serif"
+                fontSize={Math.max(8, Math.min(11, height * 0.021))}
+                lineHeight={1.15}
+                fill={textColor}
+              />
+            ) : null}
+            <Text
+              x={width * 0.872}
+              y={y0 - height * 0.026}
+              width={width * 0.105}
+              text={`${Math.round(valueAt(index) * 10) / 10}%`}
+              fontFamily="Arial, Helvetica, sans-serif"
+              fontSize={Math.max(11, Math.min(17, height * 0.032))}
+              fontStyle="bold"
               fill={textColor}
             />
           </InfographicItemGroup>

--- a/servers/nextjs/components/slide-editor/text/template-v2-text.ts
+++ b/servers/nextjs/components/slide-editor/text/template-v2-text.ts
@@ -415,7 +415,7 @@ export function rawTextListRenderItems(
       .map((run) => renderTextRun(run, baseFont));
 
     return {
-      marker: textListMarkerPrefix(element.marker, index),
+      marker: textListMarkerText(element.marker, index),
       markerFont,
       runs: runs.length > 0 ? runs : [{ text: " ", font: markerFont }],
     };
@@ -883,6 +883,7 @@ export function layoutTextListRenderItems(
     marker: RenderTextRun & { width: number } | null;
     segments: Array<RenderTextRun & { width: number }>;
     indentWidth: number;
+    gapBefore: number;
     height: number;
     width: number;
   };
@@ -893,11 +894,23 @@ export function layoutTextListRenderItems(
       ? items
       : [{ marker: "", markerFont: font, runs: [{ text: " ", font }] }];
 
-  for (const item of sourceItems) {
-    const markerWidth = item.marker
+  const itemGap = Math.max(0, readNumber(element.gap) ?? 0);
+  const explicitMarkerGap = readNumber(
+    element.marker_gap ?? element.markerGap,
+  );
+
+  sourceItems.forEach((item, itemIndex) => {
+    const markerTextWidth = item.marker
       ? measureRenderText(item.marker, item.markerFont)
       : 0;
-    const contentWidth = Math.max(1, width - markerWidth);
+    const markerGap = item.marker
+      ? Math.max(
+          0,
+          explicitMarkerGap ?? measureRenderText(" ", item.markerFont),
+        )
+      : 0;
+    const indentWidth = markerTextWidth + markerGap;
+    const contentWidth = Math.max(1, width - indentWidth);
     const contentLines = layoutRenderTextRuns(
       item.runs.length > 0 ? item.runs : [{ text: " ", font: item.markerFont }],
       contentWidth,
@@ -908,7 +921,7 @@ export function layoutTextListRenderItems(
     lines.forEach((line, lineIndex) => {
       const marker =
         lineIndex === 0 && item.marker
-          ? { text: item.marker, font: item.markerFont, width: markerWidth }
+          ? { text: item.marker, font: item.markerFont, width: markerTextWidth }
           : null;
       const markerHeight = marker
         ? marker.font.size * (marker.font.lineHeight ?? textLineHeight)
@@ -922,25 +935,27 @@ export function layoutTextListRenderItems(
         font.size * textLineHeight,
       );
       const lineWidth =
-        markerWidth + line.reduce((sum, segment) => sum + segment.width, 0);
+        indentWidth + line.reduce((sum, segment) => sum + segment.width, 0);
       plannedLines.push({
         marker,
         segments: line,
-        indentWidth: markerWidth,
+        indentWidth,
+        gapBefore: itemIndex > 0 && lineIndex === 0 ? itemGap : 0,
         height: lineHeight,
         width: lineWidth,
       });
     });
-  }
+  });
 
   const contentHeight = plannedLines.reduce(
-    (sum, line) => sum + line.height,
+    (sum, line) => sum + line.gapBefore + line.height,
     0,
   );
   let y = verticalTextStartY(verticalAlign, height, contentHeight, false);
   const tokens: LaidToken[] = [];
 
   for (const line of plannedLines) {
+    y += line.gapBefore;
     const startX = lineStartX(align, width, line.width, false);
     let x = startX;
 
@@ -1208,8 +1223,21 @@ export function scaleRawTextMetrics(
     return element;
   }
 
+  const gap = readNumber(element.gap);
+  const markerGap = readNumber(element.marker_gap);
+  const camelMarkerGap = readNumber(element.markerGap);
+
   return stripUndefined({
     ...element,
+    gap: gap == null ? element.gap : scaleTextMetric(gap, scale),
+    marker_gap:
+      markerGap == null
+        ? element.marker_gap
+        : scaleTextMetric(markerGap, scale),
+    markerGap:
+      camelMarkerGap == null
+        ? element.markerGap
+        : scaleTextMetric(camelMarkerGap, scale),
     font: scaleRawFontMetrics(element.font, scale),
     runs: scaleRawTextRunsMetrics(element.runs, scale),
     items: scaleRawTextListItemsMetrics(element.items, scale),
@@ -1370,10 +1398,15 @@ function rawRunRecordContent(value: unknown) {
 }
 
 function textListMarkerPrefix(value: unknown, index: number) {
+  const marker = textListMarkerText(value, index);
+  return marker ? `${marker} ` : "";
+}
+
+function textListMarkerText(value: unknown, index: number) {
   const marker = readString(value);
   if (marker === "none") return "";
-  if (marker === "number") return `${index + 1}. `;
-  return "• ";
+  if (marker === "number") return `${index + 1}.`;
+  return "•";
 }
 
 function rawTextListItemWithRuns(source: unknown, runs: TextRun[]): unknown {

--- a/servers/nextjs/components/slide-editor/types.ts
+++ b/servers/nextjs/components/slide-editor/types.ts
@@ -55,6 +55,7 @@ export type InfographicType =
   | "chevron_process"
   | "radial_cycle"
   | "conversion_funnel"
+  | "vertical_funnel"
   | "pyramid"
   | "segmented_wheel"
   | "customer_journey"
@@ -182,6 +183,11 @@ export type ConversionFunnelInfographicData = {
   items: ConversionFunnelInfographicItem[];
 };
 
+export type VerticalFunnelInfographicData = {
+  type: "vertical_funnel";
+  items: ConversionFunnelInfographicItem[];
+};
+
 export type PyramidInfographicData = {
   type: "pyramid";
   items: TimelineInfographicItem[];
@@ -280,6 +286,7 @@ export type InfographicData = (
   | TransformationHubInfographicData
   | RiskMatrixInfographicData
   | ConversionFunnelInfographicData
+  | VerticalFunnelInfographicData
   | MindMapInfographicData
 ) & {
   card_color?: string | null;
@@ -474,6 +481,8 @@ export type TextListElement = ElementBase & {
   type: "text-list";
   font?: Font | null;
   marker?: Marker | null;
+  gap?: number | null;
+  marker_gap?: number | null;
   items: TextListItem[];
   max_items?: number | null;
   min_items?: number | null;

--- a/servers/nextjs/lib/template-v2-json-to-html.ts
+++ b/servers/nextjs/lib/template-v2-json-to-html.ts
@@ -48,6 +48,7 @@ type InfographicKind =
   | "chevron_process"
   | "radial_cycle"
   | "conversion_funnel"
+  | "vertical_funnel"
   | "pyramid"
   | "segmented_wheel"
   | "customer_journey"
@@ -406,18 +407,33 @@ function renderTextList(item: JsonRecord, mode: RenderMode): string {
   const marker = readString(item.marker);
   const tag = marker === "number" ? "ol" : "ul";
   const font = readRecord(item.font);
+  const itemGap = Math.max(0, readNumber(item.gap) ?? 0);
+  const rawMarkerGap = readNumber(item.marker_gap ?? item.markerGap);
+  const markerGap = rawMarkerGap == null ? null : Math.max(0, rawMarkerGap);
+  const usesCustomMarkers = marker !== "none" && markerGap != null;
   const entries = readArray(item.items)
-    .map((entry) => {
+    .map((entry, index) => {
       const runs = normalizedListRunsForHtml(entry, font);
       const html = runs
         .map((run) =>
           renderTextRunHtml(run, { ...font, ...readRecord(run.font) }),
         )
         .join("");
-      return `<li style="${textOverflowStyle()}">${html}</li>`;
+      const gapStyle =
+        index > 0 && itemGap > 0
+          ? `margin-top:${cssNumber(itemGap)}px;`
+          : "";
+      if (usesCustomMarkers) {
+        const markerText = marker === "number" ? `${index + 1}.` : "•";
+        return `<li style="${gapStyle}display:grid;grid-template-columns:max-content minmax(0,1fr);column-gap:${cssNumber(
+          markerGap
+        )}px;${textOverflowStyle()}"><span aria-hidden="true">${markerText}</span><span>${html}</span></li>`;
+      }
+      return `<li style="${gapStyle}${textOverflowStyle()}">${html}</li>`;
     })
     .join("");
-  const listStyle = `margin:0;padding-left:${marker === "none" ? 0 : 24}px;${marker === "none" ? "list-style-type:none;" : ""
+  const hidesNativeMarkers = marker === "none" || usesCustomMarkers;
+  const listStyle = `margin:0;padding-left:${hidesNativeMarkers ? 0 : 24}px;${hidesNativeMarkers ? "list-style-type:none;" : ""
     }`;
 
   return `<div style="${frameStyle(item, mode)}${transformStyle(item)}${fontStyle(
@@ -943,6 +959,10 @@ const FIXED_INFOGRAPHIC_RENDERERS: Partial<
     designSize: { width: 720, height: 320 },
     renderer: renderConversionFunnelInfographic,
   },
+  vertical_funnel: {
+    designSize: { width: 720, height: 480 },
+    renderer: renderVerticalFunnelInfographic,
+  },
   pyramid: { designSize: { width: 720, height: 400 }, renderer: renderPyramidInfographic },
   segmented_wheel: {
     designSize: { width: 720, height: 460 },
@@ -1459,6 +1479,48 @@ function renderConversionFunnelInfographic(item: JsonRecord, mode: RenderMode): 
   return `<div style="${frameStyle(item, mode, { width: 720, height: 320 })}${transformStyle(
     item
   )}position:relative;overflow:hidden"><svg width="100%" height="100%" viewBox="0 0 720 320" preserveAspectRatio="none" style="position:absolute;inset:0;display:block">${fills}<path d="${curvePath}" fill="none" stroke="${escapeAttribute(escapeCssColor(colors[(safeEntries.length + 1) % colors.length]))}" stroke-width="6" stroke-linejoin="round"/>${separators}<rect x=".75" y=".75" width="718.5" height="318.5" fill="none" stroke="#D1D1D1" stroke-width="1.5"/></svg>${labels}</div>`;
+}
+
+function renderVerticalFunnelInfographic(item: JsonRecord, mode: RenderMode): string {
+  const data = infographicData(item);
+  const entries = readArray(data.items).map(readRecord).slice(0, 8);
+  const safeEntries = entries.length > 0 ? entries : [{ value: 50, heading: "Stage" }];
+  const colors = infographicPalette(item);
+  const background = infographicBaseColor(item);
+  const dark = isDarkInfographicColor(background);
+  const textColor = infographicTextColor(item, dark ? "#F0F1F4" : "#111111");
+  const top = 38;
+  const bottom = 38;
+  const funnelCenterX = 360;
+  const maxFunnelWidth = 300;
+  const stageHeight = (480 - top - bottom) / safeEntries.length;
+  const valueAt = (index: number) => clamp(readNumber(safeEntries[index]?.value) ?? 0, 0, 100);
+  const widthAt = (value: number) => Math.max(4, (value / 100) * maxFunnelWidth);
+  const guides = safeEntries.map((_, index) => {
+    const y = top + index * stageHeight;
+    return `<line x1="140" y1="${cssNumber(y)}" x2="615" y2="${cssNumber(y)}" stroke="#D1D5DB" stroke-width="1"/>`;
+  }).join("");
+  const fills = safeEntries.map((_, index) => {
+    const y0 = top + index * stageHeight;
+    const y1 = y0 + stageHeight;
+    const topWidth = widthAt(valueAt(index));
+    const bottomWidth = widthAt(valueAt(Math.min(index + 1, safeEntries.length - 1)));
+    const points = [
+      `${cssNumber(funnelCenterX - topWidth / 2)},${cssNumber(y0)}`,
+      `${cssNumber(funnelCenterX + topWidth / 2)},${cssNumber(y0)}`,
+      `${cssNumber(funnelCenterX + bottomWidth / 2)},${cssNumber(y1)}`,
+      `${cssNumber(funnelCenterX - bottomWidth / 2)},${cssNumber(y1)}`,
+    ].join(" ");
+    return `<polygon points="${points}" fill="${escapeAttribute(escapeCssColor(colors[index % colors.length]))}"/>`;
+  }).join("");
+  const labels = safeEntries.map((entry, index) => {
+    const y = top + index * stageHeight;
+    const value = valueAt(index);
+    return `<div style="position:absolute;left:18px;top:${cssNumber(y - 12)}px;width:185px;color:${escapeCssColor(textColor)};font-family:Arial,Helvetica,sans-serif"><div style="font-size:15px;font-weight:700;line-height:1.1">${escapeHtml(readString(entry.heading) ?? `Stage ${index + 1}`)}</div><div style="padding-top:5px;font-size:10px;line-height:1.15">${escapeHtml(readString(entry.description) ?? "")}</div></div><div style="position:absolute;left:628px;top:${cssNumber(y - 12)}px;width:74px;color:${escapeCssColor(textColor)};font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:700;line-height:1.1">${cssNumber(value)}%</div>`;
+  }).join("");
+  return `<div style="${frameStyle(item, mode, { width: 720, height: 480 })}${transformStyle(
+    item
+  )}position:relative;overflow:hidden"><svg width="100%" height="100%" viewBox="0 0 720 480" preserveAspectRatio="none" style="position:absolute;inset:0;display:block">${guides}${fills}</svg>${labels}</div>`;
 }
 
 function renderPyramidInfographic(item: JsonRecord, mode: RenderMode): string {
@@ -2752,6 +2814,7 @@ function infographicKindFromValue(value: string | null): InfographicKind {
     value === "chevron_process" ||
     value === "radial_cycle" ||
     value === "conversion_funnel" ||
+    value === "vertical_funnel" ||
     value === "pyramid" ||
     value === "segmented_wheel" ||
     value === "customer_journey" ||

--- a/servers/nextjs/tests/infographic-rendering.test.mjs
+++ b/servers/nextjs/tests/infographic-rendering.test.mjs
@@ -53,6 +53,7 @@ const structuralTypes = [
   "chevron_process",
   "radial_cycle",
   "conversion_funnel",
+  "vertical_funnel",
   "pyramid",
   "segmented_wheel",
   "customer_journey",
@@ -110,6 +111,34 @@ test("preserves aspect ratio and centers fixed-layout infographics", () => {
 
   assert.match(html, /transform:scale\(0\.5\)/);
   assert.match(html, /top:115px/);
+});
+
+test("renders vertical funnel bands proportionally to stage percentages", () => {
+  const html = renderer.templateV2UiToHtml({
+    elements: [
+      {
+        type: "infographic",
+        position: { x: 0, y: 0 },
+        size: { width: 720, height: 480 },
+        data: {
+          type: "vertical_funnel",
+          items: [
+            { value: 100, heading: "Awareness" },
+            { value: 50, heading: "Interest" },
+            { value: 25, heading: "Conversion" },
+          ],
+        },
+        colors: ["#EFF4EA", "#285B20", "#73926B", "#B7C8B2"],
+      },
+    ],
+    components: [],
+  });
+
+  assert.match(html, /points="210,38 510,38 435,172\.6+ 285,172\.6+"/);
+  assert.match(html, /points="285,172\.6+ 435,172\.6+ 397\.5,307\.3+ 322\.5,307\.3+"/);
+  assert.match(html, />100%<\/div>/);
+  assert.match(html, />50%<\/div>/);
+  assert.match(html, />25%<\/div>/);
 });
 
 test("preserves infographic item offsets and image edits in export HTML", () => {

--- a/servers/nextjs/tests/template-preview-density.test.mjs
+++ b/servers/nextjs/tests/template-preview-density.test.mjs
@@ -1,0 +1,542 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { build } from "esbuild";
+
+let densityUtils;
+let temporaryDirectory;
+
+test.before(async () => {
+  temporaryDirectory = await mkdtemp(
+    path.join(tmpdir(), "presenton-template-density-"),
+  );
+  const outputFile = path.join(temporaryDirectory, "density-utils.mjs");
+
+  await build({
+    entryPoints: [
+      path.resolve(
+        "app/(presentation-generator)/template-preview/components/editor/templatePreviewUtils.ts",
+      ),
+    ],
+    outfile: outputFile,
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    tsconfig: path.resolve("tsconfig.json"),
+    logLevel: "silent",
+  });
+
+  densityUtils = await import(
+    `${pathToFileURL(outputFile).href}?cache=${Date.now()}`
+  );
+});
+
+test.after(async () => {
+  if (temporaryDirectory) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+function editableText(name, text = "Original text") {
+  return {
+    type: "text",
+    name,
+    decorative: false,
+    min_length: 4,
+    max_length: 40,
+    runs: [{ text }],
+  };
+}
+
+function repeatedCard(index, fieldName = `title_${index}`) {
+  return {
+    type: "group",
+    name: `card_${index}`,
+    children: [editableText(fieldName, `Card ${index}`)],
+  };
+}
+
+function roadmapNode(index) {
+  return {
+    type: "flex",
+    name: `process_node_${index}`,
+    direction: "column",
+    children: [
+      {
+        type: "group",
+        name: "node_badge_icon",
+        children: [
+          {
+            type: "image",
+            name: "node_badge",
+            decorative: true,
+            data: "badge.svg",
+          },
+          {
+            type: "image",
+            name: "node_icon",
+            decorative: false,
+            is_icon: true,
+            data: `icon-${index}.svg`,
+          },
+        ],
+      },
+      editableText("node_heading", `Step ${index}`),
+      editableText("node_description", "Step description"),
+    ],
+  };
+}
+
+function metricsWithLayoutOnlyWrapperDifferences() {
+  const metricText = (name, text) => ({
+    type: "text",
+    name,
+    decorative: false,
+    min_length: 1,
+    max_length: 60,
+    runs: [{ text }],
+  });
+  const contentChildren = (value, heading, description) => [
+    metricText("metric_value", value),
+    {
+      type: "flex",
+      name: "metric_text_stack",
+      direction: "column",
+      children: [
+        metricText("metric_heading", heading),
+        metricText("metric_description", description),
+      ],
+    },
+  ];
+  const divider = {
+    type: "vector",
+    decorative: true,
+    points: [
+      { x: 0, y: 0 },
+      { x: 200, y: 0 },
+    ],
+  };
+
+  return {
+    type: "group",
+    name: "metric_items",
+    children: [
+      {
+        type: "flex",
+        name: "metric_item_1",
+        direction: "row",
+        children: contentChildren(
+          "68%",
+          "Mobile-first",
+          "Primarily uses mobile",
+        ),
+      },
+      {
+        type: "flex",
+        name: "metric_item_2",
+        direction: "column",
+        children: [
+          divider,
+          {
+            type: "flex",
+            name: "metric_content",
+            direction: "row",
+            children: contentChildren(
+              "74%",
+              "Research",
+              "Compares products",
+            ),
+          },
+        ],
+      },
+      {
+        type: "flex",
+        name: "metric_item_3",
+        direction: "column",
+        children: [
+          divider,
+          {
+            type: "group",
+            name: "metric_content",
+            children: contentChildren(
+              "32%",
+              "Engagement",
+              "Prefers personalized content",
+            ),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test("uses schema min, midpoint, and max counts for text-list arrays", () => {
+  const layout = {
+    elements: [
+      {
+        type: "text-list",
+        name: "key_points",
+        decorative: false,
+        min_items: 2,
+        max_items: 4,
+        min_item_length: 4,
+        max_item_length: 30,
+        items: [
+          [{ text: "One" }],
+          [{ text: "Two" }],
+          [{ text: "Three" }],
+          [{ text: "Four" }],
+        ],
+      },
+    ],
+  };
+
+  for (const [density, expectedCount] of [
+    ["Low", 2],
+    ["Medium", 3],
+    ["High", 4],
+  ]) {
+    const preview = densityUtils.applyTemplateContentDensity(layout, density);
+    assert.equal(preview.elements[0].items.length, expectedCount);
+  }
+});
+
+test("uses min_children and max_children for repeatable flex arrays", () => {
+  const layout = {
+    components: [
+      {
+        id: "cards",
+        elements: [
+          {
+            type: "flex",
+            name: "cards",
+            min_children: 2,
+            max_children: 4,
+            children: [1, 2, 3, 4].map((index) => repeatedCard(index)),
+          },
+        ],
+      },
+    ],
+  };
+
+  for (const [density, expectedCount] of [
+    ["Low", 2],
+    ["Medium", 3],
+    ["High", 4],
+  ]) {
+    const preview = densityUtils.applyTemplateContentDensity(layout, density);
+    assert.equal(
+      preview.components[0].elements[0].children.length,
+      expectedCount,
+    );
+  }
+});
+
+test("centers reduced repeated group arrays like the backend hydrator", () => {
+  const layout = {
+    components: [
+      {
+        id: "metrics",
+        elements: [
+          {
+            type: "group",
+            name: "metrics",
+            children: [1, 2, 3, 4].map((index) => repeatedCard(index)),
+          },
+        ],
+      },
+    ],
+  };
+
+  const low = densityUtils.applyTemplateContentDensity(layout, "Low");
+  assert.deepEqual(
+    low.components[0].elements[0].children.map((child) => child.name),
+    ["card_2", "card_3"],
+  );
+
+  const medium = densityUtils.applyTemplateContentDensity(layout, "Medium");
+  assert.deepEqual(
+    medium.components[0].elements[0].children.map((child) => child.name),
+    ["card_1", "card_2", "card_3"],
+  );
+});
+
+test("supports roadmap arrays made from structurally equivalent flex children", () => {
+  const layout = {
+    components: [
+      {
+        id: "roadmap",
+        elements: [
+          {
+            type: "group",
+            name: "process_nodes",
+            children: [1, 2, 3, 4, 5, 6].map(roadmapNode),
+          },
+        ],
+      },
+    ],
+  };
+
+  assert.equal(densityUtils.hasLayoutContentDensityTargets(layout), true);
+  for (const [density, expectedCount] of [
+    ["Low", 3],
+    ["Medium", 5],
+    ["High", 6],
+  ]) {
+    const preview = densityUtils.applyTemplateContentDensity(layout, density);
+    const processNodes = preview.components[0].elements[0].children;
+    assert.equal(processNodes.length, expectedCount);
+    assert.deepEqual(
+      processNodes[0].children.map((child) => child.name),
+      ["node_badge_icon", "node_heading", "node_description"],
+    );
+  }
+
+  const low = densityUtils.applyTemplateContentDensity(layout, "Low");
+  assert.deepEqual(
+    low.components[0].elements[0].children.map(
+      (node) => node.children[0].children[1].data,
+    ),
+    ["icon-2.svg", "icon-3.svg", "icon-4.svg"],
+  );
+});
+
+test("resizes equivalent direct text, chart, and table children", () => {
+  const repeatedGroup = (name, children) => ({
+    type: "group",
+    name,
+    children,
+  });
+  const layout = {
+    components: [
+      {
+        id: "labels",
+        elements: [
+          repeatedGroup(
+            "labels",
+            [1, 2, 3, 4].map((index) =>
+              editableText(`label_${index}`, `Label ${index}`),
+            ),
+          ),
+        ],
+      },
+      {
+        id: "charts",
+        elements: [
+          repeatedGroup(
+            "charts",
+            [1, 2, 3, 4].map((index) => ({
+              type: "chart",
+              name: `chart_${index}`,
+              decorative: false,
+              chart_type: index % 2 === 0 ? "line" : "bar",
+              categories: [`Q${index}`],
+              series: [{ name: "Value", values: [index] }],
+            })),
+          ),
+        ],
+      },
+      {
+        id: "tables",
+        elements: [
+          repeatedGroup(
+            "tables",
+            [1, 2, 3, 4].map((index) => ({
+              type: "table",
+              name: `table_${index}`,
+              decorative: false,
+              min_columns: 1,
+              max_columns: 2,
+              min_rows: 1,
+              max_rows: 2,
+              columns: [{ runs: [{ text: "Metric" }] }],
+              rows: [[{ runs: [{ text: `Row ${index}` }] }]],
+            })),
+          ),
+        ],
+      },
+    ],
+  };
+
+  for (const [density, expectedCount] of [
+    ["Low", 2],
+    ["Medium", 3],
+    ["High", 4],
+  ]) {
+    const preview = densityUtils.applyTemplateContentDensity(layout, density);
+    assert.deepEqual(
+      preview.components.map(
+        (component) => component.elements[0].children.length,
+      ),
+      [expectedCount, expectedCount, expectedCount],
+    );
+  }
+
+  const low = densityUtils.applyTemplateContentDensity(layout, "Low");
+  assert.deepEqual(
+    low.components[0].elements[0].children.map((child) => child.name),
+    ["label_2", "label_3"],
+  );
+  assert.deepEqual(
+    low.components[1].elements[0].children.map((child) => child.chart_type),
+    ["line", "bar"],
+  );
+  assert.deepEqual(
+    low.components[2].elements[0].children.map(
+      (child) => child.rows[0][0].runs[0].text,
+    ),
+    ["Row 2", "Row 3"],
+  );
+});
+
+test("ignores safe layout-only wrapper differences in repeated metrics", () => {
+  const layout = {
+    components: [
+      {
+        id: "metrics_panel",
+        elements: [metricsWithLayoutOnlyWrapperDifferences()],
+      },
+    ],
+  };
+
+  for (const [density, expectedCount] of [
+    ["Low", 1],
+    ["Medium", 2],
+    ["High", 3],
+  ]) {
+    const preview = densityUtils.applyTemplateContentDensity(layout, density);
+    assert.equal(
+      preview.components[0].elements[0].children.length,
+      expectedCount,
+    );
+  }
+
+  const low = densityUtils.applyTemplateContentDensity(layout, "Low");
+  const selectedItem = low.components[0].elements[0].children[0];
+  assert.equal(selectedItem.name, "metric_item_2");
+  assert.equal(selectedItem.children[0].type, "vector");
+
+  const editableLeafNames = [];
+  const collectEditableLeafNames = (element) => {
+    if (element.decorative === false && element.name) {
+      editableLeafNames.push(element.name);
+    }
+    for (const child of element.children ?? []) {
+      collectEditableLeafNames(child);
+    }
+  };
+  collectEditableLeafNames(selectedItem);
+  assert.deepEqual(editableLeafNames, [
+    "metric_value",
+    "metric_heading",
+    "metric_description",
+  ]);
+});
+
+test("applies inferred half-to-full limits to repeated top-level groups", () => {
+  const layout = {
+    components: [
+      {
+        id: "metrics",
+        elements: [1, 2, 3, 4].map((index) => repeatedCard(index)),
+      },
+    ],
+  };
+
+  const low = densityUtils.applyTemplateContentDensity(layout, "Low");
+  assert.deepEqual(
+    low.components[0].elements.map((element) => element.name),
+    ["card_2", "card_3"],
+  );
+});
+
+test("does not resize structurally incompatible flex children", () => {
+  const layout = {
+    components: [
+      {
+        id: "mixed",
+        elements: [
+          {
+            type: "flex",
+            name: "mixed",
+            min_children: 1,
+            max_children: 2,
+            children: [
+              repeatedCard(1, "title_1"),
+              repeatedCard(2, "description_2"),
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  const low = densityUtils.applyTemplateContentDensity(layout, "Low");
+  assert.equal(low.components[0].elements[0].children.length, 2);
+});
+
+test("expands a one-item schema array and normalizes repeated names", () => {
+  const layout = {
+    components: [
+      {
+        id: "cards",
+        elements: [
+          {
+            type: "grid",
+            name: "cards",
+            min_children: 1,
+            max_children: 3,
+            children: [repeatedCard(1)],
+          },
+        ],
+      },
+    ],
+  };
+
+  const high = densityUtils.applyTemplateContentDensity(layout, "High");
+  const children = high.components[0].elements[0].children;
+  assert.deepEqual(
+    children.map((child) => child.name),
+    ["card_1", "card_2", "card_3"],
+  );
+  assert.deepEqual(
+    children.map((child) => child.children[0].name),
+    ["title_1", "title_2", "title_3"],
+  );
+});
+
+test("recognizes repeatable non-text arrays as density targets", () => {
+  const layout = {
+    components: [
+      {
+        id: "logos",
+        elements: [
+          {
+            type: "flex",
+            name: "logos",
+            min_children: 1,
+            max_children: 3,
+            children: [
+              {
+                type: "image",
+                name: "logo_1",
+                decorative: false,
+                is_icon: false,
+                data: "logo.png",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  assert.equal(densityUtils.hasLayoutContentDensityTargets(layout), true);
+  const high = densityUtils.applyTemplateContentDensity(layout, "High");
+  assert.equal(high.components[0].elements[0].children.length, 3);
+});
+

--- a/servers/nextjs/tests/template-preview-density.test.mjs
+++ b/servers/nextjs/tests/template-preview-density.test.mjs
@@ -205,6 +205,67 @@ test("uses schema min, midpoint, and max counts for text-list arrays", () => {
   }
 });
 
+test("infers table text limits and applies row and column density", () => {
+  const layout = {
+    elements: [
+      {
+        type: "table",
+        name: "metrics",
+        decorative: false,
+        min_columns: 1,
+        max_columns: 3,
+        min_rows: 1,
+        max_rows: 3,
+        size: { width: 600, height: 300 },
+        columns: [
+          { runs: [{ text: "Metric", font: { size: 14 } }] },
+          { runs: [{ text: "Value", font: { size: 14 } }] },
+        ],
+        rows: [
+          [
+            { runs: [{ text: "Activation", font: { size: 14 } }] },
+            { runs: [{ text: "71%", font: { size: 14 } }] },
+          ],
+          [
+            { runs: [{ text: "Retention", font: { size: 14 } }] },
+            { runs: [{ text: "58%", font: { size: 14 } }] },
+          ],
+        ],
+      },
+    ],
+  };
+
+  assert.equal(densityUtils.hasLayoutContentDensityTargets(layout), true);
+
+  const previews = ["Low", "Medium", "High"].map((density) =>
+    densityUtils.applyTemplateContentDensity(layout, density),
+  );
+  assert.deepEqual(
+    previews.map((preview) => preview.elements[0].columns.length),
+    [1, 2, 3],
+  );
+  assert.deepEqual(
+    previews.map((preview) => preview.elements[0].rows.length),
+    [1, 2, 3],
+  );
+  for (const preview of previews) {
+    const table = preview.elements[0];
+    assert.equal(
+      table.rows.every((row) => row.length === table.columns.length),
+      true,
+    );
+  }
+
+  const headerLengths = previews.map(
+    (preview) => preview.elements[0].columns[0].runs[0].text.length,
+  );
+  const cellLengths = previews.map(
+    (preview) => preview.elements[0].rows[0][0].runs[0].text.length,
+  );
+  assert.equal(headerLengths[0] < headerLengths[2], true);
+  assert.equal(cellLengths[0] < cellLengths[2], true);
+});
+
 test("uses min_children and max_children for repeatable flex arrays", () => {
   const layout = {
     components: [
@@ -539,4 +600,3 @@ test("recognizes repeatable non-text arrays as density targets", () => {
   const high = densityUtils.applyTemplateContentDensity(layout, "High");
   assert.equal(high.components[0].elements[0].children.length, 3);
 });
-

--- a/servers/nextjs/tests/template-v2-renderer-fields.test.mjs
+++ b/servers/nextjs/tests/template-v2-renderer-fields.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { build } from "esbuild";
+
+let importer;
+let textLayout;
+let renderer;
+let temporaryDirectory;
+
+test.before(async () => {
+  temporaryDirectory = await mkdtemp(
+    path.join(tmpdir(), "presenton-renderer-fields-"),
+  );
+  const importerOutput = path.join(temporaryDirectory, "importer.mjs");
+  const textLayoutOutput = path.join(temporaryDirectory, "text-layout.mjs");
+  const rendererOutput = path.join(temporaryDirectory, "renderer.mjs");
+
+  await Promise.all([
+    build({
+      entryPoints: [
+        path.resolve(
+          "components/slide-editor/importing/template-v2-import.ts",
+        ),
+      ],
+      outfile: importerOutput,
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      tsconfig: path.resolve("tsconfig.json"),
+      logLevel: "silent",
+    }),
+    build({
+      entryPoints: [
+        path.resolve("components/slide-editor/text/template-v2-text.ts"),
+      ],
+      outfile: textLayoutOutput,
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      tsconfig: path.resolve("tsconfig.json"),
+      logLevel: "silent",
+    }),
+    build({
+      entryPoints: [path.resolve("lib/template-v2-json-to-html.ts")],
+      outfile: rendererOutput,
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      tsconfig: path.resolve("tsconfig.json"),
+      logLevel: "silent",
+    }),
+  ]);
+
+  importer = await import(
+    `${pathToFileURL(importerOutput).href}?cache=${Date.now()}`
+  );
+  textLayout = await import(
+    `${pathToFileURL(textLayoutOutput).href}?cache=${Date.now()}`
+  );
+  renderer = await import(
+    `${pathToFileURL(rendererOutput).href}?cache=${Date.now()}`
+  );
+});
+
+test.after(async () => {
+  if (temporaryDirectory) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("preserves text-list item and marker gaps when importing Template V2", () => {
+  const slide = importer.adaptTemplateV2LayoutToSlide({
+    id: "renderer-fields",
+    elements: [
+      {
+        type: "text-list",
+        marker: "bullet",
+        gap: 9,
+        marker_gap: 6,
+        items: [[{ text: "One" }], [{ text: "Two" }]],
+      },
+    ],
+  });
+
+  assert.equal(slide.elements[0].gap, 9);
+  assert.equal(slide.elements[0].marker_gap, 6);
+});
+
+test("adds text-list gap only between items in the canvas layout", () => {
+  const baseElement = {
+    type: "text-list",
+    marker: "none",
+    font: { family: "Arial", size: 10, line_height: 1 },
+    items: [[{ text: "One" }], [{ text: "Two" }]],
+  };
+  const withoutGap = textLayout.layoutTextListRenderItems(
+    baseElement,
+    200,
+    100,
+  );
+  const withGap = textLayout.layoutTextListRenderItems(
+    { ...baseElement, gap: 7 },
+    200,
+    100,
+  );
+
+  assert.equal(withGap.contentHeight - withoutGap.contentHeight, 7);
+  assert.equal(withGap.tokens[0].y, withoutGap.tokens[0].y);
+  assert.equal(withGap.tokens[1].y - withoutGap.tokens[1].y, 7);
+});
+
+test("uses marker_gap between the marker and item text in canvas layout", () => {
+  const { tokens } = textLayout.layoutTextListRenderItems(
+    {
+      type: "text-list",
+      marker: "bullet",
+      marker_gap: 8,
+      font: { family: "Arial", size: 10, line_height: 1 },
+      items: [[{ text: "One two three" }]],
+    },
+    40,
+    100,
+  );
+
+  const marker = tokens[0];
+  const contentTokens = tokens.slice(1).filter((token) => token.text.trim());
+  const firstLineToken = contentTokens[0];
+  const wrappedLineToken = contentTokens.find(
+    (token) => token.y > firstLineToken.y,
+  );
+
+  assert.equal(firstLineToken.x - (marker.x + marker.width), 8);
+  assert.equal(wrappedLineToken.x, firstLineToken.x);
+});
+
+test("honors text-list item and marker gaps in HTML", () => {
+  const listHtml = renderer.templateV2UiToHtmlFragment(
+    {
+      elements: [
+      {
+        type: "text-list",
+        size: { width: 240, height: 100 },
+        marker: "bullet",
+        gap: 11,
+        marker_gap: 13,
+        items: [[{ text: "First" }], [{ text: "Second" }]],
+      },
+      ],
+    },
+    { width: 240, height: 100 },
+  );
+
+  assert.match(listHtml, /column-gap:13px/);
+  assert.match(listHtml, /<span aria-hidden="true">•<\/span>/);
+  assert.match(listHtml, /<li style="margin-top:11px;/);
+});


### PR DESCRIPTION
## Summary
- expand Template V2 structured visual extraction and rendering across charts, infographics, tables, and text lists
- improve text capacity, repeated-region density, and layout preservation during generation and preview editing
- preserve renderer-specific colors, spacing, sizing, and editable infographic fields across backend and frontend surfaces

## Tests
- `UV_CACHE_DIR=/private/tmp/presenton-uv-cache uv run pytest tests/unit/test_generate_slide_content.py tests/unit/test_infographic_catalog.py tests/unit/test_presentation_template_v2_ui.py tests/unit/test_templates_v2_certified_generation.py tests/unit/test_templates_v2_elements.py tests/unit/test_templates_v2_generation.py tests/unit/test_templates_v2_schema.py` (117 passed)
- `node --test tests/infographic-rendering.test.mjs tests/template-preview-density.test.mjs tests/template-v2-renderer-fields.test.mjs` (20 passed)