### PR TITLE
docs: improve API and deployment configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,85 +344,84 @@ Deploy and manage Presenton across your organization with versioned Helm charts 
 
 ### ⚙️ Deployment Configurations
 
-The lists below match the environment variables forwarded in this repository’s **`docker-compose.yml`** (`production`, `production-gpu`, `development`, and `development-gpu`). Put values in a `.env` file next to the compose file, or export them before `docker compose up`. The Electron app backend can read the same names when run outside Docker.
+The tables below match the environment variables forwarded in this repository’s **`docker-compose.yml`** (`production`, `production-gpu`, `development`, and `development-gpu`). Put values in a `.env` file next to the compose file, or export them before `docker compose up`. The Electron app backend can read the same names when run outside Docker.
 
 Other optional variables exist in code (for example advanced Mem0 paths, LiteParse runners, or `FAST_API_INTERNAL_URL` when Next.js and FastAPI are not same-origin); they are **not** wired in `docker-compose.yml`. Supported names are discoverable from `servers/fastapi/utils/get_env.py` and the Next.js server utilities under `servers/nextjs/`.
 
 #### LLM and API keys
 
-- **CAN_CHANGE_KEYS**=[true/false]: Set to **false** if you want to keep API keys hidden and make them unmodifiable.
-- **PRESENTON_PUBLIC_URL**: Optional browser-reachable Presenton origin, for example `http://localhost:5001` or `https://slides.example.com`. Set this when an MCP client reaches Presenton through a Docker-internal hostname; generated download, edit, and preview links use this origin instead.
-- **PRESENTATION_GENERATION_MODE**=[both/standard/smart]: Controls which presentation generation mode is available in the UI and which generation tools the MCP server exposes. Defaults to **both**. A single-mode value hides the mode selector and forces that mode; `smart` also hides template and custom-template features and tools. See the **[presentation generation modes guide](docs/presentation-generation-modes.md)** for configuration examples and mode behavior.
-- **LLM**=[openai/deepseek/google/vertex/azure/bedrock/openrouter/fireworks/together/cerebras/anthropic/litellm/lmstudio/ollama/custom/codex]: Select the text **LLM**.
-- **OPENAI_API_KEY**: Required if **LLM** is **openai**.
-- **OPENAI_MODEL**: Required if **LLM** is **openai** (default: `gpt-4.1`).
-- **DEEPSEEK_API_KEY**: Required if **LLM** is **deepseek**.
-- **DEEPSEEK_MODEL**: Required if **LLM** is **deepseek** (default: `deepseek-chat`).
-- **DEEPSEEK_BASE_URL**: Optional if **LLM** is **deepseek** (default: `https://api.deepseek.com`).
-- **GOOGLE_API_KEY**: Required if **LLM** is **google**.
-- **GOOGLE_MODEL**: Required if **LLM** is **google** (default: `models/gemini-2.0-flash`).
-- **VERTEX_MODEL**: Required if **LLM** is **vertex** (default: `gemini-2.5-flash`).
-- **VERTEX_API_KEY**: Optional auth path for **LLM=vertex** (Vertex Express).
-- **VERTEX_PROJECT** / **VERTEX_LOCATION**: Optional auth path for **LLM=vertex** when using GCP project credentials (do not combine with `VERTEX_API_KEY`).
-- **VERTEX_BASE_URL**: Optional Vertex gateway/base URL override.
-- **AZURE_OPENAI_MODEL**: Required if **LLM** is **azure** (deployment/model name).
-- **AZURE_OPENAI_API_KEY**: Required if **LLM** is **azure**.
-- **AZURE_OPENAI_API_VERSION**: Required if **LLM** is **azure** (for example `2024-10-21`).
-- **AZURE_OPENAI_ENDPOINT** / **AZURE_OPENAI_BASE_URL**: At least one is required if **LLM** is **azure**.
-- **AZURE_OPENAI_DEPLOYMENT**: Optional deployment override for **LLM** is **azure**.
-- **BEDROCK_REGION**: Optional if **LLM** is **bedrock** (default: `us-east-1`).
-- **BEDROCK_MODEL**: Required if **LLM** is **bedrock**. Use a standard model ID (example: `us.anthropic.claude-3-5-haiku-20241022-v1:0`) or a full **inference profile ARN** for newer models (example: Claude Sonnet 4.6). Passed through to Bedrock Converse as `modelId`. See **[Amazon Bedrock guide](docs/amazon-bedrock.md)**.
-- **BEDROCK_API_KEY**: Optional if **LLM** is **bedrock** (API key auth; alternative to AWS keys).
-- **BEDROCK_AWS_ACCESS_KEY_ID** / **BEDROCK_AWS_SECRET_ACCESS_KEY**: Required together if **LLM** is **bedrock** and `BEDROCK_API_KEY` is not set.
-- **BEDROCK_AWS_SESSION_TOKEN**: Optional session token for **LLM** is **bedrock**.
-- **BEDROCK_PROFILE_NAME**: Optional AWS profile name for **LLM** is **bedrock**.
-- **OPENROUTER_API_KEY**: Required if **LLM** is **openrouter**.
-- **OPENROUTER_MODEL**: Required if **LLM** is **openrouter** (default: `openai/gpt-4o`).
-- **OPENROUTER_BASE_URL**: Optional if **LLM** is **openrouter** (default: `https://openrouter.ai/api/v1`).
-- **OPENROUTER_PROVIDER_ORDER**: Optional comma-separated OpenRouter provider routing order.
-- **OPENROUTER_ALLOW_FALLBACKS**=[true/false]: Optional OpenRouter fallback override.
-- **OPENROUTER_REQUIRE_PARAMETERS**=[true/false]: Only route to providers supporting every request parameter.
-- **OPENROUTER_DATA_COLLECTION**=[allow/deny]: Optional OpenRouter data-collection policy.
-- **OPENROUTER_ZDR**=[true/false]: Optional OpenRouter zero-data-retention requirement.
-- **FIREWORKS_API_KEY**: Required if **LLM** is **fireworks**.
-- **FIREWORKS_MODEL**: Required if **LLM** is **fireworks** (example: `accounts/fireworks/models/llama-v3p1-8b-instruct`).
-- **FIREWORKS_BASE_URL**: Optional if **LLM** is **fireworks** (default: `https://api.fireworks.ai/inference/v1`).
-- **TOGETHER_API_KEY**: Required if **LLM** is **together**.
-- **TOGETHER_MODEL**: Required if **LLM** is **together** (example: `openai/gpt-oss-20b`).
-- **TOGETHER_BASE_URL**: Optional if **LLM** is **together** (default: `https://api.together.ai/v1`).
-- **CEREBRAS_API_KEY**: Required if **LLM** is **cerebras**.
-- **CEREBRAS_MODEL**: Required if **LLM** is **cerebras** (default: `llama-3.3-70b`).
-- **CEREBRAS_BASE_URL**: Optional if **LLM** is **cerebras** (default: `https://api.cerebras.ai/v1`).
-- **ANTHROPIC_API_KEY**: Required if **LLM** is **anthropic**.
-- **ANTHROPIC_MODEL**: Required if **LLM** is **anthropic** (default: `claude-3-5-sonnet-20241022`).
-- **CODEX_MODEL**: Required if **LLM** is **codex** (Codex OAuth flow; compose maps host port **1455** for the callback).
-- **CUSTOM_LLM_URL**: OpenAI-compatible base URL if **LLM** is **custom**. The
-  server must implement `POST /v1/chat/completions`; a provider-specific
-  completion endpoint is not sufficient.
-- **CUSTOM_LLM_API_KEY**: API key if **LLM** is **custom**.
-- **CUSTOM_MODEL**: Model id if **LLM** is **custom**.
-- **LITELLM_BASE_URL**: LiteLLM proxy or gateway base URL if **LLM** is **litellm**.
-- **LITELLM_API_KEY**: Optional API key if **LLM** is **litellm**.
-- **LITELLM_MODEL**: Required if **LLM** is **litellm** (default: `gpt-4.1`).
-- **LMSTUDIO_BASE_URL**: Optional LM Studio base URL if **LLM** is **lmstudio** (default: `http://localhost:1234/v1`; `/v1` is auto-appended when omitted).
-- **LMSTUDIO_API_KEY**: Optional API key if **LLM** is **lmstudio**.
-- **LMSTUDIO_MODEL**: Required if **LLM** is **lmstudio** (example: `openai/gpt-oss-20b`).
-- **DISABLE_THINKING**=[true/false]: If **true**, disables “thinking” for providers that support it (including DeepSeek).
-- **WEB_GROUNDING**=[true/false]: If **true**, enables web search by default.
-- **WEB_SEARCH_PROVIDER**=[auto/native/searxng/tavily/exa]: Selects the web search mode. `auto` uses native search for OpenAI, Google, and Anthropic, and otherwise leaves web search off unless you choose an external provider.
-<!-- Brave and Serper search providers are hidden until they are tested. -->
-<!-- - **WEB_SEARCH_PROVIDER** also supports `brave` and `serper`. -->
-- **WEB_SEARCH_MAX_RESULTS**: Maximum external search results to add to model context (default `5`, maximum `10`).
-- **SEARXNG_BASE_URL**: Base URL for a self-hosted SearXNG instance.
-- **TAVILY_API_KEY**, **EXA_API_KEY**: Credentials for optional hosted search APIs.
-<!-- - **BRAVE_SEARCH_API_KEY**, **SERPER_API_KEY**: Credentials for hidden, untested hosted search APIs. -->
-- **EXTENDED_REASONING**=[true/false]: Enables extended reasoning where supported by the configured stack.
-- **LLM_GENERATION_PROFILE**=[fast/balanced/deep/model_max]: Optional global generation profile (default: `balanced`).
-- **LLM_MAX_OUTPUT_TOKENS**: Optional positive output-token override for every text provider.
-- **MAX_OUTLINE_WORDS**: Maximum words allowed in each generated or edited slide outline (default: `100`). Must be a positive integer.
-- **LLM_REASONING_MODE**=[auto/enabled/disabled]: Optional global reasoning-mode override.
-- **LLM_REASONING_EFFORT**=[default/none/minimal/low/medium/high/xhigh/max]: Optional reasoning-effort override.
-- **LLM_REASONING_BUDGET_TOKENS**: Optional non-negative reasoning token budget.
+| Variable | Values / default | Purpose |
+| --- | --- | --- |
+| **CAN_CHANGE_KEYS** | `true` / `false` | Set to `false` to keep API keys hidden and unmodifiable. |
+| **PRESENTON_PUBLIC_URL** | Optional URL | Browser-reachable Presenton origin, such as `http://localhost:5001` or `https://slides.example.com`. Generated download, edit, and preview links use this origin. |
+| **PRESENTATION_GENERATION_MODE** | `both` (default), `standard`, `smart` | Controls the modes available in the UI and MCP server. A single-mode value hides the selector; `smart` also hides template features. See the **[presentation generation modes guide](docs/presentation-generation-modes.md)**. |
+| **LLM** | `openai`, `deepseek`, `google`, `vertex`, `azure`, `bedrock`, `openrouter`, `fireworks`, `together`, `cerebras`, `anthropic`, `litellm`, `lmstudio`, `ollama`, `custom`, `codex` | Selects the text LLM provider. |
+| **OPENAI_API_KEY** | Required for `LLM=openai` | OpenAI API key. |
+| **OPENAI_MODEL** | `gpt-4.1` (default) | OpenAI model. |
+| **DEEPSEEK_API_KEY** | Required for `LLM=deepseek` | DeepSeek API key. |
+| **DEEPSEEK_MODEL** | `deepseek-chat` (default) | DeepSeek model. |
+| **DEEPSEEK_BASE_URL** | `https://api.deepseek.com` (default) | DeepSeek base URL. |
+| **GOOGLE_API_KEY** | Required for `LLM=google` | Google API key. |
+| **GOOGLE_MODEL** | `models/gemini-2.0-flash` (default) | Google model. |
+| **VERTEX_MODEL** | `gemini-2.5-flash` (default) | Vertex AI model. |
+| **VERTEX_API_KEY** | Optional | Vertex Express API key authentication. |
+| **VERTEX_PROJECT** / **VERTEX_LOCATION** | Optional pair | GCP project credential authentication; do not combine with `VERTEX_API_KEY`. |
+| **VERTEX_BASE_URL** | Optional URL | Vertex gateway or base URL override. |
+| **AZURE_OPENAI_MODEL** | Required for `LLM=azure` | Azure deployment or model name. |
+| **AZURE_OPENAI_API_KEY** | Required for `LLM=azure` | Azure OpenAI API key. |
+| **AZURE_OPENAI_API_VERSION** | Required; for example `2024-10-21` | Azure OpenAI API version. |
+| **AZURE_OPENAI_ENDPOINT** / **AZURE_OPENAI_BASE_URL** | At least one required | Azure OpenAI endpoint. |
+| **AZURE_OPENAI_DEPLOYMENT** | Optional | Azure deployment override. |
+| **BEDROCK_REGION** | `us-east-1` (default) | AWS Bedrock region. |
+| **BEDROCK_MODEL** | Required for `LLM=bedrock` | Standard model ID or full inference-profile ARN, passed to Bedrock Converse as `modelId`. See the **[Amazon Bedrock guide](docs/amazon-bedrock.md)**. |
+| **BEDROCK_API_KEY** | Optional | Bedrock API-key authentication; alternative to AWS keys. |
+| **BEDROCK_AWS_ACCESS_KEY_ID** / **BEDROCK_AWS_SECRET_ACCESS_KEY** | Required together when `BEDROCK_API_KEY` is unset | AWS credential authentication for Bedrock. |
+| **BEDROCK_AWS_SESSION_TOKEN** | Optional | AWS session token. |
+| **BEDROCK_PROFILE_NAME** | Optional | AWS profile name. |
+| **OPENROUTER_API_KEY** | Required for `LLM=openrouter` | OpenRouter API key. |
+| **OPENROUTER_MODEL** | `openai/gpt-4o` (default) | OpenRouter model. |
+| **OPENROUTER_BASE_URL** | `https://openrouter.ai/api/v1` (default) | OpenRouter base URL. |
+| **OPENROUTER_PROVIDER_ORDER** | Optional comma-separated list | Provider routing order. |
+| **OPENROUTER_ALLOW_FALLBACKS** | `true` / `false` | Optional provider fallback override. |
+| **OPENROUTER_REQUIRE_PARAMETERS** | `true` / `false` | Only route to providers supporting every request parameter. |
+| **OPENROUTER_DATA_COLLECTION** | `allow` / `deny` | Optional data-collection policy. |
+| **OPENROUTER_ZDR** | `true` / `false` | Optional zero-data-retention requirement. |
+| **FIREWORKS_API_KEY** | Required for `LLM=fireworks` | Fireworks API key. |
+| **FIREWORKS_MODEL** | For example `accounts/fireworks/models/llama-v3p1-8b-instruct` | Fireworks model. |
+| **FIREWORKS_BASE_URL** | `https://api.fireworks.ai/inference/v1` (default) | Fireworks base URL. |
+| **TOGETHER_API_KEY** | Required for `LLM=together` | Together AI API key. |
+| **TOGETHER_MODEL** | For example `openai/gpt-oss-20b` | Together AI model. |
+| **TOGETHER_BASE_URL** | `https://api.together.ai/v1` (default) | Together AI base URL. |
+| **CEREBRAS_API_KEY** | Required for `LLM=cerebras` | Cerebras API key. |
+| **CEREBRAS_MODEL** | `llama-3.3-70b` (default) | Cerebras model. |
+| **CEREBRAS_BASE_URL** | `https://api.cerebras.ai/v1` (default) | Cerebras base URL. |
+| **ANTHROPIC_API_KEY** | Required for `LLM=anthropic` | Anthropic API key. |
+| **ANTHROPIC_MODEL** | `claude-3-5-sonnet-20241022` (default) | Anthropic model. |
+| **CODEX_MODEL** | Required for `LLM=codex` | Codex model. The OAuth flow maps host port `1455` for its callback. |
+| **CUSTOM_LLM_URL** | Required for `LLM=custom` | OpenAI-compatible base URL. The server must implement `POST /v1/chat/completions`; a provider-specific completion endpoint is insufficient. |
+| **CUSTOM_LLM_API_KEY** | Provider-dependent | Custom-provider API key. |
+| **CUSTOM_MODEL** | Required for `LLM=custom` | Custom-provider model ID. |
+| **LITELLM_BASE_URL** | Required for `LLM=litellm` | LiteLLM proxy or gateway base URL. |
+| **LITELLM_API_KEY** | Optional | LiteLLM API key. |
+| **LITELLM_MODEL** | `gpt-4.1` (default) | LiteLLM model. |
+| **LMSTUDIO_BASE_URL** | `http://localhost:1234/v1` (default) | LM Studio base URL; `/v1` is appended when omitted. |
+| **LMSTUDIO_API_KEY** | Optional | LM Studio API key. |
+| **LMSTUDIO_MODEL** | For example `openai/gpt-oss-20b` | LM Studio model. |
+| **DISABLE_THINKING** | `true` / `false` | Disables thinking for providers that support it, including DeepSeek. |
+| **WEB_GROUNDING** | `true` / `false` | Enables web search by default. |
+| **WEB_SEARCH_PROVIDER** | `auto`, `native`, `searxng`, `tavily`, `exa` | Selects the search mode. `auto` uses native search for OpenAI, Google, and Anthropic and otherwise leaves search off unless an external provider is selected. |
+| **WEB_SEARCH_MAX_RESULTS** | `5` (default), maximum `10` | Maximum external search results added to model context. |
+| **SEARXNG_BASE_URL** | Optional URL | Self-hosted SearXNG base URL. |
+| **TAVILY_API_KEY**, **EXA_API_KEY** | Optional | Credentials for hosted search providers. |
+| **EXTENDED_REASONING** | `true` / `false` | Enables extended reasoning where supported. |
+| **LLM_GENERATION_PROFILE** | `fast`, `balanced` (default), `deep`, `model_max` | Global generation profile. |
+| **LLM_MAX_OUTPUT_TOKENS** | Optional positive integer | Output-token override for every text provider. |
+| **MAX_OUTLINE_WORDS** | `100` (default), positive integer | Maximum words in each generated, edited, or `slides_markdown` slide outline. |
+| **LLM_REASONING_MODE** | `auto`, `enabled`, `disabled` | Global reasoning-mode override. |
+| **LLM_REASONING_EFFORT** | `default`, `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` | Reasoning-effort override. |
+| **LLM_REASONING_BUDGET_TOKENS** | Optional non-negative integer | Reasoning token budget. |
+
+<!-- Brave and Serper search providers and their credentials are hidden until they are tested. -->
 
 All advanced text-provider settings are optional. Use **Reset advanced settings** in Settings or onboarding to remove overrides and inherit application/provider defaults.
 
