### PR TITLE
feat(editor): R0 persistence CAS + operation executor

### DIFF
--- a/servers/fastapi/api/v1/ppt/endpoints/editor.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/editor.py
@@ -1,0 +1,113 @@
+import uuid
+from typing import Annotated, Any, Optional
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.database import get_async_session
+from services.operation_executor import (
+    execute_operation,
+    get_operation_receipt,
+    load_document_snapshot,
+)
+from services.proposal_store import PROPOSAL_STORE, load_proposal
+
+EDITOR_ROUTER = APIRouter(prefix="/editor/v1/documents", tags=["Editor Operations"])
+
+
+class EditorOperationRequest(BaseModel):
+    operationId: Optional[str] = None
+    baseRevision: Optional[int] = None
+    scope: str = "document"
+    targetIds: Optional[list[str]] = None
+    operationType: str
+    payload: dict[str, Any]
+
+
+class EditorBatchRequest(BaseModel):
+    operationId: Optional[str] = None
+    baseRevision: Optional[int] = None
+    proposalId: Optional[str] = None
+    operations: list[EditorOperationRequest]
+
+
+class ApplyProposalRequest(BaseModel):
+    operationId: Optional[str] = None
+    baseRevision: Optional[int] = None
+
+
+@EDITOR_ROUTER.get("/{document_id}/snapshot")
+async def get_document_snapshot(
+    document_id: uuid.UUID,
+    sql_session: AsyncSession = Depends(get_async_session),
+):
+    return await load_document_snapshot(sql_session, document_id)
+
+
+@EDITOR_ROUTER.post("/{document_id}/proposals")
+async def create_document_proposal(
+    document_id: uuid.UUID,
+    request: EditorBatchRequest,
+    sql_session: AsyncSession = Depends(get_async_session),
+):
+    return await PROPOSAL_STORE.create(
+        document_id,
+        request.baseRevision,
+        [op.model_dump() for op in request.operations],
+        request.proposalId,
+    )
+
+
+@EDITOR_ROUTER.post("/{document_id}/operations")
+async def submit_document_operations(
+    document_id: uuid.UUID,
+    request: EditorBatchRequest,
+    sql_session: AsyncSession = Depends(get_async_session),
+):
+    return await execute_operation(
+        sql_session,
+        document_id=document_id,
+        base_revision=request.baseRevision,
+        operations=[op.model_dump() for op in request.operations],
+        operation_id=request.operationId,
+        proposal_id=request.proposalId,
+    )
+
+
+@EDITOR_ROUTER.post("/{document_id}/proposals/{proposal_id}/apply")
+async def apply_document_proposal(
+    document_id: uuid.UUID,
+    proposal_id: uuid.UUID,
+    request: ApplyProposalRequest,
+    sql_session: AsyncSession = Depends(get_async_session),
+):
+    from services.proposal_store import PROPOSAL_STORE, load_proposal
+
+    proposal = await load_proposal(sql_session, document_id, proposal_id)
+    if proposal is None:
+        raise HTTPException(404, "Proposal not found.")
+    if proposal["status"] != "ready":
+        if proposal["status"] == "stale":
+            raise HTTPException(409, "Proposal is stale. Regenerate it from the current document revision.")
+        raise HTTPException(409, f"Proposal is not ready to apply: {proposal['status']}")
+    if proposal["baseRevision"] != request.baseRevision:
+        raise HTTPException(409, "REVISION_CONFLICT")
+    return await execute_operation(
+        sql_session,
+        document_id=document_id,
+        base_revision=request.baseRevision,
+        operations=proposal["operations"],
+        operation_id=request.operationId,
+        proposal_id=str(proposal_id),
+        actor_source="ai",
+    )
+
+
+@EDITOR_ROUTER.get("/{document_id}/operations/{operation_id}")
+async def get_document_operation(
+    document_id: uuid.UUID,
+    operation_id: uuid.UUID,
+    sql_session: AsyncSession = Depends(get_async_session),
+):
+    return await get_operation_receipt(sql_session, document_id, operation_id)

--- a/servers/fastapi/api/v1/ppt/endpoints/presentation.py
+++ b/servers/fastapi/api/v1/ppt/endpoints/presentation.py
@@ -2443,98 +2443,26 @@ async def stream_presentation(
 
 @PRESENTATION_ROUTER.patch("/update", response_model=PresentationWithSlides)
 async def update_presentation(
+    request: Request,
     id: Annotated[uuid.UUID, Body()],
-    n_slides: Annotated[Optional[int], Body()] = None,
-    title: Annotated[Optional[str], Body()] = None,
-    theme: Annotated[Optional[dict], Body()] = None,
-    slides: Annotated[Optional[List[SlideModel]], Body()] = None,
+    base_document: Annotated[Optional[dict], Body()] = None,
     sql_session: AsyncSession = Depends(get_async_session),
 ):
-    presentation = await sql_session.get(PresentationModel, id)
-    if not presentation:
-        raise HTTPException(status_code=404, detail="Presentation not found")
-
-    presentation_update_dict = {}
-    if n_slides is not None:
-        if n_slides < 1:
-            raise HTTPException(
-                status_code=400,
-                detail="Number of slides must be greater than 0",
-            )
-        if n_slides > MAX_NUMBER_OF_SLIDES:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Number of slides cannot be greater than {MAX_NUMBER_OF_SLIDES}",
-            )
-        presentation_update_dict["n_slides"] = n_slides
-    if title:
-        presentation_update_dict["title"] = title
-    if theme or theme is None:
-        presentation_update_dict["theme"] = theme
-
-    if presentation_update_dict:
-        presentation.sqlmodel_update(presentation_update_dict)
-    if slides:
-        if len(slides) > MAX_NUMBER_OF_SLIDES:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Number of slides cannot be greater than {MAX_NUMBER_OF_SLIDES}",
-            )
-        # Just to make sure id is UUID
-        for slide in slides:
-            slide.presentation = uuid.UUID(slide.presentation)
-            slide.id = uuid.UUID(slide.id)
-
-        await sql_session.execute(
-            delete(SlideModel).where(
-                SlideModel.presentation == presentation.id,
-                SlideModel.owner_id == get_current_owner_id(),
-            )
-        )
-        sql_session.add_all(slides)
-
-    await sql_session.commit()
-
-    response_slides = slides or []
-    return PresentationWithSlides(
-        **_presentation_response_data(presentation),
-        slides=response_slides,
-    )
+    from services.document_compare_and_swap import save_document_if_unchanged
+    payload = await request.json()
+    changes = {key: payload[key] for key in ("slides", "title", "theme", "n_slides") if key in payload}
+    presentation, slides = await save_document_if_unchanged(sql_session, id, base_document, changes)
+    return PresentationWithSlides(**_presentation_response_data(presentation), slides=slides)
 
 
 @PRESENTATION_ROUTER.patch("/slide_update", response_model=SlideModel)
 async def update_presentation_slide(
     slide: Annotated[SlideModel, Body(embed=True)],
+    base_slide: Annotated[Optional[SlideModel], Body()] = None,
     sql_session: AsyncSession = Depends(get_async_session),
 ):
-    try:
-        slide_id = uuid.UUID(str(slide.id))
-        presentation_id = uuid.UUID(str(slide.presentation))
-    except (AttributeError, TypeError, ValueError) as exc:
-        raise HTTPException(
-            status_code=422,
-            detail="Slide and presentation IDs must be valid UUIDs",
-        ) from exc
-
-    stored_slide = await sql_session.get(SlideModel, slide_id)
-    if not stored_slide:
-        raise HTTPException(status_code=404, detail="Slide not found")
-
-    if stored_slide.presentation != presentation_id:
-        raise HTTPException(
-            status_code=400,
-            detail="Slide does not belong to the supplied presentation",
-        )
-
-    stored_slide.sqlmodel_update(
-        slide.model_dump(
-            exclude={"id", "presentation", "index"},
-        )
-    )
-    sql_session.add(stored_slide)
-    await sql_session.commit()
-    await sql_session.refresh(stored_slide)
-    return stored_slide
+    from services.slide_compare_and_swap import save_slide_if_unchanged
+    return await save_slide_if_unchanged(sql_session, slide, base_slide)
 
 
 async def check_if_api_request_is_valid(

--- a/servers/fastapi/api/v1/ppt/router.py
+++ b/servers/fastapi/api/v1/ppt/router.py
@@ -17,6 +17,7 @@ from api.v1.ppt.endpoints.outlines import OUTLINES_ROUTER
 from api.v1.ppt.endpoints.slide import SLIDE_ROUTER
 from api.v1.ppt.endpoints.template import TEMPLATE_ROUTER
 from api.v1.ppt.endpoints.presentation import PRESENTATION_ROUTER
+from api.v1.ppt.endpoints.editor import EDITOR_ROUTER
 from api.v1.ppt.endpoints.theme import THEMES_ROUTER
 from api.v1.ppt.endpoints.theme_generate import THEME_ROUTER
 
@@ -37,6 +38,7 @@ API_V1_PPT_ROUTER.include_router(GOOGLE_ROUTER)
 API_V1_PPT_ROUTER.include_router(GENERATION_ROUTER)
 API_V1_PPT_ROUTER.include_router(CODEX_AUTH_ROUTER)
 API_V1_PPT_ROUTER.include_router(PRESENTATION_ROUTER)
+API_V1_PPT_ROUTER.include_router(EDITOR_ROUTER)
 API_V1_PPT_ROUTER.include_router(THEMES_ROUTER)
 API_V1_PPT_ROUTER.include_router(THEME_ROUTER)
 API_V1_PPT_ROUTER.include_router(CHAT_ROUTER)

--- a/servers/fastapi/models/sql/operation.py
+++ b/servers/fastapi/models/sql/operation.py
@@ -1,0 +1,41 @@
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, String, UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+from utils.datetime_utils import get_current_utc_datetime
+
+
+class OperationState(str, Enum):
+    APPLIED = "applied"
+    CONFLICT = "conflict"
+    FAILED = "failed"
+
+
+class OperationModel(SQLModel, table=True):
+    __tablename__ = "document_operations"
+    __table_args__ = (
+        UniqueConstraint("document_id", "operation_id", name="uq_document_operation"),
+        UniqueConstraint("document_id", "idempotency_key", name="uq_document_idempotency_key"),
+    )
+
+    id: uuid.UUID = Field(primary_key=True, default_factory=uuid.uuid4)
+    document_id: uuid.UUID = Field(
+        sa_column=Column(ForeignKey("presentations.id", ondelete="CASCADE"), index=True)
+    )
+    operation_id: uuid.UUID = Field(index=True)
+    idempotency_key: str = Field(sa_column=Column(String(128), nullable=False))
+    request_hash: str = Field(sa_column=Column(String(64), nullable=False))
+    state: OperationState = Field(default=OperationState.APPLIED)
+    actor_id: Optional[uuid.UUID] = Field(default=None, index=True)
+    actor_source: str = Field(default="manual")
+    base_revision: int = Field(default=0)
+    resulting_revision: int = Field(default=0)
+    changed_slide_ids: Optional[list] = Field(sa_column=Column(JSON), default=None)
+    receipt: Optional[dict] = Field(sa_column=Column(JSON), default=None)
+    created_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=get_current_utc_datetime)
+    )

