### PR TITLE
fix(images): send Open WebUI requests to the /api/v1 API root

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ These variables match `docker-compose.yml`. **`IMAGE_PROVIDER`** selects the bac
 | **DALL_E_3_QUALITY** | `standard` (default), `hd` | DALL-E 3 image quality. |
 | **GPT_IMAGE_1_5_QUALITY** | `low`, `medium` (default), `high` | GPT Image 1.5 image quality. |
 | **COMFYUI_URL** / **COMFYUI_WORKFLOW** | Required for `IMAGE_PROVIDER=comfyui` | Self-hosted ComfyUI endpoint and workflow JSON. |
-| **OPEN_WEBUI_IMAGE_URL** / **OPEN_WEBUI_IMAGE_API_KEY** | Required for `IMAGE_PROVIDER=open_webui` | Open WebUI-compatible image endpoint and API key. |
+| **OPEN_WEBUI_IMAGE_URL** / **OPEN_WEBUI_IMAGE_API_KEY** | Required for `IMAGE_PROVIDER=open_webui` | Open WebUI API root (`http://host:8080/api/v1`; a bare origin gets `/api/v1` appended) and API key. |
 | **OPENAI_COMPAT_IMAGE_BASE_URL** / **OPENAI_COMPAT_IMAGE_API_KEY** / **OPENAI_COMPAT_IMAGE_MODEL** | Required for `IMAGE_PROVIDER=openai_compatible` | Sends image requests to an OpenAI-compatible `/v1/images/*` endpoint such as LiteLLM, Azure, or a vLLM gateway. |
 
 The parallel image generation option applies everywhere images are generated: initial presentation generation, slide editing and regeneration, direct image requests, and assistant image tools.

--- a/servers/fastapi/services/image_generation_service.py
+++ b/servers/fastapi/services/image_generation_service.py
@@ -4,6 +4,7 @@ import json
 import os
 import secrets
 from weakref import WeakKeyDictionary
+from urllib.parse import urlparse
 
 import aiohttp
 from fastapi import HTTPException
@@ -43,11 +44,27 @@ from utils.image_generation_error import normalize_image_generation_error
 import uuid
 
 
+OPEN_WEBUI_API_PREFIX = "/api/v1"
 COMFYUI_MAX_SEED = 0xFFFFFFFFFFFFFFFF
 COMFYUI_SEED_SOURCE_VALUE_KEYS = {"value", "int", "integer", "number"}
 _IMAGE_GENERATION_LOCKS: WeakKeyDictionary[
     asyncio.AbstractEventLoop, asyncio.Lock
 ] = WeakKeyDictionary()
+
+
+def resolve_open_webui_api_base(base_url: str) -> str:
+    """Return the Open WebUI API root that the image endpoints hang off.
+
+    Open WebUI serves its REST API under ``/api/v1``; the site root only serves
+    the web app, which answers a POST to ``/images/generations`` with 405. A
+    bare origin such as ``http://127.0.0.1:8080`` therefore gets the prefix
+    appended. A URL that already carries a path is used verbatim so existing
+    configurations keep working.
+    """
+    base_url = base_url.strip().rstrip("/")
+    if urlparse(base_url).path in ("", "/"):
+        return base_url + OPEN_WEBUI_API_PREFIX
+    return base_url
 
 
 def _get_image_generation_lock() -> asyncio.Lock:
@@ -194,10 +211,8 @@ class ImageGenerationService:
         if not base_url:
             raise ValueError("OPEN_WEBUI_IMAGE_URL environment variable is not set")
 
-        base_url = base_url.rstrip("/")
+        base_url = resolve_open_webui_api_base(base_url)
         api_key = get_open_webui_image_api_key_env() or ""
-
-        from urllib.parse import urlparse
 
         parsed = urlparse(base_url)
         origin = f"{parsed.scheme}://{parsed.netloc}"
@@ -222,8 +237,15 @@ class ImageGenerationService:
 
             if resp.status != 200:
                 error_text = await resp.text()
+                hint = ""
+                if resp.status in (404, 405):
+                    hint = (
+                        " (OPEN_WEBUI_IMAGE_URL should point at the Open WebUI"
+                        f" API root, e.g. {origin}{OPEN_WEBUI_API_PREFIX})"
+                    )
                 raise Exception(
-                    f"Open WebUI image generation returned {resp.status}: {error_text}"
+                    f"Open WebUI image generation returned {resp.status}: "
+                    f"{error_text}{hint}"
                 )
 
             body = await resp.json()