@@ -430,9 +429,11 @@ All advanced text-provider settings are optional. Use **Reset advanced settings*
 
 Use when **LLM** is **ollama**:
 
-- **OLLAMA_URL**: Base URL of the Ollama HTTP API (e.g. `http://host.docker.internal:11434` from Docker).
-- **OLLAMA_MODEL**: Model name in Ollama (e.g. `llama3.2:3b`).
-- **START_OLLAMA**=[true/false]: Container entrypoint (`start.js`): optional install + `ollama serve`. Default **false** (`development` / `production` compose).
+| Variable | Values / default | Purpose |
+| --- | --- | --- |
+| **OLLAMA_URL** | For example `http://host.docker.internal:11434` from Docker | Ollama HTTP API base URL. |
+| **OLLAMA_MODEL** | For example `llama3.2:3b` | Ollama model name. |
+| **START_OLLAMA** | `false` (default), `true` | Allows the container entrypoint (`start.js`) to install Ollama and run `ollama serve`. |
 
 #### Presentation memory (Mem0 OSS)
 
@@ -463,29 +464,35 @@ Docker images install the default spaCy model (`en_core_web_sm`) during build so
 
 #### Database
 
-- **DATABASE_URL**: SQLAlchemy URL; if unset, the app falls back to SQLite under app data.
-- **MIGRATE_DATABASE_ON_STARTUP**: Compose sets **`true`** for all services so migrations run on startup.
+| Variable | Values / default | Purpose |
+| --- | --- | --- |
+| **DATABASE_URL** | Optional SQLAlchemy URL | Configures the database; when unset, the app uses SQLite under app data. |
+| **MIGRATE_DATABASE_ON_STARTUP** | `true` in Compose | Runs database migrations during startup. |
 
 #### Image generation
 
 These variables match `docker-compose.yml`. **`IMAGE_PROVIDER`** selects the backend (`pexels`, `pixabay`, `gemini_flash`, `nanobanana_pro`, `dall-e-3`, `gpt-image-1.5`, `comfyui`, `open_webui`). Use **OPENAI_API_KEY** for OpenAI image modes and **GOOGLE_API_KEY** for Gemini image modes (same keys as the LLM section).
 
