### PR TITLE
fix: restore main workflow checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presenton",
-  "version": "0.9.9-beta",
+  "version": "0.9.10-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presenton",
-      "version": "0.9.9-beta",
+      "version": "0.9.10-beta",
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.2",
         "sharp": "^0.34.5"

--- a/servers/fastapi/tests/unit/test_mcp_openapi_templates.py
+++ b/servers/fastapi/tests/unit/test_mcp_openapi_templates.py
@@ -14,6 +14,8 @@ def test_default_templates_match_supported_builtin_groups():
         "standard",
         "swift",
         "editorial",
+        "mosaic",
+        "verdant",
     ]
 
 


### PR DESCRIPTION
## Summary

- align the root package lock version with the application version
- include the bundled Mosaic and Verdant templates in the FastAPI expectation

## Validation

- `npm test`: passed
- FastAPI full suite: 888 passed
- Next.js tests: 49 passed
- Next.js lint: passed with existing warnings
- Next.js production build: passed
- Cypress component tests: passed in the latest GitHub Actions run; local rerun was unavailable because this host does not have Xvfb

These fixes address the pre-existing failures in the repository-tooling and FastAPI jobs on `main`.