### PR TITLE
fix(generation): improve outline and slide content reliability

### DIFF
--- a/servers/fastapi/tests/unit/test_generate_presentation_outlines.py
+++ b/servers/fastapi/tests/unit/test_generate_presentation_outlines.py
@@ -79,6 +79,10 @@ def test_system_prompt_forbids_sources_in_outlines():
     assert "Give each slide one clear purpose" in prompt
     assert "Vary audience-facing content structures where appropriate" in prompt
     assert "Generation settings are authoritative" in prompt
+    assert "Use the literal token `<LINE_BREAK>`" in prompt
+    assert "never return bare text or paragraph lines" in prompt
+    assert "Content voice rules" in prompt
+    assert 'Never refer to "this presentation"' in prompt
 
 
 def test_system_prompt_requires_content_only_outlines_for_visual_instructions():

--- a/servers/fastapi/tests/unit/test_generate_slide_content.py
+++ b/servers/fastapi/tests/unit/test_generate_slide_content.py
@@ -31,6 +31,52 @@ def test_slide_content_user_prompt_includes_one_indexed_slide_number():
     assert "# Slide Number:\n1" in prompt
 
 
+def test_build_slide_content_schemas_uses_soft_prompt_limits():
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "heading": {"type": "string", "minLength": 10, "maxLength": 20},
+            "items": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 5, "maxLength": 9},
+            },
+        },
+    }
+
+    prompt_schema, provider_schema, validation_schema = (
+        generate_slide_content.build_slide_content_schemas(response_schema)
+    )
+
+    assert prompt_schema["properties"]["heading"]["minLength"] == 16
+    assert prompt_schema["properties"]["heading"]["maxLength"] == 16
+    assert prompt_schema["properties"]["items"]["items"]["minLength"] == 7
+    assert prompt_schema["properties"]["items"]["items"]["maxLength"] == 7
+    assert provider_schema["properties"]["heading"]["minLength"] == 8
+    assert "maxLength" not in provider_schema["properties"]["heading"]
+    assert "minLength" not in validation_schema["properties"]["heading"]
+    assert "maxLength" not in validation_schema["properties"]["heading"]
+    assert response_schema["properties"]["heading"]["minLength"] == 10
+    assert response_schema["properties"]["heading"]["maxLength"] == 20
+
+
+def test_slide_content_prompt_includes_soft_targets_and_length_rules():
+    prompt_schema, _, _ = generate_slide_content.build_slide_content_schemas(
+        {
+            "type": "object",
+            "properties": {
+                "heading": {"type": "string", "minLength": 10, "maxLength": 20}
+            },
+        }
+    )
+
+    prompt = generate_slide_content.get_system_prompt(response_schema=prompt_schema)
+
+    assert '"minLength": 16' in prompt
+    assert '"maxLength": 16' in prompt
+    assert "aim for that exact count" in prompt
+    assert "use a shorter natural value instead" in prompt
+
+
 def test_slide_content_generation_skips_schema_without_content_fields(monkeypatch):
     monkeypatch.setattr(
         generate_slide_content,
@@ -131,6 +177,10 @@ def test_slide_content_generation_normalizes_object_schema_and_calls_llm(
     assert result["title"] == "Generated title"
     assert captured["json_schema"]["type"] == "object"
     assert "__speaker_note__" in captured["json_schema"]["properties"]
-    assert captured["response_format"].json_schema == captured["json_schema"]
+    provider_schema = captured["response_format"].json_schema
+    assert provider_schema["properties"]["__speaker_note__"]["minLength"] == 80
+    assert "maxLength" not in provider_schema["properties"]["__speaker_note__"]
+    assert "minLength" not in captured["json_schema"]["properties"]["__speaker_note__"]
+    assert "maxLength" not in captured["json_schema"]["properties"]["__speaker_note__"]
     assert captured["response_format"].strict is True
     assert "# Slide Number:\n2" in captured["messages"][1].content

--- a/servers/fastapi/tests/unit/test_outline_limits.py
+++ b/servers/fastapi/tests/unit/test_outline_limits.py
@@ -1,5 +1,8 @@
 from models.presentation_outline_model import PresentationOutlineModel
-from utils.outline_limits import normalize_outline_payload
+from utils.outline_limits import (
+    normalize_generated_outline_content,
+    normalize_outline_payload,
+)
 
 
 def test_normalize_outline_payload_unwraps_json_encoded_slides_response():
@@ -11,7 +14,7 @@ def test_normalize_outline_payload_unwraps_json_encoded_slides_response():
     outline = PresentationOutlineModel.model_validate(normalized)
 
     assert [slide.content for slide in outline.slides] == [
-        "## Intro\nA valid outline"
+        "## Intro\n- A valid outline"
     ]
 
 
@@ -27,3 +30,27 @@ def test_normalize_outline_payload_leaves_non_json_slides_for_validation():
     payload = {"slides": "not JSON"}
 
     assert normalize_outline_payload(payload, max_slides=10) == payload
+
+
+def test_normalize_generated_outline_content_decodes_tokens_and_marks_bare_lines():
+    assert normalize_generated_outline_content(
+        "## Roadmap<LINE_BREAK>Opening overview<LINE_BREAK>1. First milestone"
+    ) == "## Roadmap\n- Opening overview\n1. First milestone"
+
+
+def test_normalize_outline_payload_normalizes_generated_markdown():
+    normalized = normalize_outline_payload(
+        {
+            "slides": [
+                {
+                    "content": "## Roadmap<LINE_BREAK>Opening overview",
+                    "layout": "hero",
+                }
+            ]
+        },
+        max_slides=10,
+    )
+
+    assert normalized["slides"] == [
+        {"content": "## Roadmap\n- Opening overview", "layout": "hero"}
+    ]

--- a/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
+++ b/servers/fastapi/utils/llm_calls/generate_presentation_outlines.py
@@ -20,6 +20,7 @@ from utils.llm_calls.generate_web_search_query import generate_web_search_query
 from utils.llm_client_error_handler import handle_llm_client_exceptions
 from utils.llm_config import get_llm_config
 from utils.llm_provider import get_model
+from utils.outline_limits import LINE_BREAK_TOKEN
 from utils.llm_utils import (
     DisconnectChecker,
     get_generate_kwargs,
@@ -37,6 +38,14 @@ from utils.web_search import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+DIRECT_CONTENT_VOICE_RULES = """Content voice rules:
+- Write the content itself, not commentary about the presentation medium.
+- Never refer to "this presentation", "this slide", "this deck", "the following slide", "the previous slide", or similar phrases.
+- Never use meta-introductions such as "this presentation explores", "this slide presents", "we will discuss", "here we show", or equivalent wording.
+- Start directly with the subject, claim, finding, action, or relevant fact.
+- Treat the supplied current date as context only. Do not mention it or begin content with it unless the user explicitly requests the date or it is substantively relevant to the source content.
+"""
 
 
 @dataclass(frozen=True)
@@ -84,10 +93,18 @@ def get_system_prompt(
     toc_block = f"{toc_instruction}\n" if toc_instruction else ""
 
     slide_outline_structure = (
-        "Each slide content:\n"
-        "   - Must have a ## title.\n"
-        # "   - Must have content either in multiple bullet points or table or both.\n"
-        "   - Must be in Markdown format.\n"
+        "Each slide content must be a complete multiline Markdown document.\n"
+        f"Use the literal token `{LINE_BREAK_TOKEN}` wherever the final Markdown requires a line break.\n"
+        "Do not replace the token with spaces or another separator.\n"
+        "After line-break tokens are decoded, each slide content must follow these rules:\n"
+        "   - Its first line must be exactly `## <title>` and contain only the slide title.\n"
+        "   - It must contain at least one non-empty body line after the title.\n"
+        "   - Never put the title and body content in the same segment.\n"
+        f"   - Put `{LINE_BREAK_TOKEN}` between every Markdown block.\n"
+        "   - Every non-empty body line must use explicit Markdown syntax; never return bare text or paragraph lines.\n"
+        "   - Use a suitable Markdown structure: bullet lists, numbered lists, tables, blockquotes, or level-three-or-lower subheadings.\n"
+        "   - The title slide must put presenter, date, and overview below the title rather than appending them to the title line.\n"
+        f"   - Before responding, verify that every slide content contains `{LINE_BREAK_TOKEN}` immediately after its title segment.\n"
         "   - Don't use **bold** and __italic__ text.\n"
         "   - First slide title must be the same as the presentation title."
     )
@@ -118,6 +135,7 @@ def get_system_prompt(
         "If Language is not auto-detect, generate every presentation title and slide "
         "outline in exactly that language, even if Content asks for a different language.\n"
         "Generate flow based on user **content** and use **context** just for reference.\n"
+        f"{DIRECT_CONTENT_VOICE_RULES}\n"
         "Presentation title should be plain text, not markdown. It should be a concise title for the presentation.\n"
         "Each slide content should contain the content for that slide.\n"
         f"Never generate more than {MAX_NUMBER_OF_SLIDES} slide outlines, even if the user asks for more. "

--- a/servers/fastapi/utils/llm_calls/generate_slide_content.py
+++ b/servers/fastapi/utils/llm_calls/generate_slide_content.py
@@ -1,6 +1,7 @@
 import json
+from copy import deepcopy
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from llmai import get_client
 from llmai.shared import JSONSchemaResponse, Message, SystemMessage, UserMessage
@@ -87,6 +88,86 @@ ASSET_ONLY_FIELDS = ["__image_url__", "__icon_url__"]
 AUTO_DETECT_LANGUAGE_INSTRUCTION = (
     "auto-detect from the slide content and use the same language as the slide content"
 )
+SLIDE_CONTENT_LENGTH_RATIO = 0.8
+
+SLIDE_CONTENT_LENGTH_RULES = """
+
+# Character Budget Rules
+Treat the maximum shown for every field as an absolute ceiling, counting spaces and punctuation. When minimum and maximum are equal, aim for that exact count; however, if an exact count would require a clipped word, invented abbreviation, padding, repetition, or unsupported fact, use a shorter natural value instead. Never exceed the maximum.
+
+For targets below 10 characters, use a complete familiar word or source-supported label. For longer fields, rephrase with complete natural wording. Before returning JSON, silently check every constrained string and shorten any value over its ceiling. Never invent numbers or measurements.
+"""
+
+
+def _scale_string_length_constraints(
+    value: Any,
+    *,
+    markdown_targets: bool = False,
+    remove_min_length: bool = False,
+    remove_max_length: bool = False,
+) -> Any:
+    if isinstance(value, dict):
+        scaled = {
+            key: _scale_string_length_constraints(
+                item,
+                markdown_targets=markdown_targets,
+                remove_min_length=remove_min_length,
+                remove_max_length=remove_max_length,
+            )
+            for key, item in value.items()
+        }
+        if scaled.get("type") != "string":
+            return scaled
+
+        minimum = scaled.get("minLength")
+        if isinstance(minimum, int):
+            if remove_min_length:
+                scaled.pop("minLength", None)
+            else:
+                scaled["minLength"] = max(
+                    1, int(minimum * SLIDE_CONTENT_LENGTH_RATIO)
+                )
+
+        maximum = scaled.get("maxLength")
+        if isinstance(maximum, int):
+            soft_maximum = max(1, int(maximum * SLIDE_CONTENT_LENGTH_RATIO))
+            if remove_max_length:
+                scaled.pop("maxLength", None)
+            else:
+                scaled["maxLength"] = soft_maximum
+                if markdown_targets:
+                    scaled["minLength"] = soft_maximum
+        return scaled
+
+    if isinstance(value, list):
+        return [
+            _scale_string_length_constraints(
+                item,
+                markdown_targets=markdown_targets,
+                remove_min_length=remove_min_length,
+                remove_max_length=remove_max_length,
+            )
+            for item in value
+        ]
+
+    return deepcopy(value)
+
+
+def build_slide_content_schemas(response_schema: dict) -> tuple[dict, dict, dict]:
+    prompt_schema = _scale_string_length_constraints(
+        response_schema,
+        markdown_targets=True,
+    )
+    provider_schema = _scale_string_length_constraints(
+        response_schema,
+        remove_max_length=True,
+    )
+    validation_schema = _scale_string_length_constraints(
+        provider_schema,
+        remove_min_length=True,
+        remove_max_length=True,
+    )
+    return prompt_schema, provider_schema, validation_schema
 
 
 def _resolve_prompt_language(language: Optional[str]) -> str:
@@ -140,13 +221,14 @@ def get_system_prompt(
         response_schema
     )
 
-    return SLIDE_CONTENT_SYSTEM_PROMPT.format(
+    system_prompt = SLIDE_CONTENT_SYSTEM_PROMPT.format(
         markdown_emphasis_rules=markdown_emphasis_rules,
         user_instructions=user_instructions,
         tone_instructions=tone_instructions,
         verbosity_instructions=verbosity_instructions,
         output_fields_instructions=output_fields_instructions,
     )
+    return system_prompt + SLIDE_CONTENT_LENGTH_RULES
 
 
 def _get_slide_number_section(slide_number: Optional[int]) -> str:
@@ -241,13 +323,17 @@ async def get_slide_content_from_type_and_outline(
     if response_schema is None:
         return {}
 
+    prompt_schema, provider_schema, validation_schema = build_slide_content_schemas(
+        response_schema
+    )
+
     client = get_client(config=get_llm_config())
     model = get_model()
 
     try:
         response_format = JSONSchemaResponse(
             name="response",
-            json_schema=response_schema,
+            json_schema=provider_schema,
             strict=True,
         )
         messages = get_messages(
@@ -256,7 +342,7 @@ async def get_slide_content_from_type_and_outline(
             tone,
             verbosity,
             instructions,
-            response_schema,
+            prompt_schema,
             slide_number=slide_number,
         )
 
@@ -265,7 +351,7 @@ async def get_slide_content_from_type_and_outline(
             model,
             messages=messages,
             response_format=response_format,
-            json_schema=response_schema,
+            json_schema=validation_schema,
             strict=False,
             validate_schema=True,
             disconnect_checker=disconnect_checker,

--- a/servers/fastapi/utils/outline_limits.py
+++ b/servers/fastapi/utils/outline_limits.py
@@ -6,6 +6,30 @@ from constants.presentation import MAX_OUTLINE_CONTENT_WORDS
 
 
 OUTLINE_WORD_PATTERN = re.compile(r"\S+")
+LINE_BREAK_TOKEN = "<LINE_BREAK>"
+
+
+def _has_explicit_markdown_prefix(line: str) -> bool:
+    return line.startswith(
+        ("- ", "* ", "+ ", "|", "> ", "### ", "#### ", "##### ", "###### ")
+    ) or bool(re.match(r"^\d+[.)]\s+", line))
+
+
+def normalize_generated_outline_content(value: Any) -> str:
+    """Decode generated line-break tokens and normalize Markdown body lines."""
+    content = "" if value is None else str(value)
+    lines = content.replace(LINE_BREAK_TOKEN, "\n").splitlines()
+    if not lines:
+        return ""
+
+    normalized_lines = [lines[0].strip()]
+    for line in lines[1:]:
+        stripped = line.strip()
+        if not stripped or _has_explicit_markdown_prefix(stripped):
+            normalized_lines.append(stripped)
+        else:
+            normalized_lines.append(f"- {stripped}")
+    return "\n".join(normalized_lines)
 
 
 def count_outline_words(text: str) -> int:
@@ -59,10 +83,16 @@ def normalize_outline_payload(payload: dict[str, Any], max_slides: int) -> dict[
     normalized["slides"] = [
         {
             **slide,
-            "content": normalize_outline_content(slide.get("content", "")),
+            "content": normalize_outline_content(
+                normalize_generated_outline_content(slide.get("content", ""))
+            ),
         }
         if isinstance(slide, dict)
-        else {"content": normalize_outline_content(slide)}
+        else {
+            "content": normalize_outline_content(
+                normalize_generated_outline_content(slide)
+            )
+        }
         for slide in raw_slides[:max_slides]
     ]
     return normalized

--- a/servers/nextjs/utils/presentationLimits.ts
+++ b/servers/nextjs/utils/presentationLimits.ts
@@ -1,5 +1,6 @@
 export const MAX_NUMBER_OF_SLIDES = 50;
 export const MAX_OUTLINE_CONTENT_WORDS = 100;
+export const OUTLINE_LINE_BREAK_TOKEN = "<LINE_BREAK>";
 
 const WORD_PATTERN = /\S+/g;
 
@@ -30,7 +31,7 @@ export function limitOutlines<T extends { content?: unknown }>(
     ...outline,
     content: trimTextToWordLimit(
       typeof outline?.content === "string"
-        ? outline.content
+        ? outline.content.replaceAll(OUTLINE_LINE_BREAK_TOKEN, "\n")
         : String(outline?.content ?? "")
     ),
   }));


### PR DESCRIPTION
## Summary
- normalize generated outline Markdown with a line-break token
- keep outline content direct and audience-facing
- use 80% soft character targets to reduce slide-content clipping

## Validation
- 727 backend unit tests
- 28 presentation-generation integration tests
- 49 Next.js tests
- TypeScript and ESLint checks