-- **DISABLE_IMAGE_GENERATION**=[true/false]: Disable slide image generation.
-- **ENABLE_PARALLEL_IMAGE_GENERATION**=[true/false]: Allow concurrent image provider requests (default `true`). Set to `false` to generate images one at a time when the provider has strict rate limits.
-- **IMAGE_PROVIDER**: Provider id (see enum above).
-- **PEXELS_API_KEY**: Pexels stock images.
-- **PIXABAY_API_KEY**: Pixabay stock images.
-- **DALL_E_3_QUALITY**=[standard/hd]: Optional for **dall-e-3** (default `standard`).
-- **GPT_IMAGE_1_5_QUALITY**=[low/medium/high]: Optional for **gpt-image-1.5** (default `medium`).
-- **COMFYUI_URL** / **COMFYUI_WORKFLOW**: Self-hosted ComfyUI workflow JSON.
-- **OPEN_WEBUI_IMAGE_URL** / **OPEN_WEBUI_IMAGE_API_KEY**: Open WebUI–compatible image endpoint.
-- **OPENAI_COMPAT_IMAGE_BASE_URL** / **OPENAI_COMPAT_IMAGE_API_KEY** / **OPENAI_COMPAT_IMAGE_MODEL**: Required if using **openai_compatible** to send image requests to any OpenAI-compatible `/v1/images/*` endpoint (LiteLLM, Azure, vLLM Gateways, etc.).
+| Variable | Values / default | Purpose |
+| --- | --- | --- |
+| **DISABLE_IMAGE_GENERATION** | `true` / `false` | Disables slide image generation. |
+| **ENABLE_PARALLEL_IMAGE_GENERATION** | `true` (default), `false` | Allows concurrent image-provider requests. Set to `false` for providers with strict rate limits. |
+| **IMAGE_PROVIDER** | `pexels`, `pixabay`, `gemini_flash`, `nanobanana_pro`, `dall-e-3`, `gpt-image-1.5`, `comfyui`, `open_webui`, `openai_compatible` | Selects the image backend. |
+| **PEXELS_API_KEY** | Required for `IMAGE_PROVIDER=pexels` | Pexels stock-image API key. |
+| **PIXABAY_API_KEY** | Required for `IMAGE_PROVIDER=pixabay` | Pixabay stock-image API key. |
+| **DALL_E_3_QUALITY** | `standard` (default), `hd` | DALL-E 3 image quality. |
+| **GPT_IMAGE_1_5_QUALITY** | `low`, `medium` (default), `high` | GPT Image 1.5 image quality. |
+| **COMFYUI_URL** / **COMFYUI_WORKFLOW** | Required for `IMAGE_PROVIDER=comfyui` | Self-hosted ComfyUI endpoint and workflow JSON. |
+| **OPEN_WEBUI_IMAGE_URL** / **OPEN_WEBUI_IMAGE_API_KEY** | Required for `IMAGE_PROVIDER=open_webui` | Open WebUI-compatible image endpoint and API key. |
+| **OPENAI_COMPAT_IMAGE_BASE_URL** / **OPENAI_COMPAT_IMAGE_API_KEY** / **OPENAI_COMPAT_IMAGE_MODEL** | Required for `IMAGE_PROVIDER=openai_compatible` | Sends image requests to an OpenAI-compatible `/v1/images/*` endpoint such as LiteLLM, Azure, or a vLLM gateway. |
 
 The parallel image generation option applies everywhere images are generated: initial presentation generation, slide editing and regeneration, direct image requests, and assistant image tools.
 
 #### Telemetry
 