--- a/servers/fastapi/models/sql/presentation.py
+++ b/servers/fastapi/models/sql/presentation.py
@@ -71,6 +71,7 @@ class PresentationModel(SQLModel, table=True):
     include_title_slide: bool = Field(sa_column=Column(Boolean), default=True)
     web_search: bool = Field(sa_column=Column(Boolean), default=False)
     theme: Optional[dict] = Field(sa_column=Column(JSON), default=None)
+    revision: int = Field(sa_column=Column(__import__("sqlalchemy").Integer, nullable=False, default=1, server_default="1"))
     fonts: Optional[dict] = Field(sa_column=Column(JSON), default=None)
     generation_mode: Literal["standard", "smart"] = Field(
         sa_column=Column(String, nullable=False, default="standard"),

--- a/servers/fastapi/services/database.py
+++ b/servers/fastapi/services/database.py
@@ -18,6 +18,7 @@ from models.sql.font_upload import FontUpload
 from models.sql.api_key import ApiKey
 from models.sql.image_asset import ImageAsset
 from models.sql.key_value import KeyValueSqlModel
+from models.sql.operation import OperationModel
 from models.sql.ollama_pull_status import OllamaPullStatus
 from models.sql.presentation_layout_code import PresentationLayoutCodeModel
 from models.sql.presentation import PresentationModel
@@ -130,6 +131,7 @@ async def create_db_and_tables():
                     tables=[
                         PresentationModel.__table__,
                         SlideModel.__table__,
+                        OperationModel.__table__,
                         KeyValueSqlModel.__table__,
                         TemplateV2.__table__,
                         ChatHistoryMessageModel.__table__,

--- a/servers/fastapi/services/document_compare_and_swap.py
+++ b/servers/fastapi/services/document_compare_and_swap.py
@@ -1,0 +1,101 @@
+"""SQLite laboratory guard for manual full-deck/metadata writes.
+
+Not a cross-database revision protocol. Other AI/stream writers are not covered.
+"""
+import uuid
+from sqlalchemy import delete, text
+from sqlmodel import select
+from fastapi import HTTPException
+from api.v1.auth.context import get_current_owner_id
+from models.sql.presentation import PresentationModel
+from models.sql.slide import SlideModel
+from services.slide_compare_and_swap import MUTABLE_FIELDS
+from constants.presentation import MAX_NUMBER_OF_SLIDES
+
+
+def slide_value(slide):
+    return {'id': str(slide.id), 'presentation': str(slide.presentation),
+            'index': slide.index, **{key:getattr(slide,key) for key in MUTABLE_FIELDS}}
+
+
+def snapshot(presentation, slides):
+    return {'id':str(presentation.id), 'title':presentation.title,
+            'theme':presentation.theme, 'n_slides':presentation.n_slides,
+            'slides':[slide_value(s) for s in slides]}
+
+
+def normalize_baseline(base):
+    try:
+        slides=[SlideModel.model_validate_json(__import__('json').dumps(s)) for s in base['slides']]
+        return {'id':str(uuid.UUID(str(base['id']))), 'title':base.get('title'),
+                'theme':base.get('theme'), 'n_slides':base['n_slides'],
+                'slides':[slide_value(s) for s in slides]}
+    except Exception as exc:
+        raise HTTPException(422,'Invalid saved document baseline.') from exc
+
+
+async def save_document_if_unchanged(session, presentation_id, baseline, changes):
+    if baseline is None:
+        raise HTTPException(428,'A saved document baseline is required. No changes were saved.')
+    if session.bind.dialect.name != 'sqlite':
+        raise HTTPException(501,'This laboratory document guard supports SQLite only.')
+    # Must precede reads in this request session. Serializes validation + all
+    # writes including deletes/inserts. Rollback covers failure at any point.
+    try:
+        await session.execute(text('BEGIN IMMEDIATE'))
+        owner=get_current_owner_id()
+        presentation=await session.get(PresentationModel,presentation_id)
+        if presentation is None or presentation.owner_id != owner:
+            raise HTTPException(404,'Presentation not found.')
+        slides=list((await session.scalars(select(SlideModel).where(
+            SlideModel.presentation==presentation_id, SlideModel.owner_id==owner
+        ).order_by(SlideModel.index))).all())
+        saved=snapshot(presentation,slides)
+        base=normalize_baseline(baseline)
+        if base['id'] != str(presentation_id):
+            raise HTTPException(422,'Baseline identifies a different presentation.')
+        desired={**saved}
+        for key in ('title','theme'):
+            if key in changes: desired[key]=changes[key]
+        incoming=None
+        if 'slides' in changes:
+            if not isinstance(changes['slides'],list) or not 1<=len(changes['slides'])<=MAX_NUMBER_OF_SLIDES:
+                raise HTTPException(422,'Slides must be a nonempty bounded list.')
+            incoming=[]; ids=set()
+            for index,payload in enumerate(changes['slides']):
+                try:
+                    slide=SlideModel.model_validate_json(__import__('json').dumps(payload))
+                    sid=uuid.UUID(str(slide.id));pid=uuid.UUID(str(slide.presentation))
+                except Exception as exc:raise HTTPException(422,'Invalid slide.') from exc
+                if sid in ids or pid!=presentation_id or slide.index!=index:
+                    raise HTTPException(422,'Duplicate ID, mismatched presentation, or invalid order.')
+                # Do not allow stealing or deleting another document's slide.
+                collision=await session.scalar(select(SlideModel).where(SlideModel.id==sid).execution_options(skip_owner_scope=True))
+                if collision is not None and (collision.presentation!=presentation_id or collision.owner_id!=owner):
+                    raise HTTPException(409,'Slide ID is unavailable.')
+                ids.add(sid);slide.id=sid;slide.presentation=pid;slide.owner_id=owner
+                incoming.append(slide)
+            desired['slides']=[slide_value(s) for s in incoming]
+            desired['n_slides']=len(incoming)
+        if 'n_slides' in changes and changes['n_slides']!=desired['n_slides']:
+            raise HTTPException(422,'Slide count must match the saved slide array.')
+        # Safe no-op even if a response to the first attempt was lost.
+        if desired == saved:
+            await session.commit()
+            return presentation,slides
+        if base != saved:
+            raise HTTPException(409,'Presentation changed elsewhere. Your local changes are not saved. Keep a copy before reloading.')
+        for key in ('title','theme','n_slides'):setattr(presentation,key,desired[key])
+        if incoming is not None:
+            # Remove old ORM identities before inserting retained IDs.
+            for old in slides:session.expunge(old)
+            await session.execute(delete(SlideModel).where(
+                SlideModel.presentation==presentation_id,SlideModel.owner_id==owner
+            ).execution_options(synchronize_session=False))
+            session.add_all(incoming)
+        session.add(presentation)
+        await session.commit()
+        return presentation,incoming if incoming is not None else slides
+    except Exception:
+        await session.rollback()
+        raise

--- a/servers/fastapi/services/operation_executor.py
+++ b/servers/fastapi/services/operation_executor.py
@@ -1,0 +1,417 @@
+"""Unified operation executor with document revision and idempotency.
+
+Not a general CRDT/OT system. Guards only the paths that route through this
+service. SQLite laboratory implementation.
+"""
+import hashlib
+import json
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import HTTPException
+from sqlalchemy import delete, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from api.v1.auth.context import get_current_owner_id, get_current_owner_is_admin
+from constants.presentation import MAX_NUMBER_OF_SLIDES
+from models.sql.operation import OperationModel, OperationState
+from models.sql.presentation import PresentationModel
+from models.sql.slide import SlideModel
+from services.slide_compare_and_swap import MUTABLE_FIELDS
+
+
+def canonical_json(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+def operation_request_hash(payload: dict) -> str:
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+async def _get_owned_document(session: AsyncSession, document_id) -> PresentationModel:
+    owner_id = get_current_owner_id()
+    presentation = await session.get(PresentationModel, document_id)
+    if presentation is None or (owner_id is not None and presentation.owner_id != owner_id):
+        raise HTTPException(404, "Presentation not found.")
+    return presentation
+
+
+def _slide_value(slide: SlideModel) -> dict:
+    return {
+        "id": str(slide.id),
+        "presentation": str(slide.presentation),
+        "index": slide.index,
+        **{key: getattr(slide, key) for key in MUTABLE_FIELDS},
+    }
+
+
+def document_snapshot(presentation: PresentationModel, slides: list[SlideModel]) -> dict:
+    return {
+        "document_id": str(presentation.id),
+        "revision": presentation.revision,
+        "title": presentation.title,
+        "theme": presentation.theme,
+        "n_slides": presentation.n_slides,
+        "slides": [_slide_value(slide) for slide in slides],
+    }
+
+
+async def load_document_snapshot(session: AsyncSession, document_id) -> dict:
+    presentation = await _get_owned_document(session, uuid.UUID(str(document_id)))
+    slides = list(
+        (
+            await session.scalars(
+                select(SlideModel)
+                .where(SlideModel.presentation == uuid.UUID(str(document_id)))
+                .order_by(SlideModel.index)
+            )
+        ).all()
+    )
+    return document_snapshot(presentation, slides)
+
+
+async def _load_operation(session: AsyncSession, document_id, operation_id) -> OperationModel | None:
+    document_uuid = uuid.UUID(str(document_id))
+    operation_uuid = uuid.UUID(str(operation_id))
+    result = await session.scalars(
+        select(OperationModel).where(
+            OperationModel.document_id == document_uuid,
+            OperationModel.operation_id == operation_uuid,
+        )
+    )
+    return result.first()
+
+
+def _validate_targets(document: dict, operation: dict) -> None:
+    targets = operation.get("targetIds") or []
+    if not isinstance(targets, list):
+        raise HTTPException(422, "targetIds must be a list.")
+    scope = operation.get("scope")
+    if scope == "document":
+        if targets:
+            raise HTTPException(422, "Document scope cannot target specific slides.")
+        return
+    slide_ids = {slide["id"] for slide in document["slides"]}
+    element_ids = {
+        str(component.get("id"))
+        for slide in document["slides"]
+        for component in (slide.get("ui") or {}).get("components", [])
+        if isinstance(component, dict) and component.get("id")
+    }
+    if not targets:
+        raise HTTPException(428, "Explicit targetIds are required for element/slide/selection scope.")
+    for target in targets:
+        if scope == "slide":
+            if target not in slide_ids:
+                raise HTTPException(422, f"Unknown slide target: {target}")
+        elif scope in ("element", "selection"):
+            if target not in element_ids and target not in slide_ids:
+                raise HTTPException(422, f"Unknown target: {target}")
+        else:
+            raise HTTPException(422, f"Unsupported scope: {scope}")
+
+
+def _normalize_slide_payload(raw_slide: dict, presentation_id, owner_id, index: int) -> SlideModel:
+    try:
+        slide = SlideModel.model_validate_json(canonical_json(raw_slide))
+        slide.id = uuid.UUID(str(slide.id))
+        slide.presentation = uuid.UUID(str(presentation_id))
+        slide.index = index
+        slide.owner_id = owner_id
+    except Exception as exc:
+        raise HTTPException(422, "Invalid slide payload.") from exc
+    return slide
+
+
+async def _apply_operations(
+    session: AsyncSession,
+    presentation: PresentationModel,
+    slides: list[SlideModel],
+    operations: list[dict],
+) -> tuple[list[SlideModel], dict]:
+    slide_map = {str(slide.id): slide for slide in slides}
+    order = [str(slide.id) for slide in slides]
+    metadata = {"title": presentation.title, "theme": presentation.theme, "n_slides": presentation.n_slides}
+
+    def require_slides(target_ids):
+        missing = [target for target in target_ids if target not in slide_map]
+        if missing:
+            raise HTTPException(409, f"Slides no longer exist: {', '.join(missing)}")
+
+    for operation in operations:
+        op_type = operation.get("operationType")
+        payload = operation.get("payload") or {}
+        targets = operation.get("targetIds") or []
+        if op_type == "UpdateMetadata":
+            if "title" in payload:
+                metadata["title"] = payload["title"]
+            if "theme" in payload:
+                metadata["theme"] = payload["theme"]
+            continue
+        require_slides(targets)
+        if op_type == "UpdateSlide":
+            for slide_id in targets:
+                slide = slide_map[slide_id]
+                mutable = {key: payload.get(key, getattr(slide, key)) for key in MUTABLE_FIELDS}
+                for key, value in mutable.items():
+                    setattr(slide, key, value)
+                session.add(slide)
+        elif op_type == "InsertSlide":
+            source_id = payload.get("sourceSlideId")
+            insert_after = payload.get("insertAfterId")
+            index = payload.get("index")
+            if source_id:
+                require_slides([source_id])
+                source = slide_map[source_id]
+                new_slide = source.get_new_slide(presentation.id)
+                new_slide.index = -1
+            else:
+                new_slide = SlideModel(
+                    id=uuid.uuid4(),
+                    presentation=presentation.id,
+                    layout_group=payload.get("layout_group") or "blank",
+                    layout=payload.get("layout") or "__blank_slide__",
+                    index=-1,
+                    content={},
+                    speaker_note="",
+                    ui=payload.get("ui"),
+                    properties=None,
+                )
+                new_slide.owner_id = presentation.owner_id
+            slide_map[str(new_slide.id)] = new_slide
+            if insert_after and insert_after in order:
+                order.insert(order.index(insert_after) + 1, str(new_slide.id))
+            elif index is not None and 0 <= index <= len(order):
+                order.insert(index, str(new_slide.id))
+            else:
+                order.append(str(new_slide.id))
+            session.add(new_slide)
+        elif op_type == "DuplicateSlide":
+            for slide_id in targets:
+                source = slide_map[slide_id]
+                new_slide = source.get_new_slide(presentation.id)
+                new_slide.index = -1
+                slide_map[str(new_slide.id)] = new_slide
+                order.insert(order.index(slide_id) + 1, str(new_slide.id))
+                session.add(new_slide)
+        elif op_type == "DeleteSlide":
+            for slide_id in targets:
+                session.expunge(slide_map.pop(slide_id))
+                order.remove(slide_id)
+        elif op_type == "MoveSlide":
+            for slide_id in targets:
+                order.remove(slide_id)
+                anchor = payload.get("insertAfterId")
+                if anchor and anchor in order:
+                    order.insert(order.index(anchor) + 1, slide_id)
+                else:
+                    order.append(slide_id)
+        else:
+            raise HTTPException(422, f"Unsupported operationType: {op_type}")
+
+    if not order:
+        raise HTTPException(422, "Document must contain at least one slide.")
+    if len(order) > MAX_NUMBER_OF_SLIDES:
+        raise HTTPException(422, f"Slide count cannot exceed {MAX_NUMBER_OF_SLIDES}.")
+    if len(set(order)) != len(order):
+        raise HTTPException(409, "Duplicate slide IDs are not allowed.")
+    metadata["n_slides"] = len(order)
+    for index, slide_id in enumerate(order):
+        slide_map[slide_id].index = index
+    return [slide_map[slide_id] for slide_id in order], metadata
+
+
+async def execute_operation(
+    session: AsyncSession,
+    *,
+    document_id,
+    base_revision: int | None,
+    operations: list[dict],
+    operation_id=None,
+    proposal_id=None,
+    idempotency_key=None,
+    actor_source: str = "manual",
+) -> dict:
+    if session.bind.dialect.name != "sqlite":
+        raise HTTPException(501, "Operation executor currently supports SQLite only.")
+    if not operations:
+        raise HTTPException(422, "operations must be a nonempty list.")
+    if len(operations) > MAX_NUMBER_OF_SLIDES:
+        raise HTTPException(422, "Too many operations in one batch.")
+    for operation in operations:
+        if operation.get("scope") not in {"element", "slide", "selection", "document"}:
+            raise HTTPException(422, "Invalid operation scope.")
+        if not isinstance(operation.get("payload"), dict):
+            raise HTTPException(422, "Each operation must include a payload object.")
+
+    oid = operation_id or str(uuid.uuid4())
+    dedupe_key = idempotency_key or oid
+    request_hash = operation_request_hash(
+        {
+            "document_id": str(document_id),
+            "base_revision": base_revision,
+            "operations": operations,
+            "proposal_id": proposal_id,
+            "actor_source": actor_source,
+        }
+    )
+
+    existing = await _load_operation(session, document_id, oid)
+    if existing is not None:
+        if existing.request_hash != request_hash:
+            raise HTTPException(409, "IDEMPOTENCY_CONFLICT")
+        if existing.state == OperationState.APPLIED:
+            return {
+                "operationId": str(existing.operation_id),
+                "status": "duplicate",
+                "previousRevision": existing.base_revision,
+                "resultingRevision": existing.resulting_revision,
+                "changedSlideIds": list(existing.changed_slide_ids or []),
+                "receipt": existing.receipt,
+            }
+        raise HTTPException(409, "Operation already recorded in a non-applied state.")
+
+    document_uuid = uuid.UUID(str(document_id))
+    existing_key = (
+        await session.scalars(
+            select(OperationModel).where(
+                OperationModel.document_id == document_uuid,
+                OperationModel.idempotency_key == dedupe_key,
+            )
+        )
+    ).first()
+    if existing_key is not None and str(existing_key.operation_id) != oid:
+        if existing_key.request_hash == request_hash:
+            return {
+                "operationId": str(existing_key.operation_id),
+                "status": "duplicate",
+                "previousRevision": existing_key.base_revision,
+                "resultingRevision": existing_key.resulting_revision,
+                "changedSlideIds": list(existing_key.changed_slide_ids or []),
+                "receipt": existing_key.receipt,
+            }
+        raise HTTPException(409, "IDEMPOTENCY_CONFLICT")
+
+    presentation = await _get_owned_document(session, uuid.UUID(str(document_id)))
+    current_slides = list(
+        (
+            await session.scalars(
+                select(SlideModel)
+                .where(SlideModel.presentation == uuid.UUID(str(document_id)))
+                .order_by(SlideModel.index)
+            )
+        ).all()
+    )
+    current = document_snapshot(presentation, current_slides)
+    baseline_slide_values = {str(slide.id): _slide_value(slide) for slide in current_slides}
+
+    if base_revision is None:
+        raise HTTPException(428, "A saved baseRevision is required. No changes were saved.")
+    if base_revision != current["revision"]:
+        raise HTTPException(409, "REVISION_CONFLICT")
+
+    for operation in operations:
+        _validate_targets(current, operation)
+
+    try:
+        staged_slides, staged_metadata = await _apply_operations(
+            session, presentation, current_slides, operations
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(422, f"Invalid operation payload: {exc}") from exc
+
+    changed_slide_ids = []
+    desired = {
+        "title": staged_metadata["title"],
+        "theme": staged_metadata["theme"],
+        "n_slides": staged_metadata["n_slides"],
+        "slides": [_slide_value(slide) for slide in staged_slides],
+    }
+    if desired != {key: current[key] for key in ("title", "theme", "n_slides", "slides")}:
+        previous_revision = current["revision"]
+        resulting_revision = previous_revision + 1
+        presentation.revision = resulting_revision
+        presentation.title = staged_metadata["title"]
+        presentation.theme = staged_metadata["theme"]
+        presentation.n_slides = staged_metadata["n_slides"]
+        presentation.updated_at = datetime.now(timezone.utc)
+
+        existing_slide_ids = {str(slide.id) for slide in current_slides}
+        desired_slide_ids = {str(slide.id) for slide in staged_slides}
+        removed_ids = list(existing_slide_ids - desired_slide_ids)
+        changed_slide_ids = [
+            slide_id
+            for slide_id in desired_slide_ids
+            if slide_id in existing_slide_ids
+            and _slide_value(next(s for s in staged_slides if str(s.id) == slide_id))
+            != baseline_slide_values.get(slide_id)
+        ]
+
+        for slide in current_slides:
+            if slide in session:
+                session.expunge(slide)
+        if removed_ids:
+            await session.execute(
+                delete(SlideModel).where(
+                    SlideModel.presentation == uuid.UUID(str(document_id)),
+                    SlideModel.id.in_([uuid.UUID(value) for value in removed_ids]),
+                )
+            )
+        session.add(presentation)
+        session.add_all(staged_slides)
+        await session.flush()
+    else:
+        previous_revision = current["revision"]
+        resulting_revision = previous_revision
+
+    receipt = {
+        "documentId": str(document_id),
+        "operationId": oid,
+        "status": OperationState.APPLIED,
+        "actorId": str(get_current_owner_id() or presentation.owner_id),
+        "actorSource": actor_source,
+        "baseRevision": base_revision,
+        "previousRevision": previous_revision,
+        "resultingRevision": resulting_revision,
+        "changedSlideIds": changed_slide_ids,
+        "changedElementIds": [],
+        "proposalId": proposal_id,
+        "appliedAt": datetime.now(timezone.utc).isoformat(),
+    }
+    session.add(
+        OperationModel(
+            document_id=uuid.UUID(str(document_id)),
+            operation_id=uuid.UUID(oid),
+            idempotency_key=dedupe_key,
+            request_hash=request_hash,
+            state=OperationState.APPLIED,
+            actor_id=get_current_owner_id(),
+            actor_source=actor_source,
+            base_revision=base_revision,
+            resulting_revision=resulting_revision,
+            changed_slide_ids=changed_slide_ids,
+            receipt=receipt,
+        )
+    )
+    await session.commit()
+    return {
+        "operationId": oid,
+        "status": "applied",
+        "previousRevision": previous_revision,
+        "resultingRevision": resulting_revision,
+        "changedSlideIds": changed_slide_ids,
+        "receipt": receipt,
+    }
+
+
+async def get_operation_receipt(session: AsyncSession, document_id, operation_id) -> dict:
+    operation = await _load_operation(session, document_id, operation_id)
+    if operation is None:
+        raise HTTPException(404, "Operation not found.")
+    return operation.receipt or {}
+    if operation is None:
+        raise HTTPException(404, "Operation not found.")
+    return operation.receipt or {}

--- a/servers/fastapi/services/proposal_store.py
+++ b/servers/fastapi/services/proposal_store.py
@@ -1,0 +1,87 @@
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models.sql.operation import OperationState
+from services.operation_executor import (
+    document_snapshot,
+    operation_request_hash,
+    _get_owned_document,
+)
+
+
+class ProposalStore:
+    """In-memory proposal store for the laboratory; replace with SQL table for production."""
+
+    def __init__(self):
+        self._proposals = {}
+
+    def _key(self, document_id, proposal_id):
+        return (str(document_id), str(proposal_id))
+
+    async def create(self, document_id, base_revision, operations, proposal_id=None) -> dict:
+        proposal_id = proposal_id or str(uuid.uuid4())
+        proposal = {
+            "id": proposal_id,
+            "documentId": str(document_id),
+            "baseRevision": base_revision,
+            "operations": operations,
+            "status": "ready",
+            "payloadHash": operation_request_hash(
+                {
+                    "document_id": str(document_id),
+                    "base_revision": base_revision,
+                    "operations": operations,
+                    "proposal_id": proposal_id,
+                    "actor_source": "ai",
+                }
+            ),
+            "createdAt": datetime.now(timezone.utc).isoformat(),
+        }
+        self._proposals[self._key(document_id, proposal_id)] = proposal
+        return proposal
+
+    async def get(self, document_id, proposal_id) -> Optional[dict]:
+        return self._proposals.get(self._key(document_id, proposal_id))
+
+    async def list_for_document(self, document_id) -> list[dict]:
+        return [
+            proposal
+            for (doc_id, _), proposal in self._proposals.items()
+            if doc_id == str(document_id)
+        ]
+
+    async def mark_status(self, document_id, proposal_id, status) -> dict:
+        proposal = await self.get(document_id, proposal_id)
+        if proposal is None:
+            raise HTTPException(404, "Proposal not found.")
+        proposal["status"] = status
+        return proposal
+
+
+PROPOSAL_STORE = ProposalStore()
+
+
+async def load_proposal(session: AsyncSession, document_id, proposal_id) -> Optional[dict]:
+    proposal = await PROPOSAL_STORE.get(document_id, proposal_id)
+    if proposal is None:
+        return None
+    presentation = await _get_owned_document(session, uuid.UUID(str(document_id)))
+    from models.sql.slide import SlideModel
+    slides = list(
+        (
+            await session.scalars(
+                select(SlideModel)
+                .where(SlideModel.presentation == document_id)
+                .order_by(SlideModel.index)
+            )
+        ).all()
+    )
+    current = document_snapshot(presentation, slides)
+    if proposal["baseRevision"] != current["revision"]:
+        return await PROPOSAL_STORE.mark_status(document_id, proposal_id, "stale")
+    return proposal

--- a/servers/fastapi/services/slide_compare_and_swap.py
+++ b/servers/fastapi/services/slide_compare_and_swap.py
@@ -1,0 +1,66 @@
+"""Guarded single-slide writes; no blind fallback for stale or legacy clients.
+
+This protects this endpoint only. Other deck/AI writers need their own guarded
+operation contract before the application can claim document-wide concurrency.
+"""
+import uuid
+from fastapi import HTTPException
+from sqlalchemy import update, JSON, or_
+from models.sql.slide import SlideModel
+
+MUTABLE_FIELDS = (
+    'layout_group', 'layout', 'content', 'html_content', 'speaker_note',
+    'properties', 'ui',
+)
+
+
+def mutable_values(slide):
+    return {key: getattr(slide, key) for key in MUTABLE_FIELDS}
+
+
+async def save_slide_if_unchanged(session, incoming, baseline):
+    if baseline is None:
+        raise HTTPException(428, 'A saved baseline is required. Reload before editing.')
+    try:
+        sid = uuid.UUID(str(incoming.id))
+        pid = uuid.UUID(str(incoming.presentation))
+        if uuid.UUID(str(baseline.id)) != sid or uuid.UUID(str(baseline.presentation)) != pid:
+            raise HTTPException(422, 'Baseline must identify the same slide and presentation.')
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise HTTPException(422, 'Invalid slide or presentation ID.') from exc
+
+    # ORM SELECT retains the existing request owner scoping.
+    stored = await session.get(SlideModel, sid)
+    if stored is None:
+        raise HTTPException(404, 'Slide not found.')
+    if stored.presentation != pid:
+        raise HTTPException(400, 'Slide does not belong to the supplied presentation.')
+    current, desired = mutable_values(stored), mutable_values(incoming)
+    if current == desired:
+        return stored  # Retry after an acknowledged/lost response is a no-op.
+    if current != mutable_values(baseline):
+        raise HTTPException(409, 'Slide changed elsewhere. Your local edit is not saved. Keep a copy before reloading.')
+
+    # The comparison and write must be one SQL statement, not SELECT + blind
+    # ORM commit. Explicit owner and presentation predicates also cover DML,
+    # which the existing SELECT-only tenant hook does not scope.
+    predicates = [SlideModel.id == sid, SlideModel.presentation == pid,
+                  SlideModel.owner_id == stored.owner_id]
+    for key, value in current.items():
+        column = getattr(SlideModel, key)
+        if value is None:
+            # SQL NULL and JSON null deserialize alike; allow either storage.
+            predicates.append(or_(column.is_(None), column == JSON.NULL)
+                              if key in ('content', 'properties', 'ui') else column.is_(None))
+        else:
+            predicates.append(column == value)
+    result = await session.execute(
+        update(SlideModel).where(*predicates).values(**desired)
+        .execution_options(synchronize_session=False)
+    )
+    if result.rowcount != 1:
+        await session.rollback()
+        raise HTTPException(409, 'Slide changed while saving. Your local edit is not saved.')
+    await session.commit()
+    await session.refresh(stored)
+    return stored

--- a/servers/fastapi/tests/unit/test_document_compare_and_swap.py
+++ b/servers/fastapi/tests/unit/test_document_compare_and_swap.py
@@ -1,0 +1,82 @@
+import unittest,tempfile,uuid,json
+from pathlib import Path
+from sqlalchemy.ext.asyncio import create_async_engine,async_sessionmaker
+from sqlalchemy import text
+from sqlmodel import SQLModel,select
+from fastapi import HTTPException
+from models.sql.presentation import PresentationModel,PresentationVersion
+from models.sql.slide import SlideModel
+from services.database import sql_engine as _registration
+from services.document_compare_and_swap import save_document_if_unchanged,snapshot
+from services.slide_compare_and_swap import save_slide_if_unchanged
+
+class DocumentCASTests(unittest.IsolatedAsyncioTestCase):
+ async def asyncSetUp(self):
+  self.temp=tempfile.TemporaryDirectory();self.engine=create_async_engine('sqlite+aiosqlite:///'+str(Path(self.temp.name)/'t.db'));self.sessions=async_sessionmaker(self.engine,expire_on_commit=False)
+  async with self.engine.begin() as c:await c.run_sync(SQLModel.metadata.create_all)
+  self.doc=PresentationModel(id=uuid.uuid4(),version=PresentationVersion.V2_STANDARD,content='',n_slides=3,language='Russian',title='Original',theme={'color':'red'})
+  self.slides=[SlideModel(id=uuid.uuid4(),presentation=self.doc.id,index=i,layout_group='blank',layout='blank',content={'title':str(i)},properties=None,ui={'text':str(i)}) for i in range(3)]
+  async with self.sessions() as s:s.add(self.doc);s.add_all(self.slides);await s.commit()
+  self.base=snapshot(self.doc,self.slides)
+ async def asyncTearDown(self):await self.engine.dispose();self.temp.cleanup()
+ async def attempt(self,base,changes,expected):
+  async with self.sessions() as s:
+   if expected==200:return await save_document_if_unchanged(s,self.doc.id,base,changes)
+   with self.assertRaises(HTTPException) as error:await save_document_if_unchanged(s,self.doc.id,base,changes)
+   self.assertEqual(error.exception.status_code,expected)
+ async def saved(self):
+  async with self.sessions() as s:
+   p=await s.get(PresentationModel,self.doc.id);slides=list((await s.scalars(select(SlideModel).where(SlideModel.presentation==self.doc.id).order_by(SlideModel.index))).all());return snapshot(p,slides)
+ async def test_missing_baseline(self):await self.attempt(None,{'title':'bad'},428);self.assertEqual(await self.saved(),self.base)
+ async def test_metadata_does_not_clear_theme(self):
+  await self.attempt(self.base,{'title':'Renamed'},200);new=await self.saved();self.assertEqual(new['theme'],{'color':'red'});self.assertEqual(new['slides'],self.base['slides'])
+ async def test_stale_full_deck_cannot_bypass_slide_guard(self):
+  incoming=SlideModel.model_validate_json(self.slides[0].model_dump_json());incoming.ui={'text':'A'}
+  async with self.sessions() as s:await save_slide_if_unchanged(s,incoming,self.slides[0])
+  stale=json.loads(json.dumps(self.base['slides']));stale[1]['ui']={'text':'B'}
+  await self.attempt(self.base,{'slides':stale,'n_slides':3},409);new=await self.saved();self.assertEqual(new['slides'][0]['ui'],{'text':'A'});self.assertEqual(new['slides'][1]['ui'],{'text':'1'})
+ async def test_reorder_and_identical_retry(self):
+  desired=list(reversed(json.loads(json.dumps(self.base['slides']))))
+  for i,s in enumerate(desired):s['index']=i
+  await self.attempt(self.base,{'slides':desired},200);await self.attempt(self.base,{'slides':desired},200);self.assertEqual((await self.saved())['slides'],desired)
+ async def test_structural_change_rejects_old_slide_write(self):
+  desired=self.base['slides'][1:]
+  desired=json.loads(json.dumps(desired))
+  for i,s in enumerate(desired):s['index']=i
+  await self.attempt(self.base,{'slides':desired},200)
+  incoming=SlideModel.model_validate_json(self.slides[0].model_dump_json());incoming.ui={'text':'late'}
+  async with self.sessions() as s:
+   with self.assertRaises(HTTPException) as e:await save_slide_if_unchanged(s,incoming,self.slides[0])
+   self.assertEqual(e.exception.status_code,404)
+ async def test_invalid_count_and_duplicate_rejected_atomically(self):
+  await self.attempt(self.base,{'title':'bad','slides':[]},422)
+  bad=json.loads(json.dumps(self.base['slides']));bad[1]['id']=bad[0]['id'];await self.attempt(self.base,{'title':'bad','slides':bad},422)
+  await self.attempt(self.base,{'n_slides':9},422);self.assertEqual(await self.saved(),self.base)
+ async def test_foreign_slide_id_rejected(self):
+  other=SlideModel(id=uuid.uuid4(),presentation=uuid.uuid4(),index=0,layout_group='blank',layout='blank',content={},properties=None)
+  async with self.sessions() as s:s.add(other);await s.commit()
+  bad=json.loads(json.dumps(self.base['slides']));bad[0]['id']=str(other.id)
+  await self.attempt(self.base,{'slides':bad},409);self.assertEqual(await self.saved(),self.base)
+ async def test_database_failure_rolls_back_deletion(self):
+  async with self.engine.begin() as c:await c.execute(text("CREATE TRIGGER audit_fail BEFORE INSERT ON slides BEGIN SELECT RAISE(ABORT, 'audit injected failure'); END"))
+  desired=json.loads(json.dumps(self.base['slides']));desired[0]['content']={'title':'new'}
+  async with self.sessions() as s:
+   with self.assertRaises(Exception):await save_document_if_unchanged(s,self.doc.id,self.base,{'slides':desired,'title':'bad'})
+  self.assertEqual(await self.saved(),self.base)
+
+ async def test_two_simultaneous_structural_writers_only_one_wins(self):
+  import asyncio
+  async def writer(title):
+   async with self.sessions() as session:
+    try:await save_document_if_unchanged(session,self.doc.id,self.base,{'title':title});return 200
+    except HTTPException as e:return e.status_code
+  results=await asyncio.gather(writer('A'),writer('B'))
+  self.assertEqual(sorted(results),[200,409])
+ async def test_foreign_owner_cannot_mutate_document(self):
+  from api.v1.auth.context import set_current_owner_id,reset_current_owner_id
+  token=set_current_owner_id(uuid.uuid4())
+  try:await self.attempt(self.base,{'title':'foreign'},404)
+  finally:reset_current_owner_id(token)
+  self.assertEqual(await self.saved(),self.base)
+
+if __name__=='__main__':unittest.main(verbosity=2)

--- a/servers/fastapi/tests/unit/test_editor_api.py
+++ b/servers/fastapi/tests/unit/test_editor_api.py
@@ -1,0 +1,122 @@
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import SQLModel
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+from api.main import app
+from services.database import get_async_session
+from models.sql.presentation import PresentationModel, PresentationVersion
+from models.sql.slide import SlideModel
+from services.database import sql_engine as _registration
+
+
+class EditorApiTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        engine = create_async_engine("sqlite+aiosqlite:///" + str(Path(self.temp.name) / "editor.db"))
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+        self._session_factory = self._session_override(engine)
+        app.dependency_overrides[get_async_session] = self._make_session_override()
+        self.owner_id = uuid.uuid4()
+        self.document_id = uuid.uuid4()
+        self.presentation = PresentationModel(
+            id=self.document_id,
+            owner_id=self.owner_id,
+            version=PresentationVersion.V2_STANDARD,
+            content="",
+            n_slides=2,
+            language="Russian",
+            title="Editor API",
+            theme=None,
+            revision=11,
+        )
+        self.slides = [
+            SlideModel(
+                id=uuid.uuid4(),
+                presentation=self.document_id,
+                owner_id=self.owner_id,
+                index=i,
+                layout_group="blank",
+                layout="blank",
+                content={"title": str(i)},
+                properties=None,
+                ui={"title": f"Slide {i}"},
+            )
+            for i in range(2)
+        ]
+        async with self._session_factory() as session:
+            session.add(self.presentation)
+            session.add_all(self.slides)
+            await session.commit()
+        # Laboratory-only: run with auth-disabled runtime and explicit owner context.
+        # That is the same execution path used by the Electron/local runtime.
+        import api.middlewares as middlewares
+        self._original_disable_auth = middlewares.is_disable_auth_enabled
+        middlewares.is_disable_auth_enabled = lambda: True
+        from api.v1.auth.context import set_current_owner_id
+        self._owner_token = set_current_owner_id(self.owner_id)
+        self.client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+    async def asyncTearDown(self):
+        await self.client.aclose()
+        app.dependency_overrides.clear()
+        import api.middlewares as middlewares
+        from api.v1.auth.context import reset_current_owner_id
+        middlewares.is_disable_auth_enabled = self._original_disable_auth
+        reset_current_owner_id(self._owner_token)
+        self.temp.cleanup()
+
+    def _session_override(self, engine):
+        return async_sessionmaker(engine, expire_on_commit=False)
+
+    def _make_session_override(self):
+        async def override():
+            async with self._session_factory() as session:
+                yield session
+
+        return override
+
+
+    async def test_snapshot_returns_revision_and_slides(self):
+        response = await self.client.get(f"/api/v1/ppt/editor/v1/documents/{self.document_id}/snapshot")
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["revision"], 11)
+        self.assertEqual(len(payload["slides"]), 2)
+
+    async def test_operation_endpoint_applies_and_returns_receipt(self):
+        response = await self.client.post(
+            f"/api/v1/ppt/editor/v1/documents/{self.document_id}/operations",
+            json={
+                "baseRevision": 11,
+                "operations": [
+                    {
+                        "scope": "document",
+                        "targetIds": [],
+                        "operationType": "UpdateMetadata",
+                        "payload": {"title": "Updated"},
+                    }
+                ],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["resultingRevision"], 12)
+
+        receipt_response = await self.client.get(
+            f"/api/v1/ppt/editor/v1/documents/{self.document_id}/operations/{payload['operationId']}"
+        )
+        self.assertEqual(receipt_response.status_code, 200)
+        receipt = receipt_response.json()
+        self.assertEqual(receipt["status"], "applied")
+        self.assertEqual(receipt["resultingRevision"], 12)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/servers/fastapi/tests/unit/test_operation_executor.py
+++ b/servers/fastapi/tests/unit/test_operation_executor.py
@@ -1,0 +1,269 @@
+import asyncio
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlmodel import SQLModel, select
+
+from models.sql.operation import OperationModel
+from models.sql.presentation import PresentationModel, PresentationVersion
+from models.sql.slide import SlideModel
+from services.database import sql_engine as _registration
+from services.operation_executor import execute_operation, get_operation_receipt, load_document_snapshot
+
+
+class OperationExecutorTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.engine = create_async_engine(
+            "sqlite+aiosqlite:///" + str(Path(self.temp.name) / "ops.db")
+        )
+        async with self.engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+        self.sessions = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.document_id = uuid.uuid4()
+        self.owner_id = uuid.uuid4()
+        self.presentation = PresentationModel(
+            id=self.document_id,
+            owner_id=self.owner_id,
+            version=PresentationVersion.V2_STANDARD,
+            content="",
+            n_slides=3,
+            language="Russian",
+            title="Operations",
+            theme={"color": "blue"},
+            revision=7,
+        )
+        self.slides = [
+            SlideModel(
+                id=uuid.uuid4(),
+                presentation=self.document_id,
+                owner_id=self.owner_id,
+                index=i,
+                layout_group="blank",
+                layout="blank",
+                content={"title": str(i)},
+                properties=None,
+                ui={"title": f"Slide {i}"},
+            )
+            for i in range(3)
+        ]
+        async with self.sessions() as session:
+            session.add(self.presentation)
+            session.add_all(self.slides)
+            await session.commit()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        self.temp.cleanup()
+
+    async def current_revision(self):
+        async with self.sessions() as session:
+            snapshot = await load_document_snapshot(session, self.document_id)
+            return snapshot["revision"]
+
+    async def test_two_operations_on_same_base_revision_second_conflicts(self):
+        async with self.sessions() as session:
+            first = await execute_operation(
+                session,
+                document_id=self.document_id,
+                base_revision=7,
+                operations=[
+                    {
+                        "scope": "document",
+                        "targetIds": [],
+                        "operationType": "UpdateMetadata",
+                        "payload": {"title": "A"},
+                    }
+                ],
+                operation_id=str(uuid.uuid4()),
+            )
+        self.assertEqual(first["resultingRevision"], 8)
+        async with self.sessions() as session:
+            with self.assertRaises(HTTPException) as caught:
+                await execute_operation(
+                    session,
+                    document_id=self.document_id,
+                    base_revision=7,
+                    operations=[
+                        {
+                            "scope": "document",
+                            "targetIds": [],
+                            "operationType": "UpdateMetadata",
+                            "payload": {"title": "B"},
+                        }
+                    ],
+                    operation_id=str(uuid.uuid4()),
+                )
+        self.assertEqual(caught.exception.status_code, 409)
+        self.assertEqual(await self.current_revision(), 8)
+
+    async def test_same_operation_id_twice_returns_duplicate_without_second_commit(self):
+        operation_id = str(uuid.uuid4())
+        payload = {
+            "scope": "document",
+            "targetIds": [],
+            "operationType": "UpdateMetadata",
+            "payload": {"title": "Stable"},
+        }
+        async with self.sessions() as session:
+            first = await execute_operation(
+                session,
+                document_id=self.document_id,
+                base_revision=7,
+                operations=[payload],
+                operation_id=operation_id,
+            )
+        async with self.sessions() as session:
+            duplicate = await execute_operation(
+                session,
+                document_id=self.document_id,
+                base_revision=7,
+                operations=[payload],
+                operation_id=operation_id,
+            )
+        self.assertEqual(first["status"], "applied")
+        self.assertEqual(duplicate["status"], "duplicate")
+        self.assertEqual(first["resultingRevision"], duplicate["resultingRevision"])
+        self.assertEqual(await self.current_revision(), 8)
+
+    async def test_same_operation_id_with_different_payload_is_rejected(self):
+        operation_id = str(uuid.uuid4())
+        base_ops = [
+            {
+                "scope": "document",
+                "targetIds": [],
+                "operationType": "UpdateMetadata",
+                "payload": {"title": "A"},
+            }
+        ]
+        changed_ops = [
+            {
+                "scope": "document",
+                "targetIds": [],
+                "operationType": "UpdateMetadata",
+                "payload": {"title": "B"},
+            }
+        ]
+        async with self.sessions() as session:
+            await execute_operation(
+                session,
+                document_id=self.document_id,
+                base_revision=7,
+                operations=base_ops,
+                operation_id=operation_id,
+            )
+        async with self.sessions() as session:
+            with self.assertRaises(HTTPException) as caught:
+                await execute_operation(
+                    session,
+                    document_id=self.document_id,
+                    base_revision=8,
+                    operations=changed_ops,
+                    operation_id=operation_id,
+                )
+        self.assertEqual(caught.exception.status_code, 409)
+        self.assertIn("IDEMPOTENCY_CONFLICT", str(caught.exception.detail))
+
+    async def test_missing_base_revision_is_rejected(self):
+        async with self.sessions() as session:
+            with self.assertRaises(HTTPException) as caught:
+                await execute_operation(
+                    session,
+                    document_id=self.document_id,
+                    base_revision=None,
+                    operations=[
+                        {
+                            "scope": "document",
+                            "targetIds": [],
+                            "operationType": "UpdateMetadata",
+                            "payload": {"title": "No baseline"},
+                        }
+                    ],
+                )
+        self.assertEqual(caught.exception.status_code, 428)
+        self.assertEqual(await self.current_revision(), 7)
+
+    async def test_operation_receipt_round_trip(self):
+        operation_id = str(uuid.uuid4())
+        async with self.sessions() as session:
+            result = await execute_operation(
+                session,
+                document_id=self.document_id,
+                base_revision=7,
+                operations=[
+                    {
+                        "scope": "document",
+                        "targetIds": [],
+                        "operationType": "UpdateMetadata",
+                        "payload": {"title": "Receipt"},
+                    }
+                ],
+                operation_id=operation_id,
+            )
+        async with self.sessions() as session:
+            receipt = await get_operation_receipt(session, self.document_id, operation_id)
+        self.assertEqual(receipt["operationId"], operation_id)
+        self.assertEqual(receipt["resultingRevision"], result["resultingRevision"])
+        self.assertEqual(receipt["status"], "applied")
+
+    async def test_insert_duplicate_move_delete_slide_operations(self):
+        first_slide_id = str(self.slides[0].id)
+        second_slide_id = str(self.slides[1].id)
+        async with self.sessions() as session:
+            await execute_operation(
+                session,
+                document_id=self.document_id,
+                base_revision=7,
+                operations=[
+                    {
+                        "scope": "slide",
+                        "targetIds": [first_slide_id],
+                        "operationType": "DuplicateSlide",
+                        "payload": {},
+                    },
+                    {
+                        "scope": "slide",
+                        "targetIds": [second_slide_id],
+                        "operationType": "MoveSlide",
+                        "payload": {"insertAfterId": first_slide_id},
+                    },
+                ],
+                operation_id=str(uuid.uuid4()),
+            )
+        async with self.sessions() as session:
+            snapshot = await load_document_snapshot(session, self.document_id)
+        self.assertEqual(len(snapshot["slides"]), 4)
+        self.assertEqual(snapshot["revision"], 8)
+        order = [slide["id"] for slide in snapshot["slides"]]
+        self.assertEqual(order.index(second_slide_id), order.index(first_slide_id) + 1)
+
+        duplicated_id = next(
+            slide["id"] for slide in snapshot["slides"] if slide["id"] != first_slide_id and slide["id"] != second_slide_id and slide["id"] != str(self.slides[2].id)
+        )
+        async with self.sessions() as session:
+            await execute_operation(
+                session,
+                document_id=self.document_id,
+                base_revision=8,
+                operations=[
+                    {
+                        "scope": "slide",
+                        "targetIds": [duplicated_id],
+                        "operationType": "DeleteSlide",
+                        "payload": {},
+                    }
+                ],
+                operation_id=str(uuid.uuid4()),
+            )
+        async with self.sessions() as session:
+            snapshot = await load_document_snapshot(session, self.document_id)
+        self.assertEqual(len(snapshot["slides"]), 3)
+        self.assertEqual(snapshot["revision"], 9)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/servers/fastapi/tests/unit/test_operation_executor.py
+++ b/servers/fastapi/tests/unit/test_operation_executor.py
@@ -264,6 +264,34 @@ class OperationExecutorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(snapshot["slides"]), 3)
         self.assertEqual(snapshot["revision"], 9)
 
+    async def test_in_place_update_slide_reports_changed_slide_ids(self):
+        target = str(self.slides[1].id)
+        other = str(self.slides[0].id)
+        async with self.sessions() as session:
+            result = await execute_operation(
+                session,
+                document_id=self.document_id,
+                base_revision=7,
+                operations=[
+                    {
+                        "scope": "slide",
+                        "targetIds": [target],
+                        "operationType": "UpdateSlide",
+                        "payload": {"ui": {"title": "changed in place"}},
+                    }
+                ],
+                operation_id=str(uuid.uuid4()),
+            )
+        self.assertEqual(result["changedSlideIds"], [target])
+        self.assertNotIn(other, result["changedSlideIds"])
+        self.assertEqual(result["resultingRevision"], 8)
+        async with self.sessions() as session:
+            snapshot = await load_document_snapshot(session, self.document_id)
+        changed = next(s for s in snapshot["slides"] if s["id"] == target)
+        untouched = next(s for s in snapshot["slides"] if s["id"] == other)
+        self.assertEqual(changed["ui"], {"title": "changed in place"})
+        self.assertEqual(untouched["ui"], {"title": "Slide 0"})
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/servers/fastapi/tests/unit/test_presentation_slide_update_api.py
+++ b/servers/fastapi/tests/unit/test_presentation_slide_update_api.py
@@ -1,122 +1,109 @@
-import asyncio
+"""Real SQLite tests for the guarded persistence contract (no fake rowcount)."""
+import tempfile
+import unittest
 import uuid
-
-import pytest
+from pathlib import Path
 from fastapi import HTTPException
-
-from api.v1.ppt.endpoints.presentation import update_presentation_slide
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlmodel import SQLModel
 from models.sql.slide import SlideModel
-from tests.conftest import FakeAsyncSession
+from services.database import sql_engine as _registered_models  # no connection
+from services.slide_compare_and_swap import save_slide_if_unchanged
 
 
-def _slide(
-    *,
-    slide_id: uuid.UUID | None = None,
-    presentation_id: uuid.UUID | None = None,
-    index: int = 0,
-    title: str = "Original",
-) -> SlideModel:
-    return SlideModel(
-        id=slide_id or uuid.uuid4(),
-        presentation=presentation_id or uuid.uuid4(),
-        layout_group="general",
-        layout="title",
-        index=index,
-        content={"title": title},
-        properties={"accent": "blue"},
-        ui={"components": []},
-    )
+def clone(slide):
+    return SlideModel.model_validate_json(slide.model_dump_json())
 
 
-def test_slide_update_changes_only_mutable_slide_fields():
-    stored = _slide(index=2)
-    incoming = _slide(
-        slide_id=stored.id,
-        presentation_id=stored.presentation,
-        index=99,
-        title="Updated",
-    )
-    incoming.layout = "content"
-    incoming.speaker_note = "Updated note"
-    incoming.properties = {"accent": "green"}
-    incoming.ui = {"components": [{"id": "hero"}]}
-    session = FakeAsyncSession(get_results={stored.id: stored})
+class SlideSaveTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.engine = create_async_engine('sqlite+aiosqlite:///' + str(Path(self.temp.name)/'test.db'))
+        async with self.engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+        self.sessions = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.base = SlideModel(id=uuid.uuid4(), presentation=uuid.uuid4(), index=2,
+            layout_group='blank', layout='title', content={'title':'Original'},
+            properties=None, ui={'title':'Original','body':'Original'})
+        async with self.sessions() as s:
+            s.add(self.base)
+            await s.commit()
 
-    result = asyncio.run(
-        update_presentation_slide(slide=incoming, sql_session=session)
-    )
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        self.temp.cleanup()
 
-    assert result is stored
-    assert stored.content == {"title": "Updated"}
-    assert stored.layout == "content"
-    assert stored.speaker_note == "Updated note"
-    assert stored.properties == {"accent": "green"}
-    assert stored.ui == {"components": [{"id": "hero"}]}
-    assert stored.index == 2
-    assert stored.id == incoming.id
-    assert stored.presentation == incoming.presentation
-    assert session.added == [stored]
-    assert session.commit_count == 1
+    async def attempt(self, incoming, baseline, code):
+        async with self.sessions() as s:
+            if code == 200:
+                return await save_slide_if_unchanged(s, incoming, baseline)
+            with self.assertRaises(HTTPException) as caught:
+                await save_slide_if_unchanged(s, incoming, baseline)
+            self.assertEqual(caught.exception.status_code, code)
 
+    async def read(self):
+        async with self.sessions() as s:
+            return await s.get(SlideModel, self.base.id)
 
-def test_slide_update_coerces_json_uuid_strings_before_database_lookup():
-    stored = _slide()
-    incoming = _slide(
-        slide_id=stored.id,
-        presentation_id=stored.presentation,
-        title="Updated",
-    )
-    # SQLModel table models preserve UUIDs as strings when validated from JSON.
-    incoming = SlideModel.model_validate_json(incoming.model_dump_json())
-    assert isinstance(incoming.id, str)
-    assert isinstance(incoming.presentation, str)
-    session = FakeAsyncSession(get_results={stored.id: stored})
+    async def test_mutable_fields_only_and_json_uuid_strings(self):
+        incoming=clone(self.base)
+        incoming.content={'title':'Updated'}
+        incoming.ui={'title':'Updated','body':'Original'}
+        incoming.index=99
+        incoming.owner_id=uuid.uuid4()
+        result=await self.attempt(incoming, clone(self.base), 200)
+        self.assertEqual(result.content, incoming.content)
+        self.assertEqual(result.index, 2)
+        self.assertEqual(result.owner_id, self.base.owner_id)
+        self.assertEqual(result.presentation, self.base.presentation)
 
-    result = asyncio.run(
-        update_presentation_slide(slide=incoming, sql_session=session)
-    )
+    async def test_missing_baseline_rejected(self):
+        await self.attempt(clone(self.base), None, 428)
 
-    assert result is stored
-    assert stored.content == {"title": "Updated"}
-    assert session.commit_count == 1
+    async def test_invalid_ids_rejected(self):
+        incoming=clone(self.base);incoming.id='bad-id'
+        await self.attempt(incoming, clone(self.base), 422)
 
+    async def test_unknown_slide(self):
+        incoming=clone(self.base);incoming.id=uuid.uuid4()
+        await self.attempt(incoming, clone(incoming), 404)
 
-def test_slide_update_rejects_invalid_uuid_strings():
-    incoming = _slide()
-    incoming.id = "not-a-uuid"
-    session = FakeAsyncSession()
+    async def test_presentation_mismatch(self):
+        incoming=clone(self.base);incoming.presentation=uuid.uuid4()
+        await self.attempt(incoming, clone(incoming), 400)
 
-    with pytest.raises(HTTPException) as exc_info:
-        asyncio.run(
-            update_presentation_slide(slide=incoming, sql_session=session)
-        )
+    async def test_wrong_baseline_target(self):
+        baseline=clone(self.base);baseline.id=uuid.uuid4()
+        await self.attempt(clone(self.base), baseline, 422)
 
-    assert exc_info.value.status_code == 422
-    assert session.commit_count == 0
+    async def test_stale_second_tab_and_repeat(self):
+        a=clone(self.base);a.ui={'title':'A','body':'Original'}
+        await self.attempt(a, clone(self.base), 200)
+        b=clone(self.base);b.ui={'title':'Original','body':'B'}
+        await self.attempt(b, clone(self.base), 409)
+        await self.attempt(a, clone(self.base), 200)
+        self.assertEqual((await self.read()).ui, a.ui)
 
+    async def test_atomic_guard_with_cached_stale_row(self):
+        async with self.sessions() as x, self.sessions() as y:
+            retained=await y.get(SlideModel, self.base.id)
+            a=clone(self.base);a.ui={'title':'A','body':'Original'}
+            b=clone(self.base);b.ui={'title':'Original','body':'B'}
+            await save_slide_if_unchanged(x,a,clone(self.base))
+            with self.assertRaises(HTTPException) as error:
+                await save_slide_if_unchanged(y,b,clone(self.base))
+            self.assertEqual(error.exception.status_code,409)
+            self.assertIsNotNone(retained)
+        self.assertEqual((await self.read()).ui, a.ui)
 
-def test_slide_update_rejects_unknown_slide():
-    incoming = _slide()
-    session = FakeAsyncSession()
+    async def test_json_null_and_sql_null_are_supported(self):
+        a=clone(self.base);a.speaker_note='First'
+        await self.attempt(a,clone(self.base),200)
+        b=clone(a);b.properties={'accent':'green'};b.ui=None
+        await self.attempt(b,clone(a),200)
+        c=clone(b);c.speaker_note='Next'
+        await self.attempt(c,clone(b),200)
+        self.assertIsNone((await self.read()).ui)
 
-    with pytest.raises(HTTPException) as exc_info:
-        asyncio.run(
-            update_presentation_slide(slide=incoming, sql_session=session)
-        )
-
-    assert exc_info.value.status_code == 404
-    assert session.commit_count == 0
-
-
-def test_slide_update_rejects_presentation_mismatch():
-    stored = _slide()
-    incoming = _slide(slide_id=stored.id, presentation_id=uuid.uuid4())
-    session = FakeAsyncSession(get_results={stored.id: stored})
-
-    with pytest.raises(HTTPException) as exc_info:
-        asyncio.run(
-            update_presentation_slide(slide=incoming, sql_session=session)
-        )
-
-    assert exc_info.value.status_code == 400
-    assert session.commit_count == 0
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/servers/nextjs/app/(presentation-generator)/presentation/components/PresentationPage.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/components/PresentationPage.tsx
@@ -262,7 +262,7 @@ const PresentationPage: React.FC<PresentationPageProps> = ({
   // Pause while the chat assistant is mutating the deck: the assistant edits
   // slide.ui directly in the database, so a debounced autosave firing with the
   // pre-edit Redux state would overwrite (revert) the assistant's change.
-  const { isSaving } = useAutoSave({
+  const { isSaving, saveError, retrySave } = useAutoSave({
     debounceMs: 2000,
     enabled:
       !!presentationData &&
@@ -857,6 +857,13 @@ const PresentationPage: React.FC<PresentationPageProps> = ({
         id="presentation-slides-wrapper"
         className="relative flex h-full flex-col overflow-hidden"
       >
+        {saveError && (
+          <div role="alert" data-testid="save-error" className="fixed top-20 left-4 right-4 z-[100] rounded border border-red-600 bg-white p-3 text-red-900">
+            <strong>Changes are not saved.</strong> {saveError}
+            <button type="button" className="ml-4 underline" onClick={retrySave}>Retry save</button>
+            <span className="ml-4">Keep a copy of your changes before reloading.</span>
+          </div>
+        )}
         <PresentationHeader
           presentation_id={presentation_id}
           isPresentationSaving={isSaving}

--- a/servers/nextjs/app/(presentation-generator)/presentation/hooks/useAutoSave.tsx
+++ b/servers/nextjs/app/(presentation-generator)/presentation/hooks/useAutoSave.tsx
@@ -13,6 +13,13 @@ import {
     getAutoSaveChanges,
 } from '../utils/autoSaveDiff';
 
+const savedDocumentFromSnapshot = (snapshot: AutoSaveSnapshot) => ({
+    id: snapshot.presentationId,
+    ...JSON.parse(snapshot.persistedMetadataFingerprint),
+    n_slides: snapshot.slideOrder.length,
+    slides: snapshot.slideOrder.map(id => JSON.parse(snapshot.slideFingerprints[id])),
+});
+
 interface UseAutoSaveOptions {
     debounceMs?: number;
     enabled?: boolean;
@@ -37,6 +44,7 @@ export const useAutoSave = ({
     const saveLatestRef = useRef<() => Promise<void>>(async () => undefined);
     const isSavingRef = useRef(false);
     const [isSaving, setIsSaving] = useState<boolean>(false);
+    const [saveError, setSaveError] = useState<string | null>(null);
 
     const autoSavePaused =
         !enabled || isStreaming || isLoading || isLayoutLoading;
@@ -70,15 +78,18 @@ export const useAutoSave = ({
         try {
             isSavingRef.current = true;
             setIsSaving(true);
+            setSaveError(null);
             console.log('🔄 Auto-saving presentation data...');
 
             if (changes.structuralChange) {
                 // Serialize once after the debounce window. The API accepts the
                 // serialized body and avoids a second whole-deck stringify.
                 await PresentationGenerationApi.updatePresentationContent(
-                    JSON.stringify(data)
+                    JSON.stringify({ ...data, ...(!changes.metadataChanged ? JSON.parse(acknowledged.persistedMetadataFingerprint) : {}), base_document: savedDocumentFromSnapshot(acknowledged) })
                 );
-                acknowledgedDataRef.current = createAutoSaveSnapshot(data);
+                const next = createAutoSaveSnapshot(data);
+                next.persistedMetadataFingerprint = changes.metadataChanged ? fingerprintValue({title:data.title,theme:data.theme}) : acknowledged.persistedMetadataFingerprint;
+                acknowledgedDataRef.current = next;
             } else {
                 let firstError: unknown = null;
                 const nextAcknowledged: AutoSaveSnapshot = {
@@ -90,6 +101,7 @@ export const useAutoSave = ({
                     try {
                         await PresentationGenerationApi.updatePresentationContent({
                             id: data.id,
+                            base_document: savedDocumentFromSnapshot(acknowledged),
                             title: data.title,
                             theme: data.theme,
                         });
@@ -97,6 +109,7 @@ export const useAutoSave = ({
                             title: data.title,
                             theme: data.theme,
                         });
+                        nextAcknowledged.persistedMetadataFingerprint = nextAcknowledged.metadataFingerprint;
                         acknowledgedDataRef.current = nextAcknowledged;
                     } catch (error) {
                         firstError = error;
@@ -106,7 +119,8 @@ export const useAutoSave = ({
                 for (const slide of changes.changedSlides) {
                     try {
                         await PresentationGenerationApi.updatePresentationSlide(
-                            slide as Slide
+                            slide as Slide,
+                            JSON.parse(acknowledged.slideFingerprints[slide.id]) as Slide
                         );
                         nextAcknowledged.slideFingerprints[slide.id] =
                             fingerprintValue(slide);
@@ -117,12 +131,15 @@ export const useAutoSave = ({
                 }
 
                 if (firstError) throw firstError;
-                acknowledgedDataRef.current = createAutoSaveSnapshot(data);
+                const next = createAutoSaveSnapshot(data);
+                next.persistedMetadataFingerprint = nextAcknowledged.persistedMetadataFingerprint;
+                acknowledgedDataRef.current = next;
             }
 
             console.log('✅ Auto-save successful');
         } catch (error) {
             console.error('❌ Auto-save failed:', error);
+            setSaveError(error instanceof Error ? error.message : 'Save failed. Your changes are not saved.');
         } finally {
             isSavingRef.current = false;
             setIsSaving(false);
@@ -139,6 +156,21 @@ export const useAutoSave = ({
     useEffect(() => {
         saveLatestRef.current = saveLatest;
     }, [saveLatest]);
+
+    useEffect(() => {
+        const warn = (event: BeforeUnloadEvent) => {
+            const data = latestDataRef.current;
+            const baseline = acknowledgedDataRef.current;
+            if (!data || !baseline) return;
+            const changes = getAutoSaveChanges(baseline, data);
+            if (isSavingRef.current || changes.structuralChange || changes.metadataChanged || changes.changedSlides.length) {
+                event.preventDefault();
+                event.returnValue = '';
+            }
+        };
+        window.addEventListener('beforeunload', warn);
+        return () => window.removeEventListener('beforeunload', warn);
+    }, []);
 
     // Effect to trigger auto-save when presentation data changes
     useEffect(() => {
@@ -209,5 +241,7 @@ export const useAutoSave = ({
     
     return {
         isSaving,
+        saveError,
+        retrySave: () => void saveLatestRef.current(),
     };
 };

--- a/servers/nextjs/app/(presentation-generator)/presentation/hooks/usePresentationData.ts
+++ b/servers/nextjs/app/(presentation-generator)/presentation/hooks/usePresentationData.ts
@@ -52,6 +52,7 @@ export const usePresentationData = (
         const theme = fetchedTheme ?? responseTheme ?? DEFAULT_TEMPLATE_THEME;
         const themedData = {
           ...normalizedData,
+          persistedTheme: data.theme ?? null,
           ...(templateId && !normalizedData.template_id
             ? { template_id: templateId }
             : {}),

--- a/servers/nextjs/app/(presentation-generator)/presentation/utils/autoSaveDiff.ts
+++ b/servers/nextjs/app/(presentation-generator)/presentation/utils/autoSaveDiff.ts
@@ -5,6 +5,7 @@ export interface AutoSaveSnapshot {
   slideOrder: string[];
   slideFingerprints: Record<string, string>;
   metadataFingerprint: string;
+  persistedMetadataFingerprint: string;
 }
 
 export interface AutoSaveChanges {
@@ -37,6 +38,7 @@ export const createAutoSaveSnapshot = (
     presentationId: data.id,
     slideOrder,
     slideFingerprints,
+    persistedMetadataFingerprint: fingerprintValue({title: data.title, theme: data.persistedTheme !== undefined ? data.persistedTheme : data.theme}),
     metadataFingerprint: fingerprintValue({
       title: data.title,
       theme: data.theme,

--- a/servers/nextjs/app/(presentation-generator)/services/api/presentation-generation.ts
+++ b/servers/nextjs/app/(presentation-generator)/services/api/presentation-generation.ts
@@ -210,14 +210,14 @@ export class PresentationGenerationApi {
     }
   }
 
-  static async updatePresentationSlide(slide: Slide) {
+  static async updatePresentationSlide(slide: Slide, baseSlide?: Slide) {
     try {
       const response = await fetch(
         getApiUrl(`/api/v1/ppt/presentation/slide_update`),
         {
           method: "PATCH",
           headers: getHeader(),
-          body: JSON.stringify({ slide }),
+          body: JSON.stringify({ slide, base_slide: baseSlide }),
           cache: "no-cache",
         }
       );

--- a/servers/nextjs/lib/runtime-provider-config.ts
+++ b/servers/nextjs/lib/runtime-provider-config.ts
@@ -5,11 +5,122 @@ import { hasValidLLMConfig, normalizeLLMConfig } from "@/utils/storeHelpers";
 
 export const REDACTED_SECRET_PLACEHOLDER = "__configured__";
 
-// Match credential fields, not every field containing the word "token".
-// Numeric settings such as LLM_MAX_OUTPUT_TOKENS must remain visible or the
-// client-side config validator will reject an otherwise valid shared config.
-const SECRET_FIELD =
-  /(?:API_KEY|ACCESS_KEY_ID|SECRET_ACCESS_KEY|SESSION_TOKEN|ACCESS_TOKEN|REFRESH_TOKEN|PASSWORD)$/i;
+// Fail closed: new server settings must not silently become client fields.
+const PUBLIC_TEXT_FIELDS = [
+  "LLM",
+  "OPENAI_MODEL",
+  "DEEPSEEK_MODEL",
+  "GOOGLE_MODEL",
+  "VERTEX_MODEL",
+  "AZURE_OPENAI_MODEL",
+  "AZURE_OPENAI_API_VERSION",
+  "AZURE_OPENAI_DEPLOYMENT",
+  "BEDROCK_MODEL",
+  "BEDROCK_REGION",
+  "OPENROUTER_MODEL",
+  "CEREBRAS_MODEL",
+  "FIREWORKS_MODEL",
+  "TOGETHER_MODEL",
+  "ANTHROPIC_MODEL",
+  "LITELLM_MODEL",
+  "LMSTUDIO_MODEL",
+  "OLLAMA_MODEL",
+  "CUSTOM_MODEL",
+  "CODEX_MODEL",
+  "IMAGE_PROVIDER",
+  "OPENAI_COMPAT_IMAGE_MODEL",
+  "DALL_E_3_QUALITY",
+  "GPT_IMAGE_1_5_QUALITY",
+  "LLM_GENERATION_PROFILE",
+  "LLM_REASONING_MODE",
+  "LLM_REASONING_EFFORT",
+  "WEB_SEARCH_PROVIDER",
+  "WEB_SEARCH_MAX_RESULTS",
+  "OPENROUTER_DATA_COLLECTION",
+  "DISABLE_ANONYMOUS_TRACKING"
+] as const;
+const PUBLIC_BOOL_FIELDS = [
+  "DISABLE_IMAGE_GENERATION",
+  "DISABLE_THINKING",
+  "EXTENDED_REASONING",
+  "WEB_GROUNDING",
+  "OPENROUTER_ALLOW_FALLBACKS",
+  "OPENROUTER_REQUIRE_PARAMETERS",
+  "OPENROUTER_ZDR",
+  "CODEX_IS_PRO"
+] as const;
+const SERVER_PRESENCE_FIELDS = [
+  "OPENAI_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "GOOGLE_API_KEY",
+  "VERTEX_API_KEY",
+  "VERTEX_PROJECT",
+  "VERTEX_LOCATION",
+  "AZURE_OPENAI_API_KEY",
+  "BEDROCK_API_KEY",
+  "BEDROCK_AWS_ACCESS_KEY_ID",
+  "BEDROCK_AWS_SECRET_ACCESS_KEY",
+  "BEDROCK_AWS_SESSION_TOKEN",
+  "OPENROUTER_API_KEY",
+  "CEREBRAS_API_KEY",
+  "FIREWORKS_API_KEY",
+  "TOGETHER_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "LITELLM_API_KEY",
+  "LMSTUDIO_API_KEY",
+  "CUSTOM_LLM_API_KEY",
+  "PEXELS_API_KEY",
+  "PIXABAY_API_KEY",
+  "OPEN_WEBUI_IMAGE_API_KEY",
+  "OPENAI_COMPAT_IMAGE_API_KEY",
+  "TAVILY_API_KEY",
+  "EXA_API_KEY",
+  "BRAVE_SEARCH_API_KEY",
+  "SERPER_API_KEY",
+  "CODEX_ACCESS_TOKEN",
+  "CODEX_REFRESH_TOKEN"
+] as const;
+const SERVER_ENDPOINT_FIELDS = [
+  "DEEPSEEK_BASE_URL",
+  "VERTEX_BASE_URL",
+  "AZURE_OPENAI_ENDPOINT",
+  "AZURE_OPENAI_BASE_URL",
+  "OPENROUTER_BASE_URL",
+  "CEREBRAS_BASE_URL",
+  "FIREWORKS_BASE_URL",
+  "TOGETHER_BASE_URL",
+  "LITELLM_BASE_URL",
+  "LMSTUDIO_BASE_URL",
+  "OLLAMA_URL",
+  "CUSTOM_LLM_URL",
+  "COMFYUI_URL",
+  "OPEN_WEBUI_IMAGE_URL",
+  "OPENAI_COMPAT_IMAGE_BASE_URL",
+  "SEARXNG_BASE_URL"
+] as const;
+
+export function publicProviderConfig(full: LLMConfig): LLMConfig {
+  const input = full as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+  for (const key of PUBLIC_TEXT_FIELDS) {
+    const value = input[key];
+    if (typeof value === 'string' && value.length <= 512) output[key] = value;
+  }
+  for (const key of PUBLIC_BOOL_FIELDS) {
+    if (typeof input[key] === 'boolean') output[key] = input[key];
+  }
+  const limit = input.LLM_MAX_OUTPUT_TOKENS;
+  if (typeof limit === 'number' && Number.isSafeInteger(limit) && limit > 0) output.LLM_MAX_OUTPUT_TOKENS = limit;
+  for (const key of SERVER_PRESENCE_FIELDS) {
+    if (typeof input[key] === 'string' && input[key]) output[key] = REDACTED_SECRET_PLACEHOLDER;
+  }
+  // URLs and workflows can embed credentials. UI receives presence, not contents.
+  for (const key of SERVER_ENDPOINT_FIELDS) {
+    if (typeof input[key] === 'string' && input[key]) output[key] = 'https://server-managed.invalid';
+  }
+  if (typeof input.COMFYUI_WORKFLOW === 'string' && input.COMFYUI_WORKFLOW) output.COMFYUI_WORKFLOW = '{}';
+  return output as LLMConfig;
+}
 
 export type RuntimeProviderConfig = {
   configured: boolean;
@@ -29,14 +140,7 @@ export function readRuntimeProviderConfig(): RuntimeProviderConfig {
   const full = normalizeLLMConfig(
     readUserConfigFile<LLMConfig>(path) || {}
   );
-  const config = Object.fromEntries(
-    Object.entries(full).map(([key, value]) => [
-      key,
-      SECRET_FIELD.test(key) && value
-        ? REDACTED_SECRET_PLACEHOLDER
-        : value,
-    ])
-  ) as LLMConfig;
+  const config = publicProviderConfig(full);
 
   return {
     configured: hasValidLLMConfig(full),

--- a/servers/nextjs/store/slices/presentationGeneration.ts
+++ b/servers/nextjs/store/slices/presentationGeneration.ts
@@ -16,6 +16,8 @@ export interface PresentationData {
   title: string;
   slides: any;
   theme: Theme | TemplateTheme | null;
+  /** Raw server theme, before render-only template defaults. */
+  persistedTheme?: Theme | TemplateTheme | null;
   template_id?: string | null;
   design_v2_id?: string | null;
   version?: string;

--- a/servers/nextjs/tests/auto-save-baseline.test.mjs
+++ b/servers/nextjs/tests/auto-save-baseline.test.mjs
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {build} from 'esbuild';
+import {mkdtemp,writeFile,rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {pathToFileURL} from 'node:url';
+let dir,mod;
+test.before(async()=>{dir=await mkdtemp(path.join(tmpdir(),'presenton-baseline-'));const file=path.join(dir,'entry.ts');await writeFile(file,`export * from ${JSON.stringify(path.resolve('app/(presentation-generator)/presentation/utils/autoSaveDiff.ts'))}`);await build({entryPoints:[file],outfile:path.join(dir,'out.mjs'),bundle:true,platform:'node',format:'esm',tsconfig:path.resolve('tsconfig.json'),logLevel:'silent'});mod=await import(pathToFileURL(path.join(dir,'out.mjs')).href)});
+test.after(async()=>{await rm(dir,{recursive:true,force:true})});
+test('render default is not a saved theme',()=>{const data={id:'x',title:'X',theme:{color:'render'},persistedTheme:null,slides:[{id:'s',index:0}]};const saved=mod.createAutoSaveSnapshot(data);assert.deepEqual(JSON.parse(saved.persistedMetadataFingerprint),{title:'X',theme:null});assert.equal(mod.getAutoSaveChanges(saved,data).metadataChanged,false);assert.equal(mod.getAutoSaveChanges(saved,{...data,theme:{color:'edit'}}).metadataChanged,true)});
+test('raw template theme and metadata tracked independently of display fallback',()=>{const data={id:'x',title:'X',theme:{color:'normalized'},persistedTheme:{color:'raw'},slides:[{id:'s',index:0}]};const snap=mod.createAutoSaveSnapshot(data);assert.deepEqual(JSON.parse(snap.persistedMetadataFingerprint).theme,{color:'raw'});assert.equal(mod.getAutoSaveChanges(snap,{...data,title:'new'}).metadataChanged,true)});

--- a/servers/nextjs/tests/runtime-provider-config.test.mjs
+++ b/servers/nextjs/tests/runtime-provider-config.test.mjs
@@ -19,7 +19,7 @@ test.before(async () => {
   const outputFile = path.join(temporaryDirectory, "bundle.mjs");
   await writeFile(
     entryFile,
-    `export { readRuntimeProviderConfig } from ${JSON.stringify(
+    `export { readRuntimeProviderConfig, publicProviderConfig } from ${JSON.stringify(
       path.resolve("lib/runtime-provider-config.ts")
     )};`
   );
@@ -74,4 +74,34 @@ test("regular-user runtime config keeps provider choices and redacts secrets", a
     if (previousPath === undefined) delete process.env.USER_CONFIG_PATH;
     else process.env.USER_CONFIG_PATH = previousPath;
   }
+});
+
+
+test('unknown auth fields and nested payloads never pass through', () => {
+  const marker = 'AUDIT_SECRET_SENTINEL';
+  const result = runtimeConfig.publicProviderConfig({
+    LLM:'custom', CUSTOM_MODEL:'fixture', CUSTOM_LLM_API_KEY:marker,
+    AUTH_PASSWORD_HASH:marker, AUTH_SECRET_KEY:marker, AUTH_USERNAME:marker,
+    FUTURE_PROVIDER_SECRET:marker, auth_secret_key:marker,
+    nested:{secret:marker}, LLM_MAX_OUTPUT_TOKENS:{secret:marker},
+    OPENAI_MODEL:{secret:marker}, CODEX_ACCOUNT_ID:marker,
+    CODEX_EMAIL:marker, CODEX_TOKEN_EXPIRES:marker,
+  });
+  assert.deepEqual(result, {LLM:'custom', CUSTOM_MODEL:'fixture', CUSTOM_LLM_API_KEY:'__configured__'});
+  assert.ok(!JSON.stringify(result).includes(marker));
+});
+test('server endpoints and workflow cannot leak embedded credentials', () => {
+  const marker='AUDIT_SECRET_SENTINEL';
+  const result=runtimeConfig.publicProviderConfig({
+    CUSTOM_LLM_URL:`https://user:${marker}@example.invalid/${marker}?token=${marker}`,
+    COMFYUI_WORKFLOW:JSON.stringify({credential:marker}),
+    DISABLE_IMAGE_GENERATION:true, LLM_MAX_OUTPUT_TOKENS:4096,
+  });
+  assert.equal(result.CUSTOM_LLM_URL,'https://server-managed.invalid');
+  assert.equal(result.COMFYUI_WORKFLOW,'{}');
+  assert.equal(result.LLM_MAX_OUTPUT_TOKENS,4096);
+  assert.ok(!JSON.stringify(result).includes(marker));
+});
+test('empty and wrong-type credentials never become configured', () => {
+  assert.deepEqual(runtimeConfig.publicProviderConfig({OPENAI_API_KEY:'', CUSTOM_LLM_API_KEY:{secret:'x'}, LLM_MAX_OUTPUT_TOKENS:NaN}),{});
 });


### PR DESCRIPTION
## Summary
Focused slice of #913 as requested by @sudipnext: compare-and-swap persistence and the operational executor only. No G1/R1 brand packs, charts, PPTX, quality, or chat-batch.

- `slide_update` / presentation update require `base_document` / `base_slide` (409 stale, 428 missing)
- `POST /editor/v1/documents/{id}/operations` atomic batches, idempotent `operationId`, receipts
- Runtime config allowlist (no auth material)

## Test plan
- [x] Existing executor unit tests (6)
- [x] **New:** `test_in_place_update_slide_reports_changed_slide_ids` — in-place `UpdateSlide` reports only that slide in `changedSlideIds`, sibling ui unchanged, revision 7→8

Supersedes the persistence half of #913. Lab G1/R1 stays on `audit/r0-persistence-executor`.