--- a/servers/fastapi/tests/test_image_generation_open_webui.py
+++ b/servers/fastapi/tests/test_image_generation_open_webui.py
@@ -1,0 +1,141 @@
+import base64
+import os
+from unittest.mock import patch
+
+import pytest
+
+from services.image_generation_service import (
+    ImageGenerationService,
+    resolve_open_webui_api_base,
+)
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n fake image bytes"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _FakeResponse:
+    def __init__(self, status: int, body):
+        self.status = status
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+    async def text(self):
+        return str(self._body)
+
+
+class _FakeSession:
+    """Stands in for aiohttp.ClientSession and records every POST."""
+
+    calls: list[tuple[str, dict]] = []
+    response: _FakeResponse = _FakeResponse(200, [])
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def post(self, url, **kwargs):
+        type(self).calls.append((url, kwargs))
+        return type(self).response
+
+
+@pytest.fixture
+def fake_session():
+    class FakeSession(_FakeSession):
+        calls = []
+        response = _FakeResponse(
+            200, [{"b64_json": base64.b64encode(PNG_BYTES).decode()}]
+        )
+
+    with patch("services.image_generation_service.aiohttp.ClientSession", FakeSession):
+        yield FakeSession
+
+
+def _open_webui_env(url: str, api_key: str = "sk-open-webui"):
+    return (
+        patch(
+            "services.image_generation_service.get_open_webui_image_url_env",
+            return_value=url,
+        ),
+        patch(
+            "services.image_generation_service.get_open_webui_image_api_key_env",
+            return_value=api_key,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("http://127.0.0.1:8080", "http://127.0.0.1:8080/api/v1"),
+        ("http://127.0.0.1:8080/", "http://127.0.0.1:8080/api/v1"),
+        ("  http://127.0.0.1:8080  ", "http://127.0.0.1:8080/api/v1"),
+        ("http://localhost:3000/api/v1", "http://localhost:3000/api/v1"),
+        ("http://localhost:3000/api/v1/", "http://localhost:3000/api/v1"),
+        ("https://gateway.example.com/v1", "https://gateway.example.com/v1"),
+    ],
+)
+def test_resolve_open_webui_api_base(configured, expected):
+    assert resolve_open_webui_api_base(configured) == expected
+
+
+@pytest.mark.anyio
+async def test_generate_image_open_webui_bare_origin_posts_to_api_v1(
+    tmp_path, fake_session
+):
+    service = ImageGenerationService(str(tmp_path))
+    url_env, key_env = _open_webui_env("http://127.0.0.1:8080")
+
+    with url_env, key_env:
+        image_path = await service.generate_image_open_webui(
+            "a lighthouse at dusk", str(tmp_path)
+        )
+
+    assert len(fake_session.calls) == 1
+    posted_url, kwargs = fake_session.calls[0]
+    assert posted_url == "http://127.0.0.1:8080/api/v1/images/generations"
+    assert kwargs["headers"]["Authorization"] == "Bearer sk-open-webui"
+    assert kwargs["json"]["prompt"] == "a lighthouse at dusk"
+    assert os.path.dirname(image_path) == str(tmp_path)
+    with open(image_path, "rb") as f:
+        assert f.read() == PNG_BYTES
+
+
+@pytest.mark.anyio
+async def test_generate_image_open_webui_keeps_explicit_api_root(
+    tmp_path, fake_session
+):
+    service = ImageGenerationService(str(tmp_path))
+    url_env, key_env = _open_webui_env("http://localhost:3000/api/v1/")
+
+    with url_env, key_env:
+        await service.generate_image_open_webui("a cat", str(tmp_path))
+
+    posted_url, _ = fake_session.calls[0]
+    assert posted_url == "http://localhost:3000/api/v1/images/generations"
+
+
+@pytest.mark.anyio
+async def test_generate_image_open_webui_405_error_points_at_api_root(
+    tmp_path, fake_session
+):
+    fake_session.response = _FakeResponse(405, "Method Not Allowed")
+    service = ImageGenerationService(str(tmp_path))
+    url_env, key_env = _open_webui_env("http://127.0.0.1:8080/openwebui")
+
+    with url_env, key_env, pytest.raises(Exception) as exc_info:
+        await service.generate_image_open_webui("a cat", str(tmp_path))
+
+    message = str(exc_info.value)
+    assert "returned 405" in message
+    assert "http://127.0.0.1:8080/api/v1" in message


### PR DESCRIPTION
## Summary

Fixes #930.

Open WebUI serves its REST API under `/api/v1`; the site root only serves the web app. `generate_image_open_webui` built the request as `{OPEN_WEBUI_IMAGE_URL}/images/generations`, so with the URL set to a bare origin such as `http://127.0.0.1:8080` (the value from the issue) the POST went to `/images/generations`, which the SPA route answers with `405 Method Not Allowed`. Nothing ever reached the image backend. Both symptoms in the issue come from that one request: full-deck generation runs with `allow_image_fallback=True` and turns the failure into the placeholder image, single-slide regeneration surfaces it as the 405.

The settings placeholder does say `http://localhost:3000/api/v1`, but nothing enforces or explains it, and the provider already expects Open WebUI specifically (it resolves the relative `/api/v1/files/...` URLs Open WebUI returns).

## Change

`servers/fastapi/services/image_generation_service.py`

- new `resolve_open_webui_api_base(url)`: a bare origin (`http://host:8080`, with or without trailing slash) gets `/api/v1` appended; a URL that already carries a path (`.../api/v1`, or a gateway path someone configured deliberately) is used verbatim, so no working configuration changes.
- `generate_image_open_webui` uses it before building the request; the local `urlparse` import moved to module level.
- a 404/405 answer now names the expected API root in the error message, so a reverse-proxy sub-path or similar misconfiguration is diagnosable from the UI.

`README.md`: the `OPEN_WEBUI_IMAGE_URL` row says what the value is.

## Tests

`servers/fastapi/tests/test_image_generation_open_webui.py`: the resolver table, a bare origin posting to `http://127.0.0.1:8080/api/v1/images/generations` (with bearer header, prompt and the decoded image written to the output directory), an explicit `/api/v1/` root kept as is, and the 405 message pointing at the API root. On `main` the same call posts to `http://127.0.0.1:8080/images/generations`.

```
pytest tests/test_image_generation_open_webui.py tests/test_image_generation_openai_compatible.py tests/test_image_generation_comfyui.py
20 passed
```

Not verified against a live Open WebUI; the endpoint path is the one Open WebUI documents and the one the reporter confirmed with curl.