-- **DISABLE_ANONYMOUS_TRACKING**=[true/false]: Set to **true** to disable anonymous telemetry.
+| Variable | Values / default | Purpose |
+| --- | --- | --- |
+| **DISABLE_ANONYMOUS_TRACKING** | `true` / `false` | Set to `true` to disable anonymous telemetry. |
 
 #### Multi-user authentication
 
@@ -718,14 +725,14 @@ All <code>/api/v1/</code> routes except the public authentication endpoints requ
 <td><code>content</code></td>
 <td>string</td>
 <td>Yes</td>
-<td>Main content used to generate the presentation.</td>
+<td>Main content used to generate the presentation. When using <code>slides_markdown</code> without an additional overall prompt, pass an empty string.</td>
 </tr>
 
 <tr>
 <td><code>slides_markdown</code></td>
 <td>string[] | null</td>
 <td>No</td>
-<td>Provide custom slide markdown instead of auto-generation.</td>
+<td>Provide one Markdown string per slide instead of asking Presenton to generate the slide outlines. The array length determines the number of slides.</td>
 </tr>
 
 <tr>
@@ -767,7 +774,7 @@ Options: <code>concise</code>, <code>standard</code>, <code>text-heavy</code>
 <td><code>n_slides</code></td>
 <td>integer</td>
 <td>No</td>
-<td>Number of slides to generate (default: <code>8</code>).</td>
+<td>Number of slides to generate. When omitted, the count is auto-detected. When using <code>slides_markdown</code>, its array length is used and <code>n_slides</code> can be omitted.</td>
 </tr>
 
 <tr>
@@ -842,6 +849,60 @@ Options: <code>pptx</code>, <code>pdf</code>
     "template": "general",
     "export_as": "pptx"
   }'</code></pre>
+
+**Example: provide the content for every slide with `slides_markdown`**
+
+Each array item becomes one slide. Use ordinary Markdown headings, lists, emphasis,
+and tables to describe the audience-facing content. The <code>content</code> field is
+currently required by the API schema, so set it to an empty string when you do not
+want to provide an additional overall prompt.
+
+<pre><code class="language-bash">curl \
+  -X POST http://localhost:5001/api/v1/ppt/presentation/generate \
+  -H "Authorization: Bearer sk-presenton-YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "",
+    "slides_markdown": [
+      "# Acme Q2 Review\n\nRevenue grew **18% year over year** while customer retention reached 94%.",
+      "# What changed\n\n- Enterprise revenue increased 24%\n- Support response time fell to 42 minutes\n- Expansion revenue offset slower new-logo growth",
+      "# Next quarter\n\n1. Launch the self-service onboarding flow\n2. Expand the enterprise pilot program\n3. Reduce infrastructure cost per account by 10%"
+    ],
+    "template": "general",
+    "language": "English",
+    "export_as": "pdf"
+  }'</code></pre>
+
+**Example: provide numeric data for a chart or table layout**
+
+Markdown tables with numeric columns help Presenton select a compatible chart or
+table layout. You can use <code>instructions</code> for presentation-level visual
+direction without adding those directions to the visible slide text.
+
+<pre><code class="language-bash">curl \
+  -X POST http://localhost:5001/api/v1/ppt/presentation/generate \
+  -H "Authorization: Bearer sk-presenton-YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "",
+    "slides_markdown": [
+      "# Regional revenue\n\n| Region | Q1 | Q2 |\n| --- | ---: | ---: |\n| North America | 2.4 | 2.9 |\n| Europe | 1.7 | 2.1 |\n| Asia Pacific | 1.1 | 1.6 |",
+      "# Key takeaway\n\nAsia Pacific grew fastest at **45%**, while North America remained the largest market."
+    ],
+    "instructions": "Use a bar chart for slide 1 and an emphasis layout for slide 2.",
+    "template": "general",
+    "export_as": "pptx"
+  }'</code></pre>
+
+<blockquote>
+<strong>How <code>slides_markdown</code> works:</strong>
+It skips AI outline generation, but it is not a deterministic Markdown-to-slide renderer.
+Presenton still uses the configured text LLM to select suitable layouts and map each
+Markdown item into the template's structured fields, so text may be rephrased to fit.
+Provide at most 50 array items. Each item is limited to 100 words by default; longer
+items are truncated. Self-hosted deployments can change the per-slide limit with
+<code>MAX_OUTLINE_WORDS</code>.
+</blockquote>
 
 **Example Response**
 


### PR DESCRIPTION
## Summary

- document how to use `slides_markdown` with complete curl examples
- clarify the required empty `content` value, slide-count behavior, limits, and continued LLM usage
- reorganize deployment environment variables into readable configuration tables

## Validation

- `git diff --check`
- documentation-only change; application tests not run

Closes